### PR TITLE
Introduce a class to hold standard RUM attributes

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -20,6 +20,7 @@ import android.app.Application;
 
 import com.splunk.rum.Config;
 import com.splunk.rum.SplunkRum;
+import com.splunk.rum.StandardAttributes;
 
 import io.opentelemetry.api.common.Attributes;
 
@@ -36,7 +37,11 @@ public class SampleApplication extends Application {
                 .applicationName("Android Demo App")
                 .debugEnabled(true)
                 .deploymentEnvironment("demo")
-                .globalAttributes(Attributes.builder().put("vendor", "Splunk").build())
+                .globalAttributes(
+                        Attributes.builder()
+                                .put("vendor", "Splunk")
+                                .put(StandardAttributes.APP_VERSION, BuildConfig.VERSION_NAME)
+                                .build())
                 .build();
         SplunkRum.initialize(config, this);
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+
+/**
+ * This class hold {@link AttributeKey}s for standard RUM-related attributes that are not in the
+ * OpenTelemetry {@link io.opentelemetry.semconv.trace.attributes.SemanticAttributes} definitions.
+ */
+public class StandardAttributes {
+    /**
+     * The version of your app. Useful for adding to global attributes.
+     *
+     * @see Config.Builder#globalAttributes(Attributes)
+     */
+    public static final AttributeKey<String> APP_VERSION = AttributeKey.stringKey("app.version");
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
@@ -23,11 +23,14 @@ import io.opentelemetry.api.common.Attributes;
  * This class hold {@link AttributeKey}s for standard RUM-related attributes that are not in the
  * OpenTelemetry {@link io.opentelemetry.semconv.trace.attributes.SemanticAttributes} definitions.
  */
-public class StandardAttributes {
+public final class StandardAttributes {
     /**
      * The version of your app. Useful for adding to global attributes.
      *
      * @see Config.Builder#globalAttributes(Attributes)
      */
     public static final AttributeKey<String> APP_VERSION = AttributeKey.stringKey("app.version");
+
+    private StandardAttributes() {
+    }
 }


### PR DESCRIPTION
Useful until they are included in the OTel semantic conventions.