### PR TITLE
Provide a means of redacting data from export

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -16,6 +16,8 @@
 
 package com.splunk.android.sample;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
 import android.app.Application;
 
 import com.splunk.rum.Config;
@@ -42,6 +44,10 @@ public class SampleApplication extends Application {
                                 .put("vendor", "Splunk")
                                 .put(StandardAttributes.APP_VERSION, BuildConfig.VERSION_NAME)
                                 .build())
+                .filterSpans(spanFilter ->
+                        spanFilter
+                                .removeSpanAttribute(stringKey("http.user_agent"))
+                                .rejectSpansByName(spanName -> spanName.equals("ignored")))
                 .build();
         SplunkRum.initialize(config, this);
     }

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -47,7 +47,7 @@ public class SampleApplication extends Application {
                 .filterSpans(spanFilter ->
                         spanFilter
                                 .removeSpanAttribute(stringKey("http.user_agent"))
-                                .rejectSpansByName(spanName -> spanName.equals("ignored")))
+                                .rejectSpansByName(spanName -> spanName.contains("ignored")))
                 .build();
         SplunkRum.initialize(config, this);
     }

--- a/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
@@ -93,9 +94,12 @@ public class SecondFragment extends Fragment {
                 span.end();
             }
         });
-        binding.buttonToWebview.setOnClickListener(v ->
-                NavHostFragment.findNavController(SecondFragment.this)
-                        .navigate(R.id.action_SecondFragment_to_webViewFragment));
+        binding.buttonToWebview.setOnClickListener(v -> {
+            SplunkRum.getInstance().addRumEvent("this span will be ignored", Attributes.empty());
+
+            NavHostFragment.findNavController(SecondFragment.this)
+                    .navigate(R.id.action_SecondFragment_to_webViewFragment);
+        });
 
         binding.buttonToCustomTab.setOnClickListener(v -> {
             String url = "https://ssidhu.o11ystore.com/";

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ModifiedSpanData.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ModifiedSpanData.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+
+final class ModifiedSpanData implements SpanData {
+    private final SpanData original;
+    private final Attributes modifiedAttributes;
+
+    ModifiedSpanData(SpanData original, Attributes modifiedAttributes) {
+        this.original = original;
+        this.modifiedAttributes = modifiedAttributes;
+    }
+
+    @Override
+    public String getName() {
+        return original.getName();
+    }
+
+    @Override
+    public SpanKind getKind() {
+        return original.getKind();
+    }
+
+    @Override
+    public SpanContext getSpanContext() {
+        return original.getSpanContext();
+    }
+
+    @Override
+    public SpanContext getParentSpanContext() {
+        return original.getParentSpanContext();
+    }
+
+    @Override
+    public StatusData getStatus() {
+        return original.getStatus();
+    }
+
+    @Override
+    public long getStartEpochNanos() {
+        return original.getStartEpochNanos();
+    }
+
+    @Override
+    public Attributes getAttributes() {
+        return modifiedAttributes;
+    }
+
+    @Override
+    public List<EventData> getEvents() {
+        return original.getEvents();
+    }
+
+    @Override
+    public List<LinkData> getLinks() {
+        return original.getLinks();
+    }
+
+    @Override
+    public long getEndEpochNanos() {
+        return original.getEndEpochNanos();
+    }
+
+    @Override
+    public boolean hasEnded() {
+        return original.hasEnded();
+    }
+
+    @Override
+    public int getTotalRecordedEvents() {
+        return original.getTotalRecordedEvents();
+    }
+
+    @Override
+    public int getTotalRecordedLinks() {
+        return original.getTotalRecordedLinks();
+    }
+
+    @Override
+    public int getTotalAttributeCount() {
+        // TODO: not sure about this
+        return modifiedAttributes.size();
+    }
+
+    @Override
+    public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+        return original.getInstrumentationLibraryInfo();
+    }
+
+    @Override
+    public Resource getResource() {
+        return original.getResource();
+    }
+
+    // TODO: hashCode, equals ?
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -177,11 +177,12 @@ class RumInitializer {
         }
         SpanExporter zipkinSpanExporter = getCoreSpanExporter(endpoint);
 
-        return ThrottlingExporter.newBuilder(new BufferingExporter(connectionUtil, zipkinSpanExporter))
+        ThrottlingExporter throttlingExporter = ThrottlingExporter.newBuilder(new BufferingExporter(connectionUtil, zipkinSpanExporter))
                 .categorizeByAttribute(SplunkRum.COMPONENT_KEY)
                 .maxSpansInWindow(100)
                 .windowSize(Duration.ofSeconds(30))
                 .build();
+        return config.decorateWithSpanFilter(throttlingExporter);
     }
 
     //visible for testing

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+final class SpanFilter implements SpanExporter {
+    private final SpanExporter delegate;
+    private final Predicate<String> rejectSpanNamesPredicate;
+    private final Map<AttributeKey<String>, Predicate<String>> rejectSpanAttributesPredicates;
+    private final Map<AttributeKey<String>, Function<String, String>> spanAttributeReplacements;
+
+    SpanFilter(SpanExporter delegate,
+               Predicate<String> rejectSpanNamesPredicate,
+               Map<AttributeKey<String>, Predicate<String>> rejectSpanAttributesPredicates,
+               Map<AttributeKey<String>, Function<String, String>> spanAttributeReplacements) {
+        this.delegate = delegate;
+        this.rejectSpanNamesPredicate = rejectSpanNamesPredicate;
+        this.rejectSpanAttributesPredicates = rejectSpanAttributesPredicates;
+        this.spanAttributeReplacements = spanAttributeReplacements;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        List<SpanData> filtered = new ArrayList<>();
+        for (SpanData span : spans) {
+            if (reject(span)) {
+                continue;
+            }
+            filtered.add(modify(span));
+        }
+        return delegate.export(filtered);
+    }
+
+    private boolean reject(SpanData span) {
+        if (rejectSpanNamesPredicate.test(span.getName())) {
+            return true;
+        }
+        Attributes attributes = span.getAttributes();
+        for (Map.Entry<AttributeKey<String>, Predicate<String>> e : rejectSpanAttributesPredicates.entrySet()) {
+            AttributeKey<String> key = e.getKey();
+            Predicate<String> valuePredicate = e.getValue();
+            String attributeValue = attributes.get(key);
+            if (attributeValue != null && valuePredicate.test(attributeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private SpanData modify(SpanData span) {
+        if (spanAttributeReplacements.isEmpty()) {
+            return span;
+        }
+
+        AttributesBuilder modifiedAttributes = Attributes.builder();
+        span.getAttributes().forEach((key, value) -> {
+            if (!(value instanceof String)) {
+                modifiedAttributes.put((AttributeKey<Object>) key, value);
+                return;
+            }
+            String oldValue = (String) value;
+            Function<String, String> valueModifier = spanAttributeReplacements.getOrDefault(key, Function.identity());
+            String newValue = valueModifier.apply(oldValue);
+            if (newValue != null) {
+                modifiedAttributes.put((AttributeKey<String>) key, newValue);
+            }
+        });
+
+        return new ModifiedSpanData(span, modifiedAttributes.build());
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return delegate.flush();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return delegate.shutdown();
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
@@ -54,7 +54,7 @@ public final class SpanFilterBuilder {
     /**
      * Remove matching spans from the exporter pipeline.
      * <p>
-     * Any Span that contains an attribute with key {@code attributeKey} and value matching the
+     * Any span that contains an attribute with key {@code attributeKey} and value matching the
      * {@code attributeValuePredicate} will not be exported.
      *
      * @param attributeKey            An attribute key to match.

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/**
+ * Allows to modify span data before it is sent to the exported. Spans can be modified or entirely
+ * rejected from export.
+ */
+public final class SpanFilterBuilder {
+
+    private Predicate<String> rejectSpanNamesPredicate = spanName -> false;
+    private final Map<AttributeKey<String>, Predicate<String>> rejectSpanAttributesPredicates = new HashMap<>();
+    private final Map<AttributeKey<String>, Function<String, String>> spanAttributeReplacements = new HashMap<>();
+
+    SpanFilterBuilder() {
+    }
+
+    /**
+     * Remove matching spans from the exporter pipeline.
+     * <p>
+     * Span names that match the {@code spanNamePredicate} will not be exported.
+     *
+     * @param spanNamePredicate A function that returns true if a span with passed name should be
+     *                          rejected.
+     * @return {@code this}.
+     */
+    public SpanFilterBuilder rejectSpansByName(Predicate<String> spanNamePredicate) {
+        rejectSpanNamesPredicate = rejectSpanNamesPredicate.or(spanNamePredicate);
+        return this;
+    }
+
+    /**
+     * Remove matching spans from the exporter pipeline.
+     * <p>
+     * Span that contains an attribute with key {@code attributeKey} and value matching the
+     * {@code attributeValuePredicate} will not be exported.
+     *
+     * @param attributeKey            An attribute key to match.
+     * @param attributeValuePredicate A function that returns true if a span containing an attribute
+     *                                with matching value should be rejected.
+     * @return {@code this}.
+     */
+    public SpanFilterBuilder rejectSpansByAttributeValue(
+            AttributeKey<String> attributeKey,
+            Predicate<String> attributeValuePredicate) {
+
+        rejectSpanAttributesPredicates.compute(attributeKey,
+                (k, oldValue) -> oldValue == null
+                        ? attributeValuePredicate
+                        : oldValue.or(attributeValuePredicate));
+        return this;
+    }
+
+    public SpanFilterBuilder removeSpanAttribute(AttributeKey<String> attributeKey) {
+        return removeSpanAttribute(attributeKey, value -> true);
+    }
+
+    /**
+     * Modify span data before it enters the exporter pipeline.
+     * <p>
+     * An attribute with key {@code attributeKey} and value matching the
+     * {@code attributeValuePredicate} will be removed from the span before it is exported.
+     *
+     * @param attributeKey            An attribute key to match.
+     * @param attributeValuePredicate A function that returns true if an attribute with matching
+     *                                value should be removed from the span.
+     * @return {@code this}.
+     */
+    public SpanFilterBuilder removeSpanAttribute(
+            AttributeKey<String> attributeKey,
+            Predicate<String> attributeValuePredicate) {
+
+        return replaceSpanAttribute(attributeKey, old -> attributeValuePredicate.test(old) ? null : old);
+    }
+
+    /**
+     * Modify span data before it enters the exporter pipeline.
+     * <p>
+     * Value of an attribute with key {@code attributeKey} will be passed to the
+     * {@code attributeValueModifier} function. Value returned by the function will replace the
+     * original value. When the modifier function returns {@code null} the attribute will be removed
+     * from the span.
+     *
+     * @param attributeKey           An attribute key to match.
+     * @param attributeValueModifier A function that receives the old attribute value and returns
+     *                               the new one.
+     * @return {@code this}.
+     */
+    public SpanFilterBuilder replaceSpanAttribute(
+            AttributeKey<String> attributeKey,
+            Function<String, String> attributeValueModifier) {
+
+        spanAttributeReplacements.compute(attributeKey,
+                (k, oldValue) -> oldValue == null
+                        ? attributeValueModifier
+                        : oldValue.andThen(attributeValueModifier));
+        return this;
+    }
+
+    Function<SpanExporter, SpanExporter> build() {
+        // make a copy so that the references from the builder are not included in the returned function
+        Predicate<String> rejectSpanNamesPredicate = this.rejectSpanNamesPredicate;
+        Map<AttributeKey<String>, Predicate<String>> rejectSpanAttributesPredicates = new HashMap<>(this.rejectSpanAttributesPredicates);
+        Map<AttributeKey<String>, Function<String, String>> spanAttributeReplacements = new HashMap<>(this.spanAttributeReplacements);
+
+        return exporter -> new SpanFilter(exporter, rejectSpanNamesPredicate, rejectSpanAttributesPredicates, spanAttributeReplacements);
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
@@ -40,7 +40,7 @@ public final class SpanFilterBuilder {
     /**
      * Remove matching spans from the exporter pipeline.
      * <p>
-     * Span names that match the {@code spanNamePredicate} will not be exported.
+     * Spans with names that match the {@code spanNamePredicate} will not be exported.
      *
      * @param spanNamePredicate A function that returns true if a span with passed name should be
      *                          rejected.
@@ -54,7 +54,7 @@ public final class SpanFilterBuilder {
     /**
      * Remove matching spans from the exporter pipeline.
      * <p>
-     * Span that contains an attribute with key {@code attributeKey} and value matching the
+     * Any Span that contains an attribute with key {@code attributeKey} and value matching the
      * {@code attributeValuePredicate} will not be exported.
      *
      * @param attributeKey            An attribute key to match.
@@ -76,7 +76,7 @@ public final class SpanFilterBuilder {
     /**
      * Modify span data before it enters the exporter pipeline.
      * <p>
-     * An attribute with key {@code attributeKey} and  will be removed from the span before it is exported.
+     * Any attribute with key {@code attributeKey} and  will be removed from the span before it is exported.
      *
      * @param attributeKey An attribute key to match.
      * @return {@code this}.
@@ -88,7 +88,7 @@ public final class SpanFilterBuilder {
     /**
      * Modify span data before it enters the exporter pipeline.
      * <p>
-     * An attribute with key {@code attributeKey} and value matching the
+     * Any attribute with key {@code attributeKey} and value matching the
      * {@code attributeValuePredicate} will be removed from the span before it is exported.
      *
      * @param attributeKey            An attribute key to match.
@@ -106,8 +106,8 @@ public final class SpanFilterBuilder {
     /**
      * Modify span data before it enters the exporter pipeline.
      * <p>
-     * Value of an attribute with key {@code attributeKey} will be passed to the
-     * {@code attributeValueModifier} function. Value returned by the function will replace the
+     * The value of any attribute with key {@code attributeKey} will be passed to the
+     * {@code attributeValueModifier} function. The value returned by the function will replace the
      * original value. When the modifier function returns {@code null} the attribute will be removed
      * from the span.
      *

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
@@ -73,6 +73,14 @@ public final class SpanFilterBuilder {
         return this;
     }
 
+    /**
+     * Modify span data before it enters the exporter pipeline.
+     * <p>
+     * An attribute with key {@code attributeKey} and  will be removed from the span before it is exported.
+     *
+     * @param attributeKey An attribute key to match.
+     * @return {@code this}.
+     */
     public <T> SpanFilterBuilder removeSpanAttribute(AttributeKey<T> attributeKey) {
         return removeSpanAttribute(attributeKey, value -> true);
     }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ModifiedSpanDataTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ModifiedSpanDataTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.assertEquals;
+import static java.util.Collections.emptyList;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import org.junit.Test;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+
+public class ModifiedSpanDataTest {
+    private static final String TRACE_ID = TraceId.fromLongs(0, 42);
+    private static final String SPAN_ID = SpanId.fromLong(123);
+
+    @Test
+    public void shouldForwardAllCallsExceptAttributesToTheOriginal() {
+        SpanData original = TestSpanData.builder()
+                .setName("test")
+                .setKind(SpanKind.CLIENT)
+                .setSpanContext(SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()))
+                .setParentSpanContext(SpanContext.getInvalid())
+                .setStatus(StatusData.ok())
+                .setStartEpochNanos(123)
+                .setAttributes(Attributes.of(stringKey("attribute"), "original value"))
+                .setEvents(emptyList())
+                .setLinks(emptyList())
+                .setEndEpochNanos(456)
+                .setHasEnded(true)
+                .setTotalRecordedEvents(0)
+                .setTotalRecordedLinks(0)
+                .setTotalAttributeCount(12)
+                .setInstrumentationLibraryInfo(InstrumentationLibraryInfo.create("test", "0.0.1"))
+                .setResource(Resource.getDefault())
+                .build();
+        SpanData modified = new ModifiedSpanData(original, Attributes.of(stringKey("attribute"), "modified"));
+
+        assertEquals(original.getName(), modified.getName());
+        assertEquals(original.getKind(), modified.getKind());
+        assertEquals(original.getSpanContext(), modified.getSpanContext());
+        assertEquals(original.getParentSpanContext(), modified.getParentSpanContext());
+        assertEquals(original.getStatus(), modified.getStatus());
+        assertEquals(original.getStartEpochNanos(), modified.getStartEpochNanos());
+        assertEquals(Attributes.of(stringKey("attribute"), "modified"), modified.getAttributes());
+        assertEquals(original.getEvents(), modified.getEvents());
+        assertEquals(original.getLinks(), modified.getLinks());
+        assertEquals(original.getEndEpochNanos(), modified.getEndEpochNanos());
+        assertEquals(original.hasEnded(), modified.hasEnded());
+        assertEquals(original.getTotalRecordedEvents(), modified.getTotalRecordedEvents());
+        assertEquals(original.getTotalRecordedLinks(), modified.getTotalRecordedLinks());
+        assertEquals(1, modified.getTotalAttributeCount());
+        assertEquals(original.getInstrumentationLibraryInfo(), modified.getInstrumentationLibraryInfo());
+        assertEquals(original.getResource(), modified.getResource());
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SpanFilterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SpanFilterTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpanFilterTest {
+    static final AttributeKey<String> ATTRIBUTE = stringKey("attribute");
+    static final AttributeKey<String> OTHER_ATTRIBUTE = stringKey("other_attribute");
+    static final AttributeKey<Long> LONG_ATTRIBUTE = longKey("long_attribute");
+
+    @Mock
+    SpanExporter delegate;
+
+    @Captor
+    ArgumentCaptor<Collection<SpanData>> spansCaptor;
+
+    @Test
+    public void shouldRejectSpansByName() {
+        // given
+        SpanExporter underTest = new SpanFilterBuilder()
+                .rejectSpansByName(spanName -> spanName.equals("span2"))
+                .rejectSpansByName(spanName -> spanName.equals("span4"))
+                .build()
+                .apply(delegate);
+
+        SpanData span1 = span("span1");
+        SpanData span2 = span("span2");
+        SpanData span3 = span("span3");
+        SpanData span4 = span("span4");
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(asList(span1, span3))).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(asList(span1, span2, span3, span4));
+
+        // then
+        assertSame(expectedResult, result);
+    }
+
+    @Test
+    public void shouldRejectSpansByAttributeValue() {
+        // given
+        SpanExporter underTest = new SpanFilterBuilder()
+                .rejectSpansByAttributeValue(ATTRIBUTE, value -> value.equals("test"))
+                .rejectSpansByAttributeValue(ATTRIBUTE, value -> value.equals("rejected!"))
+                .build()
+                .apply(delegate);
+
+        SpanData rejected = span("span", Attributes.of(ATTRIBUTE, "test"));
+        SpanData differentKey = span("span", Attributes.of(OTHER_ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
+        SpanData anotherRejected = span("span", Attributes.of(ATTRIBUTE, "rejected!"));
+        SpanData differentValue = span("span", Attributes.of(ATTRIBUTE, "not really test"));
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(asList(differentKey, differentValue))).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(
+                asList(rejected, differentKey, anotherRejected, differentValue));
+
+        // then
+        assertSame(expectedResult, result);
+    }
+
+    @Test
+    public void shouldRemoveSpanAttributes() {
+        // given
+        SpanExporter underTest = new SpanFilterBuilder()
+                .removeSpanAttribute(ATTRIBUTE, value -> value.equals("test"))
+                // make sure that attribute types are taken into account
+                .removeSpanAttribute(stringKey("long_attribute"))
+                .build()
+                .apply(delegate);
+
+        SpanData span1 = span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
+        SpanData span2 = span("second", Attributes.of(ATTRIBUTE, "not test", OTHER_ATTRIBUTE, "test"));
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(spansCaptor.capture())).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(asList(span1, span2));
+
+        // then
+        assertSame(expectedResult, result);
+
+        List<SpanData> exportedSpans = new ArrayList<>(spansCaptor.getValue());
+        assertEquals(2, exportedSpans.size());
+        assertEquals("first", exportedSpans.get(0).getName());
+        assertEquals(Attributes.of(LONG_ATTRIBUTE, 42L), exportedSpans.get(0).getAttributes());
+        assertEquals("second", exportedSpans.get(1).getName());
+        assertEquals(Attributes.of(ATTRIBUTE, "not test", OTHER_ATTRIBUTE, "test"), exportedSpans.get(1).getAttributes());
+    }
+
+    @Test
+    public void shouldReplaceSpanAttributes() {
+        // given
+        SpanExporter underTest = new SpanFilterBuilder()
+                .replaceSpanAttribute(ATTRIBUTE, value -> value + "!!!")
+                .replaceSpanAttribute(ATTRIBUTE, value -> value + "1")
+                // make sure that attribute types are taken into account
+                .replaceSpanAttribute(stringKey("long_attribute"), value -> "abc")
+                .build()
+                .apply(delegate);
+
+        SpanData span1 = span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
+        SpanData span2 = span("second", Attributes.of(OTHER_ATTRIBUTE, "test"));
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(spansCaptor.capture())).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(asList(span1, span2));
+
+        // then
+        assertSame(expectedResult, result);
+
+        List<SpanData> exportedSpans = new ArrayList<>(spansCaptor.getValue());
+        assertEquals(2, exportedSpans.size());
+        assertEquals("first", exportedSpans.get(0).getName());
+        assertEquals(Attributes.of(ATTRIBUTE, "test!!!1", LONG_ATTRIBUTE, 42L), exportedSpans.get(0).getAttributes());
+        assertEquals("second", exportedSpans.get(1).getName());
+        assertEquals(Attributes.of(OTHER_ATTRIBUTE, "test"), exportedSpans.get(1).getAttributes());
+    }
+
+    @Test
+    public void builderChangesShouldNotApplyToAlreadyDecoratedExporter() {
+        // given
+        SpanFilterBuilder builder = new SpanFilterBuilder();
+        SpanExporter underTest = builder
+                .build()
+                .apply(delegate);
+
+        builder.rejectSpansByName(spanName -> spanName.equals("span"))
+                .rejectSpansByAttributeValue(ATTRIBUTE, value -> true)
+                .removeSpanAttribute(ATTRIBUTE, value -> true)
+                .replaceSpanAttribute(ATTRIBUTE, value -> "abc");
+
+        SpanData span = span("span", Attributes.of(ATTRIBUTE, "test"));
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(singletonList(span))).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(singletonList(span));
+
+        // then
+        assertSame(expectedResult, result);
+    }
+
+    @Test
+    public void shouldDelegateCalls() {
+        SpanExporter underTest = new SpanFilterBuilder()
+                .build()
+                .apply(delegate);
+
+        underTest.flush();
+        verify(delegate).flush();
+
+        underTest.shutdown();
+        verify(delegate).shutdown();
+    }
+
+    private static SpanData span(String name) {
+        return span(name, Attributes.empty());
+    }
+
+    private static SpanData span(String name, Attributes attributes) {
+        return TestSpanData.builder()
+                .setName(name)
+                .setKind(SpanKind.INTERNAL)
+                .setStatus(StatusData.unset())
+                .setHasEnded(true)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(123)
+                .setAttributes(attributes)
+                .build();
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SpanFilterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SpanFilterTest.java
@@ -171,6 +171,31 @@ public class SpanFilterTest {
     }
 
     @Test
+    public void shouldReplaceSpanAttributes_removeAttributeByReturningNull() {
+        // given
+        SpanExporter underTest = new SpanFilterBuilder()
+                .replaceSpanAttribute(ATTRIBUTE, value -> null)
+                .build()
+                .apply(delegate);
+
+        SpanData span = span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
+
+        CompletableResultCode expectedResult = new CompletableResultCode();
+        when(delegate.export(spansCaptor.capture())).thenReturn(expectedResult);
+
+        // when
+        CompletableResultCode result = underTest.export(singletonList(span));
+
+        // then
+        assertSame(expectedResult, result);
+
+        List<SpanData> exportedSpans = new ArrayList<>(spansCaptor.getValue());
+        assertEquals(1, exportedSpans.size());
+        assertEquals("first", exportedSpans.get(0).getName());
+        assertEquals(Attributes.of(LONG_ATTRIBUTE, 42L), exportedSpans.get(0).getAttributes());
+    }
+
+    @Test
     public void builderChangesShouldNotApplyToAlreadyDecoratedExporter() {
         // given
         SpanFilterBuilder builder = new SpanFilterBuilder();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -21,6 +21,7 @@ import android.app.Application;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
 
 import java.util.List;
 
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,6 +70,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.isDebugEnabled()).thenReturn(true);
+        when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> connectionUtil);
         SplunkRum sameInstance = SplunkRum.initialize(config, application);
@@ -87,6 +90,7 @@ public class SplunkRumTest {
         Config config = mock(Config.class);
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
+        when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertSame(singleton, SplunkRum.getInstance());
@@ -103,6 +107,7 @@ public class SplunkRumTest {
         Config config = mock(Config.class);
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
+        when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
 
         SplunkRum splunkRum = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertNotNull(splunkRum.getOpenTelemetry());


### PR DESCRIPTION
Implements:
* Rejecting spans from export by name and/or attribute
* Removing/modifying attribute value in a span before export

Modifying span name before export could be easily implemented if needed. I didn't implement modifying span events, it'd be a bit harder to do since events have name + attributes at the very least and we don't expose SDK types like `EventData` to the user of the library.
The fact that we don't expose SDK types is also the reason why I built the `SpanFilterBuilder` class and didn't just use a simple `SpanData -> SpanData?` function. 