### PR TITLE
Hack the zipkin encoder to preserve span name casing.

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
@@ -170,7 +170,7 @@ public class SecondFragment extends Fragment {
     }
 
     private void createSpamSpan() {
-        sampleAppTracer.spanBuilder("spam span no. " + spans.incrementAndGet())
+        sampleAppTracer.spanBuilder("Spam Span no. " + spans.incrementAndGet())
                 .setAttribute("number", spans.get())
                 .startSpan()
                 .end();

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import zipkin2.Span;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.Encoding;
+import zipkin2.internal.JsonCodec;
+import zipkin2.internal.V2SpanWriter;
+import zipkin2.internal.WriteBuffer;
+
+class CustomZipkinEncoder implements BytesEncoder<Span> {
+
+    private final WriteBuffer.Writer<Span> writer = new V2SpanWriter();
+
+    public Encoding encoding() {
+        return Encoding.JSON;
+    }
+
+    public int sizeInBytes(Span span) {
+        return this.writer.sizeInBytes(span);
+    }
+
+    public byte[] encode(Span span) {
+        String properSpanName = span.tags().get(RumAttributeAppender.SPLUNK_OPERATION_KEY.getKey());
+
+        //note: this can be optimized, if necessary. Let's keep it simple for now.
+        byte[] rawBytes = JsonCodec.write(this.writer, span);
+        String renamedResult = new String(rawBytes).replace(
+                "\"name\":\"" + span.name() + "\"",
+                "\"name\":\"" + properSpanName + "\"");
+        return renamedResult.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] encodeList(List<Span> spans) {
+        //note: this doesn't appear to be called in our current code paths, so let's leave it be.
+        return JsonCodec.writeList(this.writer, spans);
+    }
+
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
@@ -36,14 +36,17 @@ class CustomZipkinEncoder implements BytesEncoder<Span> {
 
     private final WriteBuffer.Writer<Span> writer = new V2SpanWriter();
 
+    @Override
     public Encoding encoding() {
         return Encoding.JSON;
     }
 
+    @Override
     public int sizeInBytes(Span span) {
         return this.writer.sizeInBytes(span);
     }
 
+    @Override
     public byte[] encode(Span span) {
         String properSpanName = span.tags().get(RumAttributeAppender.SPLUNK_OPERATION_KEY.getKey());
 
@@ -55,6 +58,7 @@ class CustomZipkinEncoder implements BytesEncoder<Span> {
         return renamedResult.getBytes(StandardCharsets.UTF_8);
     }
 
+    @Override
     public byte[] encodeList(List<Span> spans) {
         //note: this doesn't appear to be called in our current code paths, so let's leave it be.
         return JsonCodec.writeList(this.writer, spans);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
@@ -26,6 +26,12 @@ import zipkin2.internal.JsonCodec;
 import zipkin2.internal.V2SpanWriter;
 import zipkin2.internal.WriteBuffer;
 
+/**
+ * We need a custom encoder to correct for the fact that the zipkin Span.Builder lowercases all Span names.
+ * <p>
+ * We do this by having the {@link RumAttributeAppender} add an additional attribute ({@link RumAttributeAppender#SPLUNK_OPERATION_KEY})
+ * with the span name properly cased, then correcting the span name here at encoding time.
+ */
 class CustomZipkinEncoder implements BytesEncoder<Span> {
 
     private final WriteBuffer.Writer<Span> writer = new V2SpanWriter();

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
@@ -16,6 +16,9 @@
 
 package com.splunk.rum;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
+
 import android.os.Build;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -24,9 +27,6 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
 
 class RumAttributeAppender implements SpanProcessor {
     static final AttributeKey<String> APP_NAME_KEY = stringKey("app");
@@ -39,6 +39,7 @@ class RumAttributeAppender implements SpanProcessor {
     //note: these will be in the otel semantic conventions as of spec v1.6.0
     static final AttributeKey<String> NETWORK_TYPE_KEY = stringKey("host.connection.type");
     static final AttributeKey<String> NETWORK_SUBTYPE_KEY = stringKey("host.connection.subtype");
+    static final AttributeKey<String> SPLUNK_OPERATION_KEY = stringKey("_splunk_operation");
 
     private final Config config;
     private final SessionId sessionId;
@@ -56,6 +57,8 @@ class RumAttributeAppender implements SpanProcessor {
 
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
+        //set this custom attribute in order to let the CustomZipEncoder use it for the span name on the wire.
+        span.setAttribute(SPLUNK_OPERATION_KEY, span.getName());
         span.setAttribute(APP_NAME_KEY, config.getApplicationName());
         span.setAttribute(SESSION_ID_KEY, sessionId.getSessionId());
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
@@ -57,7 +57,7 @@ class RumAttributeAppender implements SpanProcessor {
 
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
-        //set this custom attribute in order to let the CustomZipEncoder use it for the span name on the wire.
+        //set this custom attribute in order to let the CustomZipkinEncoder use it for the span name on the wire.
         span.setAttribute(SPLUNK_OPERATION_KEY, span.getName());
         span.setAttribute(APP_NAME_KEY, config.getApplicationName());
         span.setAttribute(SESSION_ID_KEY, sessionId.getSessionId());

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -174,7 +174,9 @@ class RumInitializer {
             // we'll do our best to hang on to the spans with the wrapping BufferingExporter.
             ZipkinSpanExporter.baseLogger.setLevel(Level.SEVERE);
         }
-        ZipkinSpanExporter zipkinSpanExporter = ZipkinSpanExporter.builder().setEndpoint(endpoint).build();
+        ZipkinSpanExporter zipkinSpanExporter = ZipkinSpanExporter.builder()
+                .setEncoder(new CustomZipkinEncoder())
+                .setEndpoint(endpoint).build();
         SpanExporter throttlingExporter = ThrottlingExporter.newBuilder(zipkinSpanExporter)
                 .categorizeByAttribute(SplunkRum.COMPONENT_KEY)
                 .maxSpansInWindow(100)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/CustomZipkinEncoderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/CustomZipkinEncoderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
+import zipkin2.Span;
+
+public class CustomZipkinEncoderTest {
+
+    @Test
+    public void nameReplacement() {
+        CustomZipkinEncoder encoder = new CustomZipkinEncoder();
+        Span span = Span.newBuilder()
+                .name("lowercase")
+                .traceId(TraceId.fromLongs(1, 2))
+                .id(SpanId.fromLong(1))
+                .putTag(RumAttributeAppender.SPLUNK_OPERATION_KEY.getKey(), "UpperCase")
+                .build();
+        byte[] bytes = encoder.encode(span);
+        //this assertion verifies that we changed the name
+        assertEquals("{\"traceId\":\"00000000000000010000000000000002\",\"id\":\"0000000000000001\",\"name\":\"UpperCase\",\"tags\":{\"_splunk_operation\":\"UpperCase\"}}", new String(bytes));
+        assertEquals(bytes.length, encoder.sizeInBytes(span));
+    }
+}


### PR DESCRIPTION
The Zipkin Span.Builder lowercases all span names, without an option to disable this behavior. To work around this, we add an extra attribute with the actual span name, and then munge the output of the zipkin V2 Span Encoder implementation to replace the proper span name from the attribute value.