### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,8 @@ The Splunk Android RUM Instrumentation is released under the terms of the Apache
 version 2.0. See
 [the license file](./LICENSE) for more details.
 
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
 
 [desugar]: https://developer.android.com/studio/write/java8-support#library-desugaring
 
 [javadoc-url]: https://www.javadoc.io/doc/com.splunk/splunk-otel-android/latest/com/splunk/rum/SplunkRum.html
-
->ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.

--- a/README.md
+++ b/README.md
@@ -261,3 +261,5 @@ version 2.0. See
 [desugar]: https://developer.android.com/studio/write/java8-support#library-desugaring
 
 [javadoc-url]: https://www.javadoc.io/doc/com.splunk/splunk-otel-android/latest/com/splunk/rum/SplunkRum.html
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.