### PR TITLE
Apply GDI spec 1.2 to Android RUM

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumAttributeAppender.java
@@ -36,7 +36,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 class RumAttributeAppender implements SpanProcessor {
     static final AttributeKey<String> APP_NAME_KEY = stringKey("app");
     static final AttributeKey<String> SESSION_ID_KEY = stringKey("splunk.rumSessionId");
-    static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rumVersion");
+    static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rum.version");
 
     static final AttributeKey<String> SPLUNK_OPERATION_KEY = stringKey("_splunk_operation");
 


### PR DESCRIPTION
I'm not adding the badge yet because of the [`os.type`/`os.name`](https://github.com/signalfx/gdi-specification/pull/155) bug in the spec; but aside from that this repo implements the 1.2 spec.