### PR TITLE
Bump several dependencies' versions (and compile/target SDK version)

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -9,13 +9,13 @@ val localProperties = Properties()
 localProperties.load(FileInputStream(rootProject.file("local.properties")))
 
 android {
-    compileSdk = 30
+    compileSdk = 31
     buildToolsVersion = "30.0.3"
 
     defaultConfig {
         applicationId = "com.splunk.android.sample"
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         versionCode = 1
         versionName = "1.0"
 
@@ -53,13 +53,13 @@ dependencies {
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
-    implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.webkit:webkit:1.4.0")
-    implementation("androidx.browser:browser:1.3.0")
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("androidx.browser:browser:1.4.0")
+    implementation("com.google.android.material:material:1.5.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.3")
-    implementation("androidx.navigation:navigation-fragment:2.3.5")
-    implementation("androidx.navigation:navigation-ui:2.3.5")
+    implementation("androidx.navigation:navigation-fragment:2.4.0")
+    implementation("androidx.navigation:navigation-ui:2.4.0")
     implementation(project(":splunk-otel-android"))
 
     testImplementation("junit:junit:4.13.2")

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/Theme.SplunkRUMSampleApp.NoActionBar">
+            android:theme="@style/Theme.SplunkRUMSampleApp.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanFilter.java
@@ -80,14 +80,15 @@ final class SpanFilter implements SpanExporter {
         }
 
         AttributesBuilder modifiedAttributes = Attributes.builder();
-        span.getAttributes().forEach((key, oldValue) -> {
+        for (Map.Entry<AttributeKey<?>, Object> entry : span.getAttributes().asMap().entrySet()) {
+            AttributeKey<?> key = entry.getKey();
             Function<? super Object, ?> valueModifier =
                     (Function<? super Object, ?>) spanAttributeReplacements.getOrDefault(key, Function.identity());
-            Object newValue = valueModifier.apply(oldValue);
+            Object newValue = valueModifier.apply(entry.getValue());
             if (newValue != null) {
                 modifiedAttributes.put((AttributeKey<Object>) key, newValue);
             }
-        });
+        }
 
         return new ModifiedSpanData(span, modifiedAttributes.build());
     }


### PR DESCRIPTION
CC @jkwatson I think I might've accidentally fixed the `java.lang.AbstractMethodError: abstract method "void io.opentelemetry.api.common.Attributes.forEach(j$.util.function.BiConsumer)"` that you encountered; it looks like just not calling that `forEach` method is enough to make the sample app run without issues.