### PR TITLE
Add a try/catch around registering network callbacks.

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
@@ -48,6 +48,7 @@ class ConnectionUtil {
             registerNetworkCallbacks(createNetworkMonitoringRequest, connectivityManager);
         } catch (Exception e) {
             //if this fails, we'll go without network change events.
+            Log.w(SplunkRum.LOG_TAG, "Failed to register network callbacks. Automatic network monitoring is disabled.", e);
         }
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
@@ -44,6 +44,14 @@ class ConnectionUtil {
 
     void startMonitoring(Supplier<NetworkRequest> createNetworkMonitoringRequest, ConnectivityManager connectivityManager) {
         refreshNetworkStatus();
+        try {
+            registerNetworkCallbacks(createNetworkMonitoringRequest, connectivityManager);
+        } catch (Exception e) {
+            //if this fails, we'll go without network change events.
+        }
+    }
+
+    private void registerNetworkCallbacks(Supplier<NetworkRequest> createNetworkMonitoringRequest, ConnectivityManager connectivityManager) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             connectivityManager.registerDefaultNetworkCallback(new ConnectionMonitor());
         } else {


### PR DESCRIPTION
Looks like this is another thing that can fail with the same Android bug (https://issuetracker.google.com/issues/175055271 for reference)