### PR TITLE
Add a required proguard rule for library consumers.

### DIFF
--- a/splunk-otel-android/consumer-rules.pro
+++ b/splunk-otel-android/consumer-rules.pro
@@ -1,0 +1,2 @@
+# keep everything in the opentelemetry packages
+-keep class io.opentelemetry.** { *; }


### PR DESCRIPTION
I'd love to figure out how to test that this is sufficient at build time. 