### PR TITLE
Handle exceptions that occur while making okhttp calls.

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/FirstFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/FirstFragment.java
@@ -68,6 +68,7 @@ public class FirstFragment extends Fragment {
 
         binding.httpMe.setOnClickListener(v -> backgrounder.submit(() -> makeCall("https://ssidhu.o11ystore.com/")));
         binding.httpMeBad.setOnClickListener(v -> backgrounder.submit(() -> makeCall("https://asdlfkjasd.asdfkjasdf.ifi")));
+        binding.httpMeNotFound.setOnClickListener(v -> backgrounder.submit(() -> makeCall("https://ssidhu.o11ystore.com/foobarbaz")));
     }
 
     private void makeCall(String url) {

--- a/sample-app/src/main/res/layout/fragment_first.xml
+++ b/sample-app/src/main/res/layout/fragment_first.xml
@@ -56,6 +56,13 @@
                 android:text="@string/http_me_up" />
 
             <Button
+                android:id="@+id/http_me_not_found"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/http_not_found" />
+
+            <Button
                 android:id="@+id/http_me_bad"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="clippy">clippy</string>
     <string name="http_me_up">HTTP me up!</string>
     <string name="http_me_bad">Http Error</string>
+    <string name="http_not_found">HTTP Not Found</string>
 </resources>

--- a/splunk-otel-android/src/main/java/com/splunk/rum/OkHttpRumInterceptor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/OkHttpRumInterceptor.java
@@ -24,6 +24,8 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 class OkHttpRumInterceptor implements Interceptor {
     static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
     static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
+    static final AttributeKey<String> ERROR_TYPE_KEY = stringKey("error.type");
+    static final AttributeKey<String> ERROR_MESSAGE_KEY = stringKey("error.message");
 
     private final Interceptor coreInterceptor;
     private final ServerTimingHeaderParser headerParser;
@@ -70,6 +72,10 @@ class OkHttpRumInterceptor implements Interceptor {
                 //record these here since zipkin eats the event attributes that are recorded by default.
                 span.setAttribute(SemanticAttributes.EXCEPTION_TYPE, e.getClass().getSimpleName());
                 span.setAttribute(SemanticAttributes.EXCEPTION_MESSAGE, e.getMessage());
+
+                //these attributes are here to support the RUM UI/backend until it can be updated to use otel conventions.
+                span.setAttribute(ERROR_TYPE_KEY, e.getClass().getSimpleName());
+                span.setAttribute(ERROR_MESSAGE_KEY, e.getMessage());
                 throw e;
             }
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/OkHttpRumInterceptorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/OkHttpRumInterceptorTest.java
@@ -83,6 +83,10 @@ public class OkHttpRumInterceptorTest {
         assertEquals("http", spanData.getAttributes().get(SplunkRum.COMPONENT_KEY));
         assertEquals("IOException", spanData.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE));
         assertEquals("failed to make a call", spanData.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE));
+
+        //temporary attributes until the RUM UI/backend can be brought up to date with otel conventions.
+        assertEquals("IOException", spanData.getAttributes().get(OkHttpRumInterceptor.ERROR_TYPE_KEY));
+        assertEquals("failed to make a call", spanData.getAttributes().get(OkHttpRumInterceptor.ERROR_MESSAGE_KEY));
     }
 
     @Test


### PR DESCRIPTION
This is necessary since zipkin swallows event attributes, and we lose the details from the otel instrumentation.