### PR TITLE
Provide a means of filtering spans based on name

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -24,6 +24,8 @@ import com.splunk.rum.Config;
 import com.splunk.rum.SplunkRum;
 import com.splunk.rum.StandardAttributes;
 
+import java.util.regex.Pattern;
+
 import io.opentelemetry.api.common.Attributes;
 
 public class SampleApplication extends Application {
@@ -47,7 +49,7 @@ public class SampleApplication extends Application {
                 .filterSpans(spanFilter ->
                         spanFilter
                                 .removeSpanAttribute(stringKey("http.user_agent"))
-                                .rejectSpansByName(spanName -> spanName.contains("ignored")))
+                                .rejectSpansByName(Pattern.compile(".*ignored.*")))
                 .build();
         SplunkRum.initialize(config, this);
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilterBuilder.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -35,6 +36,19 @@ public final class SpanFilterBuilder {
     private final Map<AttributeKey<?>, Function<?, ?>> spanAttributeReplacements = new HashMap<>();
 
     SpanFilterBuilder() {
+    }
+
+    /**
+     * Remove matching spans from the exporter pipeline.
+     * <p>
+     * Spans with names that match the passed {@code pattern} will not be exported.
+     *
+     * @param pattern A regular expression pattern that matches names of spans that should be
+     *                rejected.
+     * @return {@code this}.
+     */
+    public SpanFilterBuilder rejectSpansByName(Pattern pattern) {
+        return rejectSpansByName(spanName -> pattern.matcher(spanName).matches());
     }
 
     /**


### PR DESCRIPTION
It almost seems too easy with the existing `SpanFilterBuilder` framework...

Do we need a `rejectSpansByName(Pattern...)` variant? Or is calling `rejectSpansByName()` multiple times acceptable?