### PR TITLE
Make the beaconEndpoint always overrule the realm setting.

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import android.util.Log;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -147,6 +149,7 @@ public class Config {
         private Attributes globalAttributes = Attributes.empty();
         private String deploymentEnvironment;
         private final SpanFilterBuilder spanFilterBuilder = new SpanFilterBuilder();
+        private String realm;
 
         /**
          * Create a new instance of {@link Config} from the options provided.
@@ -167,6 +170,10 @@ public class Config {
          * @return this
          */
         public Builder beaconEndpoint(String beaconEndpoint) {
+            if (realm != null) {
+                Log.w(SplunkRum.LOG_TAG, "Explicitly setting the beaconEndpoint will override the realm configuration.");
+                realm = null;
+            }
             this.beaconEndpoint = beaconEndpoint;
             return this;
         }
@@ -179,7 +186,12 @@ public class Config {
          * @return this
          */
         public Builder realm(String realm) {
+            if (beaconEndpoint != null && this.realm == null) {
+                Log.w(SplunkRum.LOG_TAG, "beaconEndpoint has already been set. Realm configuration will be ignored.");
+                return this;
+            }
             this.beaconEndpoint = "https://rum-ingest." + realm + ".signalfx.com/v1/rum";
+            this.realm = realm;
             return this;
         }
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ConfigTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ConfigTest.java
@@ -16,17 +16,17 @@
 
 package com.splunk.rum;
 
-import org.junit.Test;
-
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import org.junit.Test;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 
 public class ConfigTest {
 
@@ -103,5 +103,17 @@ public class ConfigTest {
         config.updateGlobalAttributes(ab -> ab.put("drink", "lemonade"));
         Attributes result = config.getGlobalAttributes();
         assertEquals(Attributes.of(stringKey("drink"), "lemonade", stringKey("food"), "candy"), result);
+    }
+
+    @Test
+    public void beaconOverridesRealm() {
+        Config config = Config.builder().applicationName("appName")
+                .rumAccessToken("authToken")
+                .realm("us1")
+                .beaconEndpoint("http://beacon")
+                .globalAttributes(null)
+                .realm("us0")
+                .build();
+        assertEquals("http://beacon", config.getBeaconEndpoint());
     }
 }


### PR DESCRIPTION
And, log warnings when both are being set.
Resolves #181