### PR TITLE
Update for otel-java 1.6.0

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -30,7 +30,7 @@ import io.opentelemetry.api.common.Attributes;
 
 public class SampleApplication extends Application {
 
-    private static final Pattern HTTP_URL_SENSITIVE_DATA_PATTERN = Pattern.compile("(user|pass)=\\\\w+");
+    private static final Pattern HTTP_URL_SENSITIVE_DATA_PATTERN = Pattern.compile("(user|pass)=\\w+");
 
     @Override
     public void onCreate() {

--- a/splunk-otel-android/build.gradle
+++ b/splunk-otel-android/build.gradle
@@ -45,12 +45,12 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.navigation:navigation-fragment:2.3.5'
 
-    api platform("io.opentelemetry:opentelemetry-bom:1.5.0")
+    api platform("io.opentelemetry:opentelemetry-bom:1.6.0")
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-zipkin'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'
 
-    implementation platform("io.opentelemetry:opentelemetry-bom-alpha:1.5.0-alpha")
+    implementation platform("io.opentelemetry:opentelemetry-bom-alpha:1.6.0-alpha")
     implementation 'io.opentelemetry:opentelemetry-semconv'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:1.5.3-alpha'
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ModifiedSpanData.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ModifiedSpanData.java
@@ -118,5 +118,13 @@ final class ModifiedSpanData implements SpanData {
         return original.getResource();
     }
 
+    @Override
+    public String toString() {
+        return "ModifiedSpanData{" +
+                "original=" + original +
+                ", modifiedAttributes=" + modifiedAttributes +
+                '}';
+    }
+
     // TODO: hashCode, equals ?
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/NetworkMonitor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NetworkMonitor.java
@@ -16,15 +16,15 @@
 
 package com.splunk.rum;
 
-import static com.splunk.rum.RumAttributeAppender.NETWORK_SUBTYPE_KEY;
-import static com.splunk.rum.RumAttributeAppender.NETWORK_TYPE_KEY;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 class NetworkMonitor implements AppStateListener {
     static final AttributeKey<String> NETWORK_STATUS_KEY = stringKey("network.status");
@@ -70,15 +70,15 @@ class NetworkMonitor implements AppStateListener {
                         .setAttribute(NETWORK_STATUS_KEY, "lost")
                         .startSpan()
                         //put this after span start to override what might be set in the RumAttributeAppender.
-                        .setAttribute(NETWORK_TYPE_KEY, activeNetwork.getState().getHumanName())
+                        .setAttribute(NET_HOST_CONNECTION_TYPE, activeNetwork.getState().getHumanName())
                         .end();
             } else {
                 Span available = tracer.spanBuilder("network.change")
                         .setAttribute(NETWORK_STATUS_KEY, "available")
                         .startSpan()
                         //put these after span start to override what might be set in the RumAttributeAppender.
-                        .setAttribute(NETWORK_TYPE_KEY, activeNetwork.getState().getHumanName());
-                activeNetwork.getSubType().ifPresent(subType -> available.setAttribute(NETWORK_SUBTYPE_KEY, subType));
+                        .setAttribute(NET_HOST_CONNECTION_TYPE, activeNetwork.getState().getHumanName());
+                activeNetwork.getSubType().ifPresent(subType -> available.setAttribute(SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE, subType));
                 available.end();
             }
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/NetworkState.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NetworkState.java
@@ -16,13 +16,15 @@
 
 package com.splunk.rum;
 
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
 enum NetworkState {
-    //note: these will be in the otel semantic conventions as of spec v1.6.0
-    NO_NETWORK_AVAILABLE("unavailable"),
-    TRANSPORT_CELLULAR("cell"),
-    TRANSPORT_WIFI("wifi"),
-    TRANSPORT_VPN("vpn"),
-    TRANSPORT_UNKNOWN("unknown");
+    NO_NETWORK_AVAILABLE(SemanticAttributes.NetHostConnectionTypeValues.UNAVAILABLE),
+    TRANSPORT_CELLULAR(SemanticAttributes.NetHostConnectionTypeValues.CELL),
+    TRANSPORT_WIFI(SemanticAttributes.NetHostConnectionTypeValues.WIFI),
+    TRANSPORT_UNKNOWN(SemanticAttributes.NetHostConnectionTypeValues.UNKNOWN),
+    //this one doesn't seem to have an otel value at this point.
+    TRANSPORT_VPN("vpn");
 
     private final String humanName;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
@@ -22,6 +22,8 @@ import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DE
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_NAME;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
 
 import android.os.Build;
 
@@ -35,10 +37,6 @@ class RumAttributeAppender implements SpanProcessor {
     static final AttributeKey<String> APP_NAME_KEY = stringKey("app");
     static final AttributeKey<String> SESSION_ID_KEY = stringKey("splunk.rumSessionId");
     static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rumVersion");
-
-    //note: these 2 will be in the otel semantic conventions as of spec v1.6.0
-    static final AttributeKey<String> NETWORK_TYPE_KEY = stringKey("host.connection.type");
-    static final AttributeKey<String> NETWORK_SUBTYPE_KEY = stringKey("host.connection.subtype");
 
     static final AttributeKey<String> SPLUNK_OPERATION_KEY = stringKey("_splunk_operation");
 
@@ -75,8 +73,8 @@ class RumAttributeAppender implements SpanProcessor {
         String currentScreen = visibleScreenTracker.getCurrentlyVisibleScreen();
         span.setAttribute(SplunkRum.SCREEN_NAME_KEY, currentScreen);
         CurrentNetwork currentNetwork = connectionUtil.getActiveNetwork();
-        span.setAttribute(NETWORK_TYPE_KEY, currentNetwork.getState().getHumanName());
-        currentNetwork.getSubType().ifPresent(subtype -> span.setAttribute(NETWORK_SUBTYPE_KEY, subtype));
+        span.setAttribute(NET_HOST_CONNECTION_TYPE, currentNetwork.getState().getHumanName());
+        currentNetwork.getSubType().ifPresent(subtype -> span.setAttribute(NET_HOST_CONNECTION_SUBTYPE, subtype));
     }
 
     @Override

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NetworkMonitorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NetworkMonitorTest.java
@@ -19,6 +19,8 @@ package com.splunk.rum;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,8 +57,8 @@ public class NetworkMonitorTest {
         assertEquals("network.change", spanData.getName());
         Attributes attributes = spanData.getAttributes();
         assertEquals("available", attributes.get(NetworkMonitor.NETWORK_STATUS_KEY));
-        assertEquals("wifi", attributes.get(RumAttributeAppender.NETWORK_TYPE_KEY));
-        assertNull(attributes.get(RumAttributeAppender.NETWORK_SUBTYPE_KEY));
+        assertEquals("wifi", attributes.get(NET_HOST_CONNECTION_TYPE));
+        assertNull(attributes.get(NET_HOST_CONNECTION_SUBTYPE));
     }
 
     @Test
@@ -71,8 +73,8 @@ public class NetworkMonitorTest {
         assertEquals("network.change", spanData.getName());
         Attributes attributes = spanData.getAttributes();
         assertEquals("available", attributes.get(NetworkMonitor.NETWORK_STATUS_KEY));
-        assertEquals("cell", attributes.get(RumAttributeAppender.NETWORK_TYPE_KEY));
-        assertEquals("LTE", attributes.get(RumAttributeAppender.NETWORK_SUBTYPE_KEY));
+        assertEquals("cell", attributes.get(NET_HOST_CONNECTION_TYPE));
+        assertEquals("LTE", attributes.get(NET_HOST_CONNECTION_SUBTYPE));
     }
 
     @Test
@@ -87,8 +89,8 @@ public class NetworkMonitorTest {
         assertEquals("network.change", spanData.getName());
         Attributes attributes = spanData.getAttributes();
         assertEquals("lost", attributes.get(NetworkMonitor.NETWORK_STATUS_KEY));
-        assertEquals("unavailable", attributes.get(RumAttributeAppender.NETWORK_TYPE_KEY));
-        assertNull(attributes.get(RumAttributeAppender.NETWORK_SUBTYPE_KEY));
+        assertEquals("unavailable", attributes.get(NET_HOST_CONNECTION_TYPE));
+        assertNull(attributes.get(NET_HOST_CONNECTION_SUBTYPE));
     }
 
     @Test

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumAttributeAppenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumAttributeAppenderTest.java
@@ -34,6 +34,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 public class RumAttributeAppenderTest {
 
@@ -110,8 +111,8 @@ public class RumAttributeAppenderTest {
         verify(span).setAttribute(ResourceAttributes.OS_TYPE, "linux");
         verify(span).setAttribute(ResourceAttributes.OS_NAME, "Android");
         verify(span).setAttribute(SplunkRum.SCREEN_NAME_KEY, "ScreenOne");
-        verify(span).setAttribute(RumAttributeAppender.NETWORK_TYPE_KEY, "cell");
-        verify(span).setAttribute(RumAttributeAppender.NETWORK_SUBTYPE_KEY, "LTE");
+        verify(span).setAttribute(SemanticAttributes.NET_HOST_CONNECTION_TYPE, "cell");
+        verify(span).setAttribute(SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE, "LTE");
 
         //these values don't seem to be available in unit tests, so just assert that something was set.
         verify(span).setAttribute(eq(ResourceAttributes.DEVICE_MODEL_IDENTIFIER), any());


### PR DESCRIPTION
This doesn't include the okhttp instrumentation update, but since everything is backwards compatible, that can wait.

Also fixed the regex in the sample app for attribute cleaning, and added a toString for the modified span data.