### PR TITLE
Provide an OkHttp Call.Factory, rather than an Interceptor

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
@@ -23,7 +23,9 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTracing;
+import okhttp3.Call;
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 
 class NoOpSplunkRum extends SplunkRum {
     static final NoOpSplunkRum INSTANCE = new NoOpSplunkRum();
@@ -35,6 +37,11 @@ class NoOpSplunkRum extends SplunkRum {
     @Override
     public Interceptor createOkHttpRumInterceptor() {
         return OkHttpTracing.create(OpenTelemetry.noop()).newInterceptor();
+    }
+
+    @Override
+    public Call.Factory createRumOkHttpCallFactory(OkHttpClient client) {
+        return client;
     }
 
     @Override

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
@@ -18,11 +18,13 @@ package com.splunk.rum;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import okhttp3.OkHttpClient;
 
 public class NoOpSplunkRumTest {
 
@@ -37,6 +39,8 @@ public class NoOpSplunkRumTest {
         assertNotNull(instance.getRumSessionId());
         assertNotNull(instance.getTracer());
         assertNotNull(instance.startWorkflow("foo"));
+        OkHttpClient okHttpClient = mock(OkHttpClient.class);
+        assertSame(okHttpClient, instance.createRumOkHttpCallFactory(okHttpClient));
 
         instance.updateGlobalAttributes(attributesBuilder -> {
         });


### PR DESCRIPTION
This change will provide real async context propagation, in the cases where callers are properly managing the calling context scope.