### PR TITLE
Volley rum customizations

### DIFF
--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment:2.3.5")
     compileOnly("com.android.volley:volley:1.2.1")
 
+    implementation(project(":splunk-otel-android"))
+
     api(platform("io.opentelemetry:opentelemetry-bom:1.10.1"))
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
@@ -62,6 +64,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.22.0")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
     testImplementation("org.robolectric:robolectric:4.7.3")
+    testImplementation("org.mockito:mockito-core:4.2.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("com.google.mockwebserver:mockwebserver:20130706")
     testImplementation("com.android.volley:volley:1.2.0")

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/ClientRequestHeaderSetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/ClientRequestHeaderSetter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import io.opentelemetry.context.propagation.TextMapSetter;
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/RequestWrapper.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/RequestWrapper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import com.android.volley.Request;
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/TracingHurlStack.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/TracingHurlStack.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.Request;

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesExtractor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import androidx.annotation.Nullable;
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesExtractor.java
@@ -32,12 +32,12 @@ final class VolleyNetClientAttributesExtractor extends NetClientAttributesExtrac
 
     @Override
     public String peerName(RequestWrapper requestWrapper, @Nullable HttpResponse httpResponse) {
-        return requestWrapper.getUrl().getHost();
+        return requestWrapper.getUrl() != null ? requestWrapper.getUrl().getHost() : null;
     }
 
     @Override
     public Integer peerPort(RequestWrapper requestWrapper, @Nullable HttpResponse httpResponse) {
-        return requestWrapper.getUrl().getPort();
+        return requestWrapper.getUrl() != null ? requestWrapper.getUrl().getPort() : null;
     }
 
     @Override

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesExtractor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import com.android.volley.toolbox.HttpResponse;
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
@@ -1,0 +1,79 @@
+package com.splunk.rum;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import androidx.annotation.Nullable;
+
+import com.android.volley.Header;
+import com.android.volley.toolbox.HttpResponse;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+class VolleyResponseAttributesExtractor implements AttributesExtractor<RequestWrapper, HttpResponse> {
+    static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
+    static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
+
+    private final ServerTimingHeaderParser serverTimingHeaderParser;
+
+    public VolleyResponseAttributesExtractor(ServerTimingHeaderParser serverTimingHeaderParser) {
+        this.serverTimingHeaderParser = serverTimingHeaderParser;
+    }
+
+    @Override
+    public void onStart(AttributesBuilder attributes, RequestWrapper requestWrapper) {
+        attributes.put(SplunkRum.COMPONENT_KEY, "http");
+    }
+
+    @Override
+    public void onEnd(AttributesBuilder attributes, RequestWrapper requestWrapper, @Nullable HttpResponse response, @Nullable Throwable error) {
+        if (response != null) {
+            onResponse(attributes, response);
+        }
+        if (error != null) {
+            onError(attributes, error);
+        }
+    }
+
+
+    private void onResponse(AttributesBuilder attributes, HttpResponse response) {
+        recordContentLength(attributes, response);
+        String serverTimingHeader = getHeader(response, "Server-Timing");
+
+        String[] ids = serverTimingHeaderParser.parse(serverTimingHeader);
+        if (ids.length == 2) {
+            attributes.put(LINK_TRACE_ID_KEY, ids[0]);
+            attributes.put(LINK_SPAN_ID_KEY, ids[1]);
+        }
+    }
+
+    private void recordContentLength(AttributesBuilder attributesBuilder, HttpResponse response) {
+        //make a best low-impact effort at getting the content length on the response.
+        String contentLengthHeader = getHeader(response, "Content-Length");
+        if (contentLengthHeader != null) {
+            try {
+                long contentLength = Long.parseLong(contentLengthHeader);
+                if (contentLength > 0) {
+                    attributesBuilder.put(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, contentLength);
+                }
+            } catch (NumberFormatException e) {
+                //who knows what we got back? It wasn't a number!
+            }
+        }
+    }
+
+    private void onError(AttributesBuilder attributes, Throwable error) {
+        SplunkRum.addExceptionAttributes((key, value) -> attributes.put((AttributeKey<? super Object>) key, value), error);
+    }
+
+    private String getHeader(HttpResponse response, String headerName){
+        for(Header header : response.getHeaders()){
+            if(header.getName().equals(headerName)){
+                return header.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
@@ -1,6 +1,7 @@
 package com.splunk.rum;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static com.splunk.rum.SplunkRum.LINK_SPAN_ID_KEY;
+import static com.splunk.rum.SplunkRum.LINK_TRACE_ID_KEY;
 
 import androidx.annotation.Nullable;
 
@@ -10,11 +11,8 @@ import com.android.volley.toolbox.HttpResponse;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 class VolleyResponseAttributesExtractor implements AttributesExtractor<RequestWrapper, HttpResponse> {
-    static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
-    static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
 
     private final ServerTimingHeaderParser serverTimingHeaderParser;
 
@@ -39,28 +37,12 @@ class VolleyResponseAttributesExtractor implements AttributesExtractor<RequestWr
 
 
     private void onResponse(AttributesBuilder attributes, HttpResponse response) {
-        recordContentLength(attributes, response);
         String serverTimingHeader = getHeader(response, "Server-Timing");
 
         String[] ids = serverTimingHeaderParser.parse(serverTimingHeader);
         if (ids.length == 2) {
             attributes.put(LINK_TRACE_ID_KEY, ids[0]);
             attributes.put(LINK_SPAN_ID_KEY, ids[1]);
-        }
-    }
-
-    private void recordContentLength(AttributesBuilder attributesBuilder, HttpResponse response) {
-        //make a best low-impact effort at getting the content length on the response.
-        String contentLengthHeader = getHeader(response, "Content-Length");
-        if (contentLengthHeader != null) {
-            try {
-                long contentLength = Long.parseLong(contentLengthHeader);
-                if (contentLength > 0) {
-                    attributesBuilder.put(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, contentLength);
-                }
-            } catch (NumberFormatException e) {
-                //who knows what we got back? It wasn't a number!
-            }
         }
     }
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracing.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracing.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import com.android.volley.toolbox.HttpResponse;
 import com.android.volley.toolbox.HurlStack;

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.volley;
+package com.splunk.rum;
 
 import com.android.volley.toolbox.HttpResponse;
 
@@ -88,6 +88,7 @@ public final class VolleyTracingBuilder {
                         .setSpanStatusExtractor(spanStatusExtractor)
                         .addAttributesExtractor(httpAttributesExtractor)
                         .addAttributesExtractor(netAttributesExtractor)
+                        .addAttributesExtractor(new VolleyResponseAttributesExtractor(new ServerTimingHeaderParser()))
                         .addAttributesExtractors(additionalExtractors)
                         .newClientInstrumenter(ClientRequestHeaderSetter.INSTANCE);
 

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TestRequestQueue.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TestRequestQueue.java
@@ -1,2 +1,48 @@
-package com.splunk.rum;public class TestRequestQueue {
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import com.android.volley.Cache;
+import com.android.volley.Network;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.BasicNetwork;
+import com.android.volley.toolbox.HurlStack;
+import com.android.volley.toolbox.NoCache;
+
+class TestRequestQueue {
+
+    private final RequestQueue queue;
+
+    public static TestRequestQueue create(HurlStack hurlStack) {
+        return new TestRequestQueue(hurlStack);
+    }
+
+    private TestRequestQueue(HurlStack hurlStack) {
+
+        Cache cache = new NoCache();
+        Network network = new BasicNetwork(hurlStack);
+
+        queue = new RequestQueue(cache, network);
+        queue.start();
+    }
+
+    public <T> void addToQueue(Request<T> req) {
+        queue.add(req);
+    }
 }
+

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TestRequestQueue.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TestRequestQueue.java
@@ -1,0 +1,2 @@
+package com.splunk.rum;public class TestRequestQueue {
+}

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
@@ -83,7 +83,6 @@ public class TracingHurlStackExceptionTest {
 
         assertThat(spanAttributes.get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo("RuntimeException");
         assertThat(spanAttributes.get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("Something went wrong");
-
     }
 
     static class FailingURLRewriter implements HurlStack.UrlRewriter {

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
@@ -34,8 +34,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.util.Scheduler;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +44,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 @RunWith(RobolectricTestRunner.class)
 @LooperMode(LooperMode.Mode.LEGACY)
-public class ExceptionTest {
+public class TracingHurlStackExceptionTest {
 
     @Rule
     public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackExceptionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static android.os.Looper.getMainLooper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.robolectric.Shadows.shadowOf;
+
+import com.android.volley.Request;
+import com.android.volley.toolbox.HurlStack;
+import com.android.volley.toolbox.RequestFuture;
+import com.android.volley.toolbox.StringRequest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.LooperMode;
+import org.robolectric.util.Scheduler;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+@RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
+public class ExceptionTest {
+
+    @Rule
+    public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+
+    private TestRequestQueue testQueue;
+
+    @Before
+    public void setup() {
+        //setup Volley with TracingHurlStack
+        HurlStack tracingHurlStack = VolleyTracing.create(otelTesting.getOpenTelemetry()).newHurlStack(new FailingURLRewriter());
+        testQueue = TestRequestQueue.create(tracingHurlStack);
+    }
+
+    @Test
+    public void spanDecoration_error() {
+
+        RequestFuture<String> response = RequestFuture.newFuture();
+        StringRequest stringRequest = new StringRequest(Request.Method.GET, "whatever",
+                response, response);
+
+        testQueue.addToQueue(stringRequest);
+
+        Scheduler scheduler = shadowOf(getMainLooper()).getScheduler();
+        while (!scheduler.advanceToLastPostedRunnable());
+
+        assertThatThrownBy(() -> response.get(3, TimeUnit.SECONDS)).hasRootCauseInstanceOf(RuntimeException.class);
+
+        List<SpanData> spans = otelTesting.getSpans();
+        assertThat(spans).hasSize(1);
+
+        SpanData span = spans.get(0);
+
+        Attributes spanAttributes = span.getAttributes();
+        assertThat(spanAttributes.get(SplunkRum.ERROR_TYPE_KEY)).isEqualTo("RuntimeException");
+        assertThat(spanAttributes.get(SplunkRum.ERROR_MESSAGE_KEY)).isEqualTo("Something went wrong");
+
+        assertThat(spanAttributes.get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo("RuntimeException");
+        assertThat(spanAttributes.get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("Something went wrong");
+
+    }
+
+    static class FailingURLRewriter implements HurlStack.UrlRewriter {
+
+        @Override
+        public String rewriteUrl(String originalUrl) {
+            throw new RuntimeException("Something went wrong");
+        }
+    }
+
+}

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
@@ -172,10 +172,6 @@ public class TracingHurlStackTest {
 
         verifyAttributes(span, url, null);
 
-        Attributes spanAttributes = span.getAttributes();
-        assertThat(spanAttributes.get(SplunkRum.ERROR_TYPE_KEY)).isEqualTo("SocketTimeoutException");
-        assertThat(spanAttributes.get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo("SocketTimeoutException");
-
     }
 
     @Test

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
@@ -181,8 +181,8 @@ public class TracingHurlStackTest {
     @Test
     public void reusedRequest() throws IOException {
 
-        String firstResponseBody = "success1";
-        String secondResponseBody = "success2";
+        String firstResponseBody = "first response";
+        String secondResponseBody = "second response";
 
         server.enqueue(new MockResponse().setBody(firstResponseBody));
         server.enqueue(new MockResponse().setBody(secondResponseBody));

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
@@ -44,9 +44,8 @@ public class VolleyResponseAttributesExtractorTest {
         ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
         when(headerParser.parse("headerValue")).thenReturn(new String[]{"9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86"});
 
-        List<Header> responseHeaders = Arrays.asList(
-                new Header("Server-Timing", "headerValue"),
-                new Header("Content-Length", "101")
+        List<Header> responseHeaders = Collections.singletonList(
+                new Header("Server-Timing", "headerValue")
         );
         RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
@@ -58,9 +57,8 @@ public class VolleyResponseAttributesExtractorTest {
         Attributes attributes = attributesBuilder.build();
 
         assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
-        assertEquals("9499195c502eb217c448a68bfe0f967c", attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
-        assertEquals("fe16eca542cd5d86", attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
-        assertEquals(101L, (long) attributes.get(HTTP_RESPONSE_CONTENT_LENGTH));
+        assertEquals("9499195c502eb217c448a68bfe0f967c", attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
+        assertEquals("fe16eca542cd5d86", attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
     }
 
     @Test
@@ -79,29 +77,8 @@ public class VolleyResponseAttributesExtractorTest {
         Attributes attributes = attributesBuilder.build();
 
         assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
-        assertNull(attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
-        assertNull(attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
-    }
-
-    @Test
-    public void spanDecoration_contentLength() {
-        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
-        when(headerParser.parse(null)).thenReturn(new String[0]);
-
-        List<Header> responseHeaders = Collections.singletonList(
-                new Header("Content-Length", "101")
-        );
-        RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
-        HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
-
-        VolleyResponseAttributesExtractor attributesExtractor = new VolleyResponseAttributesExtractor(headerParser);
-        AttributesBuilder attributesBuilder = Attributes.builder();
-        attributesExtractor.onEnd(attributesBuilder, fakeRequest, response, null);
-        attributesExtractor.onStart(attributesBuilder, fakeRequest);
-        Attributes attributes = attributesBuilder.build();
-
-        assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
-        assertEquals(101L, (long) attributes.get(HTTP_RESPONSE_CONTENT_LENGTH));
+        assertNull(attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
+        assertNull(attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
     }
 
     @Test

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
@@ -126,6 +126,4 @@ public class VolleyResponseAttributesExtractorTest {
         assertEquals("failed to make a call", attributes.get(SplunkRum.ERROR_MESSAGE_KEY));
     }
 
-    //TODO: test like OkHttpClientInterceptor, where TracingHurlStack is registered and some internal volley behaviour is mocked
-    // to throw an exception
 }

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyResponseAttributesExtractorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH;
+
+import com.android.volley.Header;
+import com.android.volley.Request;
+import com.android.volley.toolbox.HttpResponse;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+public class VolleyResponseAttributesExtractorTest {
+
+    @Test
+    public void spanDecoration() {
+        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
+        when(headerParser.parse("headerValue")).thenReturn(new String[]{"9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86"});
+
+        List<Header> responseHeaders = Arrays.asList(
+                new Header("Server-Timing", "headerValue"),
+                new Header("Content-Length", "101")
+        );
+        RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
+        HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
+
+        VolleyResponseAttributesExtractor attributesExtractor = new VolleyResponseAttributesExtractor(headerParser);
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        attributesExtractor.onStart(attributesBuilder, fakeRequest);
+        attributesExtractor.onEnd(attributesBuilder, fakeRequest, response, null);
+        Attributes attributes = attributesBuilder.build();
+
+        assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
+        assertEquals("9499195c502eb217c448a68bfe0f967c", attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
+        assertEquals("fe16eca542cd5d86", attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
+        assertEquals(101L, (long) attributes.get(HTTP_RESPONSE_CONTENT_LENGTH));
+    }
+
+    @Test
+    public void spanDecoration_noLinkingHeader() {
+        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
+        when(headerParser.parse(null)).thenReturn(new String[0]);
+
+        RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
+        HttpResponse response = new HttpResponse(200, Collections.emptyList(), "hello".getBytes());
+
+
+        VolleyResponseAttributesExtractor attributesExtractor = new VolleyResponseAttributesExtractor(headerParser);
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        attributesExtractor.onEnd(attributesBuilder, fakeRequest, response, null);
+        attributesExtractor.onStart(attributesBuilder, fakeRequest);
+        Attributes attributes = attributesBuilder.build();
+
+        assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
+        assertNull(attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
+        assertNull(attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
+    }
+
+    @Test
+    public void spanDecoration_contentLength() {
+        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
+        when(headerParser.parse(null)).thenReturn(new String[0]);
+
+        List<Header> responseHeaders = Collections.singletonList(
+                new Header("Content-Length", "101")
+        );
+        RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
+        HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
+
+        VolleyResponseAttributesExtractor attributesExtractor = new VolleyResponseAttributesExtractor(headerParser);
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        attributesExtractor.onEnd(attributesBuilder, fakeRequest, response, null);
+        attributesExtractor.onStart(attributesBuilder, fakeRequest);
+        Attributes attributes = attributesBuilder.build();
+
+        assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
+        assertEquals(101L, (long) attributes.get(HTTP_RESPONSE_CONTENT_LENGTH));
+    }
+
+    @Test
+    public void shouldAddExceptionAttributes() {
+        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
+        VolleyResponseAttributesExtractor attributesExtractor = new VolleyResponseAttributesExtractor(headerParser);
+
+        RequestWrapper fakeRequest = new RequestWrapper(mock(Request.class), Collections.emptyMap());
+        Exception error = new IOException("failed to make a call");
+
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        attributesExtractor.onEnd(attributesBuilder, fakeRequest, null, error);
+        attributesExtractor.onStart(attributesBuilder, fakeRequest);
+        Attributes attributes = attributesBuilder.build();
+
+        assertEquals(5, attributes.size());
+        assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
+        assertEquals("IOException", attributes.get(SemanticAttributes.EXCEPTION_TYPE));
+        assertEquals("failed to make a call", attributes.get(SemanticAttributes.EXCEPTION_MESSAGE));
+        //temporary attributes until the RUM UI/backend can be brought up to date with otel conventions.
+        assertEquals("IOException", attributes.get(SplunkRum.ERROR_TYPE_KEY));
+        assertEquals("failed to make a call", attributes.get(SplunkRum.ERROR_MESSAGE_KEY));
+    }
+
+    //TODO: test like OkHttpClientInterceptor, where TracingHurlStack is registered and some internal volley behaviour is mocked
+    // to throw an exception
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/OkHttpRumInterceptor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/OkHttpRumInterceptor.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import okhttp3.Call;
 import okhttp3.Connection;
@@ -29,16 +28,12 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
 /**
  * This currently allows handling exceptions during the request and recording exception attributes to the
  * RUM http span. Hopefully the otel instrumentation will support this use-case soon and we won't
  * need to do these hijinks to capture this information.
  */
 class OkHttpRumInterceptor implements Interceptor {
-    static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
-    static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
 
     private final Interceptor coreInterceptor;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumResponseAttributesExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumResponseAttributesExtractor.java
@@ -16,7 +16,8 @@
 
 package com.splunk.rum;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static com.splunk.rum.SplunkRum.LINK_SPAN_ID_KEY;
+import static com.splunk.rum.SplunkRum.LINK_TRACE_ID_KEY;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -26,8 +27,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 class RumResponseAttributesExtractor implements AttributesExtractor<Request, Response> {
-    static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
-    static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
 
     private final ServerTimingHeaderParser serverTimingHeaderParser;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -72,6 +72,9 @@ public class SplunkRum {
     static final String LOG_TAG = "SplunkRum";
     static final String RUM_TRACER_NAME = "SplunkRum";
 
+    static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
+    static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
+
     private static SplunkRum INSTANCE;
 
     private final SessionId sessionId;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
@@ -57,8 +57,8 @@ public class RumResponseAttributesExtractorTest {
         Attributes attributes = attributesBuilder.build();
 
         assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
-        assertEquals("9499195c502eb217c448a68bfe0f967c", attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
-        assertEquals("fe16eca542cd5d86", attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
+        assertEquals("9499195c502eb217c448a68bfe0f967c", attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
+        assertEquals("fe16eca542cd5d86", attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
         assertEquals(101L, (long) attributes.get(HTTP_RESPONSE_CONTENT_LENGTH));
     }
 
@@ -82,8 +82,8 @@ public class RumResponseAttributesExtractorTest {
         Attributes attributes = attributesBuilder.build();
 
         assertEquals("http", attributes.get(SplunkRum.COMPONENT_KEY));
-        assertNull(attributes.get(OkHttpRumInterceptor.LINK_TRACE_ID_KEY));
-        assertNull(attributes.get(OkHttpRumInterceptor.LINK_SPAN_ID_KEY));
+        assertNull(attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
+        assertNull(attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
     }
 
     @Test


### PR DESCRIPTION
Similar to `RumResponseAttributesExtractor`.
Also moved Volley instrumentation from `com.splunk.rum.volley` to `com.splunk.rum` to have access to `SplunkRum` constants and `ServerTimingHeaderParser`.