### PR TITLE
Update SplunkRum#addRumException() according to RUM BE requirements

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
@@ -74,8 +74,9 @@ public class MainActivity extends AppCompatActivity {
         //noinspection SimplifiableIfStatement
         if (id == R.id.action_settings) {
             SplunkRum.getInstance()
-                    .addRumException("Unimplemented Feature", SETTINGS_FEATURE_ATTRIBUTES,
-                            new UnsupportedOperationException("Unimplemented Feature: Settings"));
+                    .addRumException(
+                            new UnsupportedOperationException("Unimplemented Feature: Settings"),
+                            SETTINGS_FEATURE_ATTRIBUTES);
             return true;
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
@@ -18,6 +18,7 @@ package com.splunk.rum;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTracing;
 import okhttp3.Interceptor;
 
@@ -50,6 +51,11 @@ class NoOpSplunkRum extends SplunkRum {
 
     @Override
     public void addRumException(String name, Attributes attributes, Throwable throwable) {
+        //no-op
+    }
+
+    @Override
+    public void addRumException(Throwable throwable, Attributes attributes) {
         //no-op
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -183,11 +183,46 @@ public class SplunkRum {
      * @param name       The name of the event.
      * @param attributes Any {@link Attributes} to associate with the event.
      * @param throwable  A {@link Throwable} associated with this event.
+     * @deprecated Use {@link #addRumException(Throwable, Attributes)} instead.
      */
+    @Deprecated
     public void addRumException(String name, Attributes attributes, Throwable throwable) {
         Span span = getTracer()
                 .spanBuilder(name)
                 .setAllAttributes(attributes)
+                .startSpan();
+        addExceptionAttributes(span, throwable);
+        span.end();
+    }
+
+    /**
+     * Add a custom exception to RUM monitoring. This can be useful for tracking custom error
+     * handling in your application.
+     * <p>
+     * This event will be turned into a Span and sent to the RUM ingest along with other, auto-generated
+     * spans.
+     *
+     * @param throwable A {@link Throwable} associated with this event.
+     */
+    public void addRumException(Throwable throwable) {
+        addRumException(throwable, Attributes.empty());
+    }
+
+    /**
+     * Add a custom exception to RUM monitoring. This can be useful for tracking custom error
+     * handling in your application.
+     * <p>
+     * This event will be turned into a Span and sent to the RUM ingest along with other, auto-generated
+     * spans.
+     *
+     * @param throwable  A {@link Throwable} associated with this event.
+     * @param attributes Any {@link Attributes} to associate with the event.
+     */
+    public void addRumException(Throwable throwable, Attributes attributes) {
+        Span span = getTracer()
+                .spanBuilder(throwable.getClass().getSimpleName())
+                .setAllAttributes(attributes)
+                .setAttribute(COMPONENT_KEY, COMPONENT_ERROR)
                 .startSpan();
         addExceptionAttributes(span, throwable);
         span.end();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
@@ -29,6 +29,7 @@ public class NoOpSplunkRumTest {
         NoOpSplunkRum instance = NoOpSplunkRum.INSTANCE;
         instance.addRumEvent("foo", Attributes.empty());
         instance.addRumException("bar", Attributes.empty(), new RuntimeException());
+        instance.addRumException(new RuntimeException(), Attributes.empty());
         assertNotNull(instance.createOkHttpRumInterceptor());
         assertNotNull(instance.getOpenTelemetry());
         assertNotNull(instance.getRumSessionId());

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -152,13 +152,14 @@ public class SplunkRumTest {
         SplunkRum splunkRum = new SplunkRum(testSdk, new SessionId());
 
         Attributes attributes = Attributes.of(stringKey("one"), "1", longKey("two"), 2L);
-        splunkRum.addRumException("fooError", attributes, new NullPointerException("oopsie"));
+        splunkRum.addRumException(new NullPointerException("oopsie"), attributes);
 
         List<SpanData> spans = testExporter.getFinishedSpanItems();
         assertEquals(1, spans.size());
-        assertEquals("fooError", spans.get(0).getName());
+        assertEquals("NullPointerException", spans.get(0).getName());
 
         Attributes expected = attributes.toBuilder()
+                .put(SplunkRum.COMPONENT_KEY, SplunkRum.COMPONENT_ERROR)
                 .put(SemanticAttributes.EXCEPTION_MESSAGE, "oopsie")
                 .put(SplunkRum.ERROR_MESSAGE_KEY, "oopsie")
                 .put(SemanticAttributes.EXCEPTION_TYPE, "NullPointerException")


### PR DESCRIPTION
I've noticed that Android RUM differs in 2 things from what RUM backend expects:

* missing `component=error` attribute;
* span name is different than `exception.type` attribute; in fact, it may be completely custom one.

I've added 2 new methods that do not allow setting custom exception span name and deprecated the old one - @jkwatson please take a look at this, whether this makes sense or not.