### PR TITLE
Set timeout in volley tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,10 @@ name: PR build
 on:
   pull_request:
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.net.URI
+import java.time.Duration
 
 plugins {
     id("com.android.library")
@@ -72,6 +73,10 @@ dependencies {
 val sourcesJar by tasks.registering(Jar::class) {
     from(android.sourceSets.named("main").get().java.srcDirs)
     archiveClassifier.set("sources")
+}
+
+tasks.withType<Test>().configureEach {
+    timeout.set(Duration.ofMinutes(15))
 }
 
 publishing {


### PR DESCRIPTION
... and set up concurrency groups for GHA builds.

These volley tests seem to be indeterministically failing (timing out) on the CI; test timeout should help with debugging that.