### PR TITLE
Slow rendering detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ when initializing your instance of the SplunkRum API:
   This can be used to provide customizations of the spans that are emitted by the library. Examples
   include: removing spans altogether from export, removing span attributes, changing span attributes
   or changing the span name. See the javadoc on the `SpanFilterBuilder` class for more details.
-- `renderDurationPollingIntervalMs(int)` :
-  Set/change the default polling interval for slow/frozen render detection, in milliseconds.
+- `slowRenderPollingDuration(Duration)` :
+  Set/change the default polling interval for slow/frozen render detection.
   Default is 1000ms. Value must be positive. 
 - `disableSlowRenderingDetection()` :
   Disable the detection of slow frame renders (default is enabled). 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ when initializing your instance of the SplunkRum API:
   or changing the span name. See the javadoc on the `SpanFilterBuilder` class for more details.
 - `renderDurationPollingIntervalMs(int)` :
   Set/change the default polling interval for slow/frozen render detection, in milliseconds.
-  Default is 1000ms. Passing zero will disable the slow render detection. 
+  Default is 1000ms. Value must be positive. 
+- `disableSlowRenderingDetection()` :
+  Disable the detection of slow frame renders (default is enabled). 
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ when initializing your instance of the SplunkRum API:
   This can be used to provide customizations of the spans that are emitted by the library. Examples
   include: removing spans altogether from export, removing span attributes, changing span attributes
   or changing the span name. See the javadoc on the `SpanFilterBuilder` class for more details.
+- `renderDurationPollingIntervalMs(int)` :
+  Set/change the default polling interval for slow/frozen render detection, in milliseconds.
+  Default is 1000ms. Passing zero will disable the slow render detection. 
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/sample-app/src/main/java/com/splunk/android/sample/DemoAnimatedView.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/DemoAnimatedView.java
@@ -1,0 +1,137 @@
+package com.splunk.android.sample;
+
+import android.animation.TimeAnimator;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class DemoAnimatedView extends androidx.appcompat.widget.AppCompatImageView {
+
+    private final AtomicBoolean firstDraw = new AtomicBoolean(false);
+    private final Paint paint = new Paint();
+    private Bitmap bitmap;
+    private Canvas canvas;
+    private TimeAnimator timeAnimator;
+    private long lastAnimationTime = 0;
+    private final List<Signal> signals = buildSignals();
+    private final AtomicBoolean slowly = new AtomicBoolean(false);
+
+    public DemoAnimatedView(Context context) {
+        super(context);
+    }
+
+    public DemoAnimatedView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        if(firstDraw.compareAndSet(false, true)){
+            init();
+        }
+        if(slowly.get()){
+            SecureRandom rand = new SecureRandom();
+            for(int i=0; i < 50000; i++){
+                rand.nextFloat();
+            }
+        }
+        canvas.drawBitmap(bitmap, 0, 0, paint);
+    }
+
+    public void init() {
+        if(getWidth() == 0){
+            return;
+        }
+        bitmap = Bitmap.createBitmap(getWidth(), getHeight(), Bitmap.Config.ARGB_8888);
+        canvas = new Canvas(bitmap);
+        paint.setColor(Color.BLACK);
+        canvas.drawRect(0, 0, getWidth(), getHeight(), paint);
+        timeAnimator = new TimeAnimator();
+        timeAnimator.setTimeListener((animation, totalTime, deltaTime) -> {
+            if(totalTime - lastAnimationTime > 25){
+                drawBitmap(totalTime);
+                lastAnimationTime = totalTime;
+            }
+        });
+        timeAnimator.start();
+    }
+
+    private void drawBitmap(long time) {
+        for(int i=0; i < 5; i++){
+            Canvas tmpCanvas = new Canvas(bitmap);
+            Rect src = new Rect(1, 0, getWidth(), getHeight());
+            Rect dst = new Rect(0, 0, getWidth()-1, getHeight());
+            tmpCanvas.drawBitmap(bitmap, src, dst, paint);
+            paint.setColor(Color.BLACK);
+            tmpCanvas.drawLine(getWidth()-1, 0, getWidth()-1, getHeight(), paint);
+
+            signals.stream().forEach(signal -> {
+                paint.setColor(signal.color);
+                int ypos = (int)(Math.sin(0.001 * signal.rate * time + signal.phase)*getHeight()/2 + (getHeight()/2));
+                tmpCanvas.drawCircle(getWidth()-1, ypos, 5, paint);
+            });
+            canvas.drawBitmap(bitmap, 0, 0, paint);
+        }
+        setImageBitmap(bitmap);
+    }
+
+    private static List<Signal> buildSignals() {
+        Random rand = new Random();
+        return Arrays.asList(
+            new Signal(randomColor(), 1.5f+rand.nextFloat()*3, rand.nextFloat() - 0.5f),
+            new Signal(randomColor(), 1.5f-rand.nextFloat()*3, rand.nextFloat() - 0.5f),
+            new Signal(randomColor(), 1.5f-rand.nextFloat()*3, rand.nextFloat() - 0.5f),
+            new Signal(randomColor(), 1.5f-rand.nextFloat()*3, rand.nextFloat() - 0.5f),
+            new Signal(randomColor(), 1.5f-rand.nextFloat()*3, rand.nextFloat() - 0.5f)
+        );
+    }
+
+    private static int randomColor(){
+        Random rand = new Random();
+        return Color.rgb(rand.nextInt(255), rand.nextInt(255), rand.nextInt(255));
+    }
+
+    public boolean toggleSlowly(){
+        synchronized(slowly){
+            boolean newValue = !slowly.get();
+            if(newValue){
+                Log.i("demo", "Starting to render more slowly...");
+            }
+            else {
+                Log.i("demo", "Back to more normal rendering speed");
+            }
+
+            slowly.set(newValue);
+            return newValue;
+        }
+    }
+
+    static class Signal {
+
+        final int color;
+        final float rate;
+        final float phase;
+
+        Signal(int color, float rate, float phase) {
+            this.color = color;
+            this.rate = rate;
+            this.phase = phase;
+        }
+
+    }
+}

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -24,6 +24,7 @@ import com.splunk.rum.Config;
 import com.splunk.rum.SplunkRum;
 import com.splunk.rum.StandardAttributes;
 
+import java.time.Duration;
 import java.util.regex.Pattern;
 
 import io.opentelemetry.api.common.Attributes;
@@ -39,6 +40,7 @@ public class SampleApplication extends Application {
                 // note: for these values to be resolved, put them in your local.properties file as
                 // rum.beacon.url and rum.access.token
                 .realm(getResources().getString(R.string.rum_realm))
+                .slowRenderPollingDuration(Duration.ofMillis(1000))
                 .rumAccessToken(getResources().getString(R.string.rum_access_token))
                 .applicationName("Android Demo App")
                 .debugEnabled(true)

--- a/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
@@ -132,6 +132,15 @@ public class SecondFragment extends Fragment {
                 appFreezer.end();
             }
         });
+        binding.drawSlowly.setOnClickListener(v -> {
+            boolean slowlyNow = binding.animatedView.toggleSlowly();
+            if(slowlyNow){
+                binding.drawSlowly.setText("Draw Normally");
+            }
+            else {
+                binding.drawSlowly.setText("Draw Slowly");
+            }
+        });
         binding.buttonWork.setOnClickListener(v -> {
             Span hardWorker =
                     SplunkRum.getInstance().startWorkflow("main thread working hard");

--- a/sample-app/src/main/res/layout/fragment_second.xml
+++ b/sample-app/src/main/res/layout/fragment_second.xml
@@ -15,14 +15,26 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+
         <TextView
             android:id="@+id/textview_second"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="second fragment"
+            app:layout_constraintBottom_toTopOf="@id/animatedView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.splunk.android.sample.DemoAnimatedView
+            android:id="@+id/animatedView"
+            android:layout_width="0dp"
+            android:layout_height="100dp"
             app:layout_constraintBottom_toTopOf="@id/button_box"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+        />
 
         <LinearLayout
             android:id="@+id/button_box"
@@ -63,19 +75,40 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/previous" />
 
-            <Button
-                android:id="@+id/button_freeze"
+            <LinearLayout
+                android:id="@+id/freezy_box"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/freeze" />
+                android:orientation="horizontal"
+
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/textview_second">
+
+                <Button
+                        android:id="@+id/button_freeze"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/freeze" />
+
+                <Button
+                    android:id="@+id/button_work"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/work_it" />
+
+            </LinearLayout>
 
             <Button
-                android:id="@+id/button_work"
+                android:id="@+id/draw_slowly"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="@string/work_it" />
+                android:text="Draw Slowly" />
 
             <Button
                 android:id="@+id/button_spam"

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -40,6 +40,7 @@ android {
 
 dependencies {
     implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("androidx.core:core:1.3.1")
     implementation("androidx.navigation:navigation-fragment:2.4.1")
 
     api(platform("io.opentelemetry:opentelemetry-bom:1.11.0"))

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
@@ -40,14 +40,16 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     private final VisibleScreenTracker visibleScreenTracker;
     private final AppStartupTimer startupTimer;
     private final List<AppStateListener> appStateListeners;
+    private SlowRenderingDetector slowRenderingDetector;
     //we count the number of activities that have been "started" and not yet "stopped" here to figure out when the app goes into the background.
     private int numberOfOpenActivities = 0;
 
-    ActivityCallbacks(Tracer tracer, VisibleScreenTracker visibleScreenTracker, AppStartupTimer startupTimer, List<AppStateListener> appStateListeners) {
+    ActivityCallbacks(Tracer tracer, VisibleScreenTracker visibleScreenTracker, AppStartupTimer startupTimer, List<AppStateListener> appStateListeners, SlowRenderingDetector slowRenderingDetector) {
         this.tracer = tracer;
         this.visibleScreenTracker = visibleScreenTracker;
         this.startupTimer = startupTimer;
         this.appStateListeners = appStateListeners;
+        this.slowRenderingDetector = slowRenderingDetector;
     }
 
     @Override
@@ -77,6 +79,7 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
         getTracer(activity)
                 .initiateRestartSpanIfNecessary(tracersByActivityClassName.size() > 1)
                 .addEvent("activityPreStarted");
+        slowRenderingDetector.add(activity);
     }
 
     @Override
@@ -149,6 +152,7 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
             }
         }
         addEvent(activity, "activityStopped");
+        slowRenderingDetector.stop(activity);
     }
 
     @Override

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
@@ -40,7 +40,7 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     private final VisibleScreenTracker visibleScreenTracker;
     private final AppStartupTimer startupTimer;
     private final List<AppStateListener> appStateListeners;
-    private SlowRenderingDetector slowRenderingDetector;
+    private final SlowRenderingDetector slowRenderingDetector;
     //we count the number of activities that have been "started" and not yet "stopped" here to figure out when the app goes into the background.
     private int numberOfOpenActivities = 0;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
@@ -83,7 +83,6 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
         getTracer(activity)
                 .initiateRestartSpanIfNecessary(tracersByActivityClassName.size() > 1)
                 .addEvent("activityPreStarted");
-        slowRenderingDetector.add(activity);
     }
 
     @Override
@@ -112,6 +111,7 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     @Override
     public void onActivityResumed(@NonNull Activity activity) {
         addEvent(activity, "activityResumed");
+        slowRenderingDetector.add(activity);
     }
 
     @Override
@@ -134,6 +134,7 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     @Override
     public void onActivityPaused(@NonNull Activity activity) {
         addEvent(activity, "activityPaused");
+        slowRenderingDetector.stop(activity);
     }
 
     @Override
@@ -156,7 +157,6 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
             }
         }
         addEvent(activity, "activityStopped");
-        slowRenderingDetector.stop(activity);
     }
 
     @Override

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
@@ -44,12 +44,16 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     //we count the number of activities that have been "started" and not yet "stopped" here to figure out when the app goes into the background.
     private int numberOfOpenActivities = 0;
 
-    ActivityCallbacks(Tracer tracer, VisibleScreenTracker visibleScreenTracker, AppStartupTimer startupTimer, List<AppStateListener> appStateListeners, SlowRenderingDetector slowRenderingDetector) {
-        this.tracer = tracer;
-        this.visibleScreenTracker = visibleScreenTracker;
-        this.startupTimer = startupTimer;
-        this.appStateListeners = appStateListeners;
-        this.slowRenderingDetector = slowRenderingDetector;
+    private ActivityCallbacks(Builder builder) {
+        this.tracer = builder.tracer;
+        this.visibleScreenTracker = builder.visibleScreenTracker;
+        this.startupTimer = builder.startupTimer;
+        this.appStateListeners = builder.appStateListeners;
+        this.slowRenderingDetector = builder.slowRenderingDetector;
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -203,6 +207,43 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
             tracersByActivityClassName.put(activity.getClass().getName(), activityTracer);
         }
         return activityTracer;
+    }
+
+    static class Builder {
+        private Tracer tracer;
+        private VisibleScreenTracker visibleScreenTracker;
+        private AppStartupTimer startupTimer;
+        private List<AppStateListener> appStateListeners;
+        private SlowRenderingDetector slowRenderingDetector;
+
+        public ActivityCallbacks build(){
+            return new ActivityCallbacks(this);
+        }
+
+        public Builder tracer(Tracer tracer) {
+            this.tracer = tracer;
+            return this;
+        }
+
+        public Builder visibleScreenTracker(VisibleScreenTracker visibleScreenTracker) {
+            this.visibleScreenTracker = visibleScreenTracker;
+            return this;
+        }
+
+        public Builder startupTimer(AppStartupTimer startupTimer) {
+            this.startupTimer = startupTimer;
+            return this;
+        }
+
+        public Builder appStateListeners(List<AppStateListener> appStateListeners) {
+            this.appStateListeners = appStateListeners;
+            return this;
+        }
+
+        public Builder slowRenderingDetector(SlowRenderingDetector slowRenderingDetector) {
+            this.slowRenderingDetector = slowRenderingDetector;
+            return this;
+        }
     }
 
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -300,7 +300,7 @@ public class Config {
 
         /**
          * Configures the rate at which frame render durations are polled.
-         * @param interval - The period that should be used for polling (in ms)
+         * @param interval - The period that should be used for polling
          * @return this
          */
         public Builder slowRenderPollingDuration(Duration interval){

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -299,8 +299,7 @@ public class Config {
         }
 
         /**
-         * Configures the rate at which frame render durations are polled. Pass zero to
-         * disable polling for slow/frozen renders.
+         * Configures the rate at which frame render durations are polled.
          * @param interval - The period that should be used for polling (in ms)
          * @return this
          */

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -18,6 +18,7 @@ package com.splunk.rum;
 
 import android.util.Log;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -36,7 +37,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 public class Config {
 
     public static final boolean DEFAULT_ENABLE_SLOW_RENDERING_DETECTION = true;
-    public static final int DEFAULT_SLOW_RENDER_POLLING_INTERVAL_MS = 1000;
+    public static final Duration DEFAULT_SLOW_RENDER_POLLING_INTERVAL = Duration.ofSeconds(1);
     private final String beaconEndpoint;
     private final String rumAccessToken;
     private final boolean debugEnabled;
@@ -47,7 +48,7 @@ public class Config {
     private final AtomicReference<Attributes> globalAttributes = new AtomicReference<>();
     private final Function<SpanExporter, SpanExporter> spanFilterExporterDecorator;
     private final boolean slowRenderingDetectionEnabled;
-    private final int renderDurationPollingIntervalMs;
+    private final Duration slowRenderPollingDuration;
 
     private Config(Builder builder) {
         this.beaconEndpoint = builder.beaconEndpoint;
@@ -58,7 +59,7 @@ public class Config {
         this.globalAttributes.set(addDeploymentEnvironment(builder));
         this.networkMonitorEnabled = builder.networkMonitorEnabled;
         this.anrDetectionEnabled = builder.anrDetectionEnabled;
-        this.renderDurationPollingIntervalMs = builder.renderDurationPollingIntervalMs;
+        this.slowRenderPollingDuration = builder.slowRenderPollingDuration;
         this.slowRenderingDetectionEnabled = builder.slowRenderingDetectionEnabled;
         this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
     }
@@ -147,12 +148,11 @@ public class Config {
 
     /**
      * Returns the number of ms to be used for polling frame render durations,
-     * used in slow render and freeze draw detection. Zero indicates that no
-     * polling will be performed.
-     * @return - Number milliseconds to poll
+     * used in slow render and freeze draw detection.
+     * @return - Duration of the polling interval
      */
-    public int getRenderDurationPollingIntervalMs() {
-        return renderDurationPollingIntervalMs;
+    public Duration getSlowRenderPollingDuration() {
+        return slowRenderPollingDuration;
     }
 
     void updateGlobalAttributes(Consumer<AttributesBuilder> updater) {
@@ -189,7 +189,7 @@ public class Config {
         private String deploymentEnvironment;
         private final SpanFilterBuilder spanFilterBuilder = new SpanFilterBuilder();
         private String realm;
-        private int renderDurationPollingIntervalMs = DEFAULT_SLOW_RENDER_POLLING_INTERVAL_MS;
+        private Duration slowRenderPollingDuration = DEFAULT_SLOW_RENDER_POLLING_INTERVAL;
 
         /**
          * Create a new instance of {@link Config} from the options provided.
@@ -304,12 +304,12 @@ public class Config {
          * @param interval - The period that should be used for polling (in ms)
          * @return this
          */
-        public Builder renderDurationPollingIntervalMs(int interval){
-            if(interval <= 0){
-                Log.e(SplunkRum.LOG_TAG, "invalid renderDurationPollingIntervalMs: " + interval + " is not positive");
+        public Builder slowRenderPollingDuration(Duration interval){
+            if(interval.toMillis() <= 0){
+                Log.e(SplunkRum.LOG_TAG, "invalid slowRenderPollingDuration: " + interval + " is not positive");
                 return this;
             }
-            this.renderDurationPollingIntervalMs = interval;
+            this.slowRenderPollingDuration = interval;
             return this;
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -142,7 +142,7 @@ class RumInitializer {
         try {
             initializationEvents.add(new RumInitializer.InitializationEvent("slowRenderingDetectorInitialized", timingClock.now()));
             Class.forName("androidx.core.app.FrameMetricsAggregator");
-            return new SlowRenderingDetectorImpl(tracer, config.getRenderDurationPollingIntervalMs());
+            return new SlowRenderingDetectorImpl(tracer, config.getSlowRenderPollingDuration());
         } catch (ClassNotFoundException e) {
             Log.w(LOG_TAG, "FrameMetricsAggregator is not available on this platform - slow/frozen rendering detection is disabled.");
             return SlowRenderingDetector.NO_OP;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -103,7 +103,8 @@ class RumInitializer {
             initializationEvents.add(new RumInitializer.InitializationEvent("networkMonitorInitialized", timingClock.now()));
         }
 
-        SlowRenderingDetector slowRenderingDetector = new SlowRenderingDetector(tracer);
+
+        SlowRenderingDetector slowRenderingDetector = buildSlowRenderDetector(tracer);
         slowRenderingDetector.start();
 
         if (Build.VERSION.SDK_INT < 29) {
@@ -121,6 +122,15 @@ class RumInitializer {
         recordInitializationSpans(startTimeNanos, initializationEvents, tracer, config);
 
         return new SplunkRum(openTelemetrySdk, sessionId, config);
+    }
+
+    private SlowRenderingDetector buildSlowRenderDetector(Tracer tracer) {
+        try {
+            Class.forName("androidx.core.app.FrameMetricsAggregator");
+            return new SlowRenderingDetectorImpl(tracer);
+        } catch (ClassNotFoundException e) {
+            return SlowRenderingDetector.NO_OP;
+        }
     }
 
     private AppStateListener initializeAnrReporting(Looper mainLooper) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -135,7 +135,7 @@ class RumInitializer {
     }
 
     private SlowRenderingDetector buildSlowRenderingDetector(Config config, Tracer tracer) {
-        if(config.getRenderDurationPollingIntervalMs() == 0){
+        if(config.isSlowRenderingDetectionDisabled()){
             Log.w(LOG_TAG, "Slow/frozen rendering detection has been disabled by user.");
             return SlowRenderingDetector.NO_OP;
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -103,10 +103,13 @@ class RumInitializer {
             initializationEvents.add(new RumInitializer.InitializationEvent("networkMonitorInitialized", timingClock.now()));
         }
 
+        SlowRenderingDetector slowRenderingDetector = new SlowRenderingDetector(tracer);
+        slowRenderingDetector.start();
+
         if (Build.VERSION.SDK_INT < 29) {
             application.registerActivityLifecycleCallbacks(new Pre29ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, appStateListeners));
         } else {
-            application.registerActivityLifecycleCallbacks(new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, appStateListeners));
+            application.registerActivityLifecycleCallbacks(new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, appStateListeners, slowRenderingDetector));
         }
         initializationEvents.add(new RumInitializer.InitializationEvent("activityLifecycleCallbacksInitialized", timingClock.now()));
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -107,7 +107,7 @@ class RumInitializer {
         }
 
 
-        SlowRenderingDetector slowRenderingDetector = buildSlowRenderDetector(config, tracer);
+        SlowRenderingDetector slowRenderingDetector = buildSlowRenderingDetector(config, tracer);
         slowRenderingDetector.start();
 
         if (Build.VERSION.SDK_INT < 29) {
@@ -127,7 +127,7 @@ class RumInitializer {
         return new SplunkRum(openTelemetrySdk, sessionId, config);
     }
 
-    private SlowRenderingDetector buildSlowRenderDetector(Config config, Tracer tracer) {
+    private SlowRenderingDetector buildSlowRenderingDetector(Config config, Tracer tracer) {
         if(config.getRenderDurationPollingIntervalMs() == 0){
             Log.w(LOG_TAG, "Slow/frozen rendering detection has been disabled by user.");
             return SlowRenderingDetector.NO_OP;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -113,7 +113,14 @@ class RumInitializer {
         if (Build.VERSION.SDK_INT < 29) {
             application.registerActivityLifecycleCallbacks(new Pre29ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, appStateListeners));
         } else {
-            application.registerActivityLifecycleCallbacks(new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, appStateListeners, slowRenderingDetector));
+            ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                    .tracer(tracer)
+                    .visibleScreenTracker(visibleScreenTracker)
+                    .startupTimer(startupTimer)
+                    .appStateListeners(appStateListeners)
+                    .slowRenderingDetector(slowRenderingDetector)
+                    .build();
+            application.registerActivityLifecycleCallbacks(activityCallbacks);
         }
         initializationEvents.add(new RumInitializer.InitializationEvent("activityLifecycleCallbacksInitialized", timingClock.now()));
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -134,7 +134,7 @@ class RumInitializer {
         }
         try {
             Class.forName("androidx.core.app.FrameMetricsAggregator");
-            return new SlowRenderingDetectorImpl(tracer);
+            return new SlowRenderingDetectorImpl(tracer, config.getRenderDurationPollingIntervalMs());
         } catch (ClassNotFoundException e) {
             Log.w(LOG_TAG, "FrameMetricsAggregator is not available on this platform - slow/frozen rendering detection is disabled.");
             return SlowRenderingDetector.NO_OP;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -140,6 +140,7 @@ class RumInitializer {
             return SlowRenderingDetector.NO_OP;
         }
         try {
+            initializationEvents.add(new RumInitializer.InitializationEvent("slowRenderingDetectorInitialized", timingClock.now()));
             Class.forName("androidx.core.app.FrameMetricsAggregator");
             return new SlowRenderingDetectorImpl(tracer, config.getRenderDurationPollingIntervalMs());
         } catch (ClassNotFoundException e) {
@@ -195,6 +196,7 @@ class RumInitializer {
         String configSettings = "[debug:" + config.isDebugEnabled() + "," +
                 "crashReporting:" + config.isCrashReportingEnabled() + "," +
                 "anrReporting:" + config.isAnrDetectionEnabled() + "," +
+                "slowRenderingDetector:" + config.isSlowRenderingDetectionEnabled() + "," +
                 "networkMonitor:" + config.isNetworkMonitorEnabled() + "]";
         span.setAttribute("config_settings", configSettings);
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
@@ -83,10 +83,10 @@ public class SlowRenderingDetector {
 
         Instant now = Instant.now();
         if(slowCount > 0){
-            makeSpan("slowSpans", slowCount, now);
+            makeSpan("slowRender", slowCount, now);
         }
         if(slowCount > 0){
-            makeSpan("frozenCount", frozenCount, now);
+            makeSpan("frozenRender", frozenCount, now);
         }
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
@@ -1,0 +1,101 @@
+package com.splunk.rum;
+
+import static androidx.core.app.FrameMetricsAggregator.DRAW_DURATION;
+import static androidx.core.app.FrameMetricsAggregator.DRAW_INDEX;
+import static com.splunk.rum.SplunkRum.LOG_TAG;
+
+import android.app.Activity;
+import android.util.Log;
+import android.util.SparseIntArray;
+
+import androidx.core.app.FrameMetricsAggregator;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+public class SlowRenderingDetector {
+
+    private final FrameMetricsAggregator frameMetrics = new FrameMetricsAggregator(DRAW_DURATION);
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    private final Set<Activity> activities = new HashSet<>();
+    private final Tracer tracer;
+
+    public SlowRenderingDetector(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public void add(Activity activity) {
+        activities.add(activity);
+        frameMetrics.add(activity);
+    }
+
+    public void stop(Activity activity) {
+        SparseIntArray[] arrays = frameMetrics.remove(activity);
+        activities.remove(activity);
+        if (arrays != null) {
+            reportSlow(arrays[DRAW_INDEX]);
+        }
+    }
+
+    public void start() {
+        executorService.scheduleAtFixedRate(this::reportSlowRenders, 1, 1, TimeUnit.SECONDS);
+    }
+
+    private void reportSlowRenders() {
+        try {
+            SparseIntArray[] metrics = frameMetrics.reset();
+            if (metrics != null) {
+                reportSlow(metrics[DRAW_INDEX]);
+            }
+        } catch (Exception e) {
+            Log.w(LOG_TAG, "Exception while processing frame metrics", e);
+        }
+        for (Activity activity : activities) {
+            frameMetrics.remove(activity);
+            frameMetrics.add(activity);
+        }
+    }
+
+    private void reportSlow(SparseIntArray durationToCountHistogram) {
+        if (durationToCountHistogram == null) {
+            return;
+        }
+        int slowCount = 0;
+        int frozenCount = 0;
+        for (int i = 0; i < durationToCountHistogram.size(); i++) {
+            int duration = durationToCountHistogram.keyAt(i);
+            int count = durationToCountHistogram.get(duration);
+            if (duration > 700) {
+                Log.d(LOG_TAG, "* FROZEN RENDER DETECTED: " + duration + " ms." + count + " times");
+                frozenCount += count;
+            } else if (duration > 16) {
+                Log.d(LOG_TAG, "* Slow render detected: " + duration + " ms. " + count + " times");
+                slowCount += count;
+            }
+        }
+
+        Instant now = Instant.now();
+        if(slowCount > 0){
+            makeSpan("slowSpans", slowCount, now);
+        }
+        if(slowCount > 0){
+            makeSpan("frozenCount", frozenCount, now);
+        }
+    }
+
+    private void makeSpan(String name, int slowCount, Instant now) {
+        Span span = tracer
+                .spanBuilder(name)
+                .setAttribute("count", slowCount)
+                .setStartTimestamp(now)
+                .startSpan();
+        span.end(now);
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
@@ -1,101 +1,28 @@
 package com.splunk.rum;
 
-import static androidx.core.app.FrameMetricsAggregator.DRAW_DURATION;
-import static androidx.core.app.FrameMetricsAggregator.DRAW_INDEX;
-import static com.splunk.rum.SplunkRum.LOG_TAG;
-
 import android.app.Activity;
-import android.util.Log;
-import android.util.SparseIntArray;
 
-import androidx.core.app.FrameMetricsAggregator;
+public interface SlowRenderingDetector {
+    SlowRenderingDetector NO_OP = new NoOp();
 
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+    void add(Activity activity);
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
+    void stop(Activity activity);
 
-public class SlowRenderingDetector {
+    void start();
 
-    private final FrameMetricsAggregator frameMetrics = new FrameMetricsAggregator(DRAW_DURATION);
-    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
-    private final Set<Activity> activities = new HashSet<>();
-    private final Tracer tracer;
+    class NoOp implements SlowRenderingDetector {
 
-    public SlowRenderingDetector(Tracer tracer) {
-        this.tracer = tracer;
-    }
-
-    public void add(Activity activity) {
-        activities.add(activity);
-        frameMetrics.add(activity);
-    }
-
-    public void stop(Activity activity) {
-        SparseIntArray[] arrays = frameMetrics.remove(activity);
-        activities.remove(activity);
-        if (arrays != null) {
-            reportSlow(arrays[DRAW_INDEX]);
-        }
-    }
-
-    public void start() {
-        executorService.scheduleAtFixedRate(this::reportSlowRenders, 1, 1, TimeUnit.SECONDS);
-    }
-
-    private void reportSlowRenders() {
-        try {
-            SparseIntArray[] metrics = frameMetrics.reset();
-            if (metrics != null) {
-                reportSlow(metrics[DRAW_INDEX]);
-            }
-        } catch (Exception e) {
-            Log.w(LOG_TAG, "Exception while processing frame metrics", e);
-        }
-        for (Activity activity : activities) {
-            frameMetrics.remove(activity);
-            frameMetrics.add(activity);
-        }
-    }
-
-    private void reportSlow(SparseIntArray durationToCountHistogram) {
-        if (durationToCountHistogram == null) {
-            return;
-        }
-        int slowCount = 0;
-        int frozenCount = 0;
-        for (int i = 0; i < durationToCountHistogram.size(); i++) {
-            int duration = durationToCountHistogram.keyAt(i);
-            int count = durationToCountHistogram.get(duration);
-            if (duration > 700) {
-                Log.d(LOG_TAG, "* FROZEN RENDER DETECTED: " + duration + " ms." + count + " times");
-                frozenCount += count;
-            } else if (duration > 16) {
-                Log.d(LOG_TAG, "* Slow render detected: " + duration + " ms. " + count + " times");
-                slowCount += count;
-            }
+        @Override
+        public void add(Activity activity) {
         }
 
-        Instant now = Instant.now();
-        if(slowCount > 0){
-            makeSpan("slowRender", slowCount, now);
+        @Override
+        public void stop(Activity activity) {
         }
-        if(slowCount > 0){
-            makeSpan("frozenRender", frozenCount, now);
-        }
-    }
 
-    private void makeSpan(String name, int slowCount, Instant now) {
-        Span span = tracer
-                .spanBuilder(name)
-                .setAttribute("count", slowCount)
-                .setStartTimestamp(now)
-                .startSpan();
-        span.end(now);
+        @Override
+        public void start() {
+        }
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -22,6 +22,8 @@ import io.opentelemetry.api.trace.Tracer;
 
 public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
 
+    public static final int SLOW_THRESHOLD_MS = 16;
+    public static final int FROZEN_THRESHOLD_MS = 700;
     private final FrameMetricsAggregator frameMetrics = new FrameMetricsAggregator(DRAW_DURATION);
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
     private final Set<Activity> activities = new HashSet<>();
@@ -75,10 +77,10 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
         for (int i = 0; i < durationToCountHistogram.size(); i++) {
             int duration = durationToCountHistogram.keyAt(i);
             int count = durationToCountHistogram.get(duration);
-            if (duration > 700) {
+            if (duration > FROZEN_THRESHOLD_MS) {
                 Log.d(LOG_TAG, "* FROZEN RENDER DETECTED: " + duration + " ms." + count + " times");
                 frozenCount += count;
-            } else if (duration > 16) {
+            } else if (duration > SLOW_THRESHOLD_MS) {
                 Log.d(LOG_TAG, "* Slow render detected: " + duration + " ms. " + count + " times");
                 slowCount += count;
             }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -88,7 +88,7 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
         if(slowCount > 0){
             makeSpan("slowRender", slowCount, now);
         }
-        if(slowCount > 0){
+        if(frozenCount > 0){
             makeSpan("frozenRender", frozenCount, now);
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -88,10 +88,10 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
 
         Instant now = Instant.now();
         if(slowCount > 0){
-            makeSpan("slowRender", slowCount, now);
+            makeSpan("slowRenders", slowCount, now);
         }
         if(frozenCount > 0){
-            makeSpan("frozenRender", frozenCount, now);
+            makeSpan("frozenRenders", frozenCount, now);
         }
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -1,0 +1,104 @@
+package com.splunk.rum;
+
+import static androidx.core.app.FrameMetricsAggregator.DRAW_DURATION;
+import static androidx.core.app.FrameMetricsAggregator.DRAW_INDEX;
+import static com.splunk.rum.SplunkRum.LOG_TAG;
+
+import android.app.Activity;
+import android.util.Log;
+import android.util.SparseIntArray;
+
+import androidx.core.app.FrameMetricsAggregator;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
+
+    private final FrameMetricsAggregator frameMetrics = new FrameMetricsAggregator(DRAW_DURATION);
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    private final Set<Activity> activities = new HashSet<>();
+    private final Tracer tracer;
+
+    public SlowRenderingDetectorImpl(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void add(Activity activity) {
+        activities.add(activity);
+        frameMetrics.add(activity);
+    }
+
+    @Override
+    public void stop(Activity activity) {
+        SparseIntArray[] arrays = frameMetrics.remove(activity);
+        activities.remove(activity);
+        if (arrays != null) {
+            reportSlow(arrays[DRAW_INDEX]);
+        }
+    }
+
+    @Override
+    public void start() {
+        executorService.scheduleAtFixedRate(this::reportSlowRenders, 1, 1, TimeUnit.SECONDS);
+    }
+
+    private void reportSlowRenders() {
+        try {
+            SparseIntArray[] metrics = frameMetrics.reset();
+            if (metrics != null) {
+                reportSlow(metrics[DRAW_INDEX]);
+            }
+        } catch (Exception e) {
+            Log.w(LOG_TAG, "Exception while processing frame metrics", e);
+        }
+        for (Activity activity : activities) {
+            frameMetrics.remove(activity);
+            frameMetrics.add(activity);
+        }
+    }
+
+    private void reportSlow(SparseIntArray durationToCountHistogram) {
+        if (durationToCountHistogram == null) {
+            return;
+        }
+        int slowCount = 0;
+        int frozenCount = 0;
+        for (int i = 0; i < durationToCountHistogram.size(); i++) {
+            int duration = durationToCountHistogram.keyAt(i);
+            int count = durationToCountHistogram.get(duration);
+            if (duration > 700) {
+                Log.d(LOG_TAG, "* FROZEN RENDER DETECTED: " + duration + " ms." + count + " times");
+                frozenCount += count;
+            } else if (duration > 16) {
+                Log.d(LOG_TAG, "* Slow render detected: " + duration + " ms. " + count + " times");
+                slowCount += count;
+            }
+        }
+
+        Instant now = Instant.now();
+        if(slowCount > 0){
+            makeSpan("slowRender", slowCount, now);
+        }
+        if(slowCount > 0){
+            makeSpan("frozenRender", frozenCount, now);
+        }
+    }
+
+    private void makeSpan(String name, int slowCount, Instant now) {
+        Span span = tracer
+                .spanBuilder(name)
+                .setAttribute("count", slowCount)
+                .setStartTimestamp(now)
+                .startSpan();
+        span.end(now);
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -10,6 +10,7 @@ import android.util.SparseIntArray;
 
 import androidx.core.app.FrameMetricsAggregator;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,18 +30,18 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
 
     private final Set<Activity> activities = new HashSet<>();
     private final Tracer tracer;
-    private final long renderDurationPollingIntervalMs;
+    private final Duration slowRenderPollingDuration;
 
-    public SlowRenderingDetectorImpl(Tracer tracer, int renderDurationPollingIntervalMs) {
-        this(tracer, new FrameMetricsAggregator(DRAW_DURATION), Executors.newScheduledThreadPool(1), renderDurationPollingIntervalMs);
+    public SlowRenderingDetectorImpl(Tracer tracer, Duration slowRenderPollingDuration) {
+        this(tracer, new FrameMetricsAggregator(DRAW_DURATION), Executors.newScheduledThreadPool(1), slowRenderPollingDuration);
     }
 
     // Exists for testing
-    SlowRenderingDetectorImpl(Tracer tracer, FrameMetricsAggregator frameMetricsAggregator, ScheduledExecutorService executorService, long renderDurationPollingIntervalMs) {
+    SlowRenderingDetectorImpl(Tracer tracer, FrameMetricsAggregator frameMetricsAggregator, ScheduledExecutorService executorService, Duration slowRenderPollingDuration) {
         this.tracer = tracer;
         this.frameMetrics = frameMetricsAggregator;
         this.executorService = executorService;
-        this.renderDurationPollingIntervalMs = renderDurationPollingIntervalMs;
+        this.slowRenderPollingDuration = slowRenderPollingDuration;
     }
 
     @Override
@@ -60,7 +61,7 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
 
     @Override
     public void start() {
-        executorService.scheduleAtFixedRate(this::reportSlowRenders, renderDurationPollingIntervalMs, renderDurationPollingIntervalMs, TimeUnit.MILLISECONDS);
+        executorService.scheduleAtFixedRate(this::reportSlowRenders, slowRenderPollingDuration.toMillis(), slowRenderPollingDuration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     private void reportSlowRenders() {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.util.Log;
 import android.util.SparseIntArray;
 
+import androidx.annotation.NonNull;
 import androidx.core.app.FrameMetricsAggregator;
 
 import java.time.Instant;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -24,13 +26,21 @@ public class SlowRenderingDetectorImpl implements SlowRenderingDetector {
 
     public static final int SLOW_THRESHOLD_MS = 16;
     public static final int FROZEN_THRESHOLD_MS = 700;
-    private final FrameMetricsAggregator frameMetrics = new FrameMetricsAggregator(DRAW_DURATION);
-    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    private final FrameMetricsAggregator frameMetrics;
+    private final ScheduledExecutorService executorService;
+
     private final Set<Activity> activities = new HashSet<>();
     private final Tracer tracer;
 
     public SlowRenderingDetectorImpl(Tracer tracer) {
+        this(tracer, new FrameMetricsAggregator(DRAW_DURATION), Executors.newScheduledThreadPool(1));
+    }
+
+    // Exists for testing
+    SlowRenderingDetectorImpl(Tracer tracer, FrameMetricsAggregator frameMetricsAggregator, ScheduledExecutorService executorService) {
         this.tracer = tracer;
+        this.frameMetrics = frameMetricsAggregator;
+        this.executorService = executorService;
     }
 
     @Override

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
@@ -47,6 +47,7 @@ public class ActivityCallbacksTest {
     private VisibleScreenTracker visibleScreenTracker;
     private final AppStartupTimer startupTimer = new AppStartupTimer();
     private final AppStateListener appStateListener = mock(AppStateListener.class);
+    private final SlowRenderingDetector slowRenderingDetector = mock(SlowRenderingDetector.class);
 
     @Before
     public void setup() {
@@ -57,7 +58,7 @@ public class ActivityCallbacksTest {
     @Test
     public void appStartup() {
         startupTimer.start(tracer);
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         Activity activity = mock(Activity.class);
@@ -99,7 +100,7 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityCreation() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
         startupAppAndClearSpans(testHarness);
 
@@ -144,7 +145,7 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityRestart() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -181,7 +182,7 @@ public class ActivityCallbacksTest {
     @Test
     public void activityResumed() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -212,7 +213,7 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityDestroyedFromStopped() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -243,7 +244,7 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityDestroyedFromPaused() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -289,7 +290,7 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityStoppedFromRunning() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener));
+        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
@@ -58,7 +58,13 @@ public class ActivityCallbacksTest {
     @Test
     public void appStartup() {
         startupTimer.start(tracer);
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         Activity activity = mock(Activity.class);
@@ -101,7 +107,14 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityCreation() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
         startupAppAndClearSpans(testHarness);
 
@@ -146,7 +159,14 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityRestart() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -183,7 +203,14 @@ public class ActivityCallbacksTest {
     @Test
     public void activityResumed() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -214,7 +241,14 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityDestroyedFromStopped() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -245,7 +279,14 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityDestroyedFromPaused() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);
@@ -292,7 +333,14 @@ public class ActivityCallbacksTest {
 
     @Test
     public void activityStoppedFromRunning() {
-        ActivityCallbacks activityCallbacks = new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer, singletonList(appStateListener), slowRenderingDetector);
+        ActivityCallbacks activityCallbacks = ActivityCallbacks.builder()
+                .tracer(tracer)
+                .visibleScreenTracker(visibleScreenTracker)
+                .startupTimer(startupTimer)
+                .appStateListeners(singletonList(appStateListener))
+                .slowRenderingDetector(slowRenderingDetector)
+                .build();
+
         ActivityCallbackTestHarness testHarness = new ActivityCallbackTestHarness(activityCallbacks);
 
         startupAppAndClearSpans(testHarness);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
@@ -328,7 +328,6 @@ public class ActivityCallbacksTest {
         checkEventExists(events, "activityPostDestroyed");
 
         verify(appStateListener).appBackgrounded();
-        verify(slowRenderingDetector).stop(activity);
     }
 
     @Test
@@ -365,6 +364,7 @@ public class ActivityCallbacksTest {
         checkEventExists(events, "activityPrePaused");
         checkEventExists(events, "activityPaused");
         checkEventExists(events, "activityPostPaused");
+        verify(slowRenderingDetector).stop(activity);
 
         SpanData destroyedSpan = spans.get(1);
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
@@ -96,6 +96,7 @@ public class ActivityCallbacksTest {
         checkEventExists(events, "activityPostResumed");
 
         verify(appStateListener).appForegrounded();
+        verify(slowRenderingDetector).add(activity);
     }
 
     @Test
@@ -286,6 +287,7 @@ public class ActivityCallbacksTest {
         checkEventExists(events, "activityPostDestroyed");
 
         verify(appStateListener).appBackgrounded();
+        verify(slowRenderingDetector).stop(activity);
     }
 
     @Test

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -68,7 +68,7 @@ public class RumInitializerTest {
 
         assertEquals("SplunkRum.initialize", initSpan.getName());
         assertEquals("appstart", initSpan.getAttributes().get(SplunkRum.COMPONENT_KEY));
-        assertEquals("[debug:false,crashReporting:true,anrReporting:true,networkMonitor:true]",
+        assertEquals("[debug:false,crashReporting:true,anrReporting:true,slowRenderingDetector:true,networkMonitor:true]",
                 initSpan.getAttributes().get(stringKey("config_settings")));
 
         List<EventData> events = initSpan.getEvents();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
@@ -1,0 +1,147 @@
+package com.splunk.rum;
+
+import static androidx.core.app.FrameMetricsAggregator.DRAW_INDEX;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.util.SparseIntArray;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.FrameMetricsAggregator;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SlowRenderingDetectorImplTest {
+
+    public static final AttributeKey<Long> COUNT_KEY = AttributeKey.longKey("count");
+    @Rule
+    public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+    @Mock
+    FrameMetricsAggregator frameMetrics;
+    @Mock
+    Activity activity;
+    Tracer tracer;
+
+    @Before
+    public void setup() {
+        tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
+    }
+
+
+    @Test
+    public void add() {
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+        testInstance.add(activity);
+        verify(frameMetrics).add(activity);
+    }
+
+    @Test
+    public void stopBeforeAddOk() {
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+        testInstance.stop(activity);
+    }
+
+    @Test
+    public void stop() {
+
+        SparseIntArray[] metricsArray = makeSomeMetrics();
+
+        when(frameMetrics.remove(activity)).thenReturn(metricsArray);
+
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+
+        testInstance.add(activity);
+        testInstance.stop(activity);
+        List<SpanData> spans = otelTesting.getSpans();
+        assertSpanContent(spans);
+    }
+
+    @Test
+    public void start() {
+        SparseIntArray[] metricsArray = makeSomeMetrics();
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+
+        when(frameMetrics.reset()).thenReturn(metricsArray);
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run(); // just call it immediately
+            return null;
+        }).when(exec).scheduleAtFixedRate(any(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, exec);
+        testInstance.add(activity);
+        testInstance.start();
+        List<SpanData> spans = otelTesting.getSpans();
+        assertEquals(2, spans.size());
+        assertSpanContent(spans);
+        InOrder inOrder = inOrder(frameMetrics);
+        inOrder.verify(frameMetrics).add(activity);
+        inOrder.verify(frameMetrics).remove(activity);
+        inOrder.verify(frameMetrics).add(activity);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private void assertSpanContent(List<SpanData> spans) {
+        assertEquals(2, spans.size());
+        SpanData slowRenders = spans.get(0);
+        SpanData frozenRenders = spans.get(1);
+
+        assertEquals("slowRenders", slowRenders.getName());
+        assertEquals(0, slowRenders.getStartEpochNanos() - slowRenders.getEndEpochNanos());
+        long slowCount = slowRenders.getAttributes().get(COUNT_KEY);
+        assertEquals(2, slowCount);
+
+        assertEquals("frozenRenders", frozenRenders.getName());
+        assertEquals(0, frozenRenders.getStartEpochNanos() - frozenRenders.getEndEpochNanos());
+        long frozenCount = frozenRenders.getAttributes().get(COUNT_KEY);
+        assertEquals(1, frozenCount);
+    }
+
+    @NonNull
+    private SparseIntArray[] makeSomeMetrics() {
+        SparseIntArray[] metricsArray = new SparseIntArray[DRAW_INDEX + 1];
+        SparseIntArray drawMetrics = mock(SparseIntArray.class);
+        when(drawMetrics.size()).thenReturn(3);
+        addFrameMetric(drawMetrics, 0, 12, 17);
+        addFrameMetric(drawMetrics, 1, 100, 2);
+        addFrameMetric(drawMetrics, 2, 701, 1);
+
+        metricsArray[DRAW_INDEX] = drawMetrics;
+        return metricsArray;
+    }
+
+    private void addFrameMetric(SparseIntArray drawMetrics, int index, int key, int value) {
+        when(drawMetrics.keyAt(index)).thenReturn(key);
+        when(drawMetrics.get(key)).thenReturn(value);
+    }
+
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
@@ -4,14 +4,10 @@ import static androidx.core.app.FrameMetricsAggregator.DRAW_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -26,9 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -59,14 +53,14 @@ public class SlowRenderingDetectorImplTest {
 
     @Test
     public void add() {
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 0);
         testInstance.add(activity);
         verify(frameMetrics).add(activity);
     }
 
     @Test
     public void stopBeforeAddOk() {
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 0);
         testInstance.stop(activity);
     }
 
@@ -77,7 +71,7 @@ public class SlowRenderingDetectorImplTest {
 
         when(frameMetrics.remove(activity)).thenReturn(metricsArray);
 
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 1001);
 
         testInstance.add(activity);
         testInstance.stop(activity);
@@ -95,9 +89,9 @@ public class SlowRenderingDetectorImplTest {
             Runnable runnable = invocation.getArgument(0);
             runnable.run(); // just call it immediately
             return null;
-        }).when(exec).scheduleAtFixedRate(any(), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+        }).when(exec).scheduleAtFixedRate(any(), eq(1001L), eq(1001L), eq(TimeUnit.MILLISECONDS));
 
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, exec);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, exec, 1001);
         testInstance.add(activity);
         testInstance.start();
         List<SpanData> spans = otelTesting.getSpans();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
@@ -24,6 +24,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -53,14 +54,14 @@ public class SlowRenderingDetectorImplTest {
 
     @Test
     public void add() {
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 0);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, Duration.ofSeconds(0));
         testInstance.add(activity);
         verify(frameMetrics).add(activity);
     }
 
     @Test
     public void stopBeforeAddOk() {
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 0);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, Duration.ofSeconds(0));
         testInstance.stop(activity);
     }
 
@@ -71,7 +72,7 @@ public class SlowRenderingDetectorImplTest {
 
         when(frameMetrics.remove(activity)).thenReturn(metricsArray);
 
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, 1001);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, null, Duration.ofMillis(1001));
 
         testInstance.add(activity);
         testInstance.stop(activity);
@@ -91,7 +92,7 @@ public class SlowRenderingDetectorImplTest {
             return null;
         }).when(exec).scheduleAtFixedRate(any(), eq(1001L), eq(1001L), eq(TimeUnit.MILLISECONDS));
 
-        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, exec, 1001);
+        SlowRenderingDetectorImpl testInstance = new SlowRenderingDetectorImpl(tracer, frameMetrics, exec, Duration.ofMillis(1001));
         testInstance.add(activity);
         testInstance.start();
         List<SpanData> spans = otelTesting.getSpans();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -77,6 +77,7 @@ public class SplunkRumTest {
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.isDebugEnabled()).thenReturn(true);
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
+        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> connectionUtil);
         SplunkRum sameInstance = SplunkRum.initialize(config, application);
@@ -97,6 +98,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
+        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertSame(singleton, SplunkRum.getInstance());
@@ -114,6 +116,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
+        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
 
         SplunkRum splunkRum = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertNotNull(splunkRum.getOpenTelemetry());
@@ -230,6 +233,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
+        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
 
         SplunkRum splunkRum = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         splunkRum.integrateWithBrowserRum(webView);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -39,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
 
+import java.time.Duration;
 import java.util.List;
 
 import io.opentelemetry.api.common.Attributes;
@@ -77,7 +78,7 @@ public class SplunkRumTest {
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.isDebugEnabled()).thenReturn(true);
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
-        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
+        when(config.getSlowRenderPollingDuration()).thenReturn(Duration.ofMillis(1000));
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> connectionUtil);
         SplunkRum sameInstance = SplunkRum.initialize(config, application);
@@ -98,7 +99,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
-        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
+        when(config.getSlowRenderPollingDuration()).thenReturn(Duration.ofMillis(1000));
 
         SplunkRum singleton = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertSame(singleton, SplunkRum.getInstance());
@@ -116,7 +117,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
-        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
+        when(config.getSlowRenderPollingDuration()).thenReturn(Duration.ofMillis(1000));
 
         SplunkRum splunkRum = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         assertNotNull(splunkRum.getOpenTelemetry());
@@ -233,7 +234,7 @@ public class SplunkRumTest {
 
         when(config.getBeaconEndpoint()).thenReturn("http://backend");
         when(config.decorateWithSpanFilter(any())).then(new ReturnsArgumentAt(0));
-        when(config.getRenderDurationPollingIntervalMs()).thenReturn(1000);
+        when(config.getSlowRenderPollingDuration()).thenReturn(Duration.ofMillis(1000));
 
         SplunkRum splunkRum = SplunkRum.initialize(config, application, () -> mock(ConnectionUtil.class, RETURNS_DEEP_STUBS));
         splunkRum.integrateWithBrowserRum(webView);


### PR DESCRIPTION
This sets up a new component: SlowRenderingDetector. This is an interface, of which there are two implementations -- a noop version and the real version. The noop version is wired in if the platform doesn't support the API class we use or if the polling mechanism is set to 0. The real implementation will poll the `FrameMetricsAggregator` every second (by default) and look for renders that are slower than 16ms (slow render) and 700ms (frozen render).

These are then aggregated per interval (1s default) and ingested as zero-duration spans (which zipkin thinks are 1us spans). The span names are `slowRenders` or `frozenRenders` and the spans contain an attribute named "count" which is a sum of the renders that met the times shown above.

The demo app was also updated to have a self-painting component in the second fragment to show this. Its slow mode can be toggled on/off with the button.