### PR TITLE
Retry sending files.

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -94,7 +94,11 @@ class FileSender {
 
         public boolean incrementAndCheckMax(File file) {
             Integer count = attempts.merge(file, 1, (cur, x) -> cur + 1);
-            return count >= maxRetries;
+            boolean exceededRetries = count >= maxRetries;
+            if(exceededRetries){
+                Log.w(LOG_TAG, "Dropping data in " + file + " (max retries exceeded " + maxRetries + ")");
+            }
+            return exceededRetries;
         }
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -107,7 +107,7 @@ class FileSender {
         private Sender sender;
         private FileUtils fileUtils = new FileUtils();
         private BandwidthTracker bandwidthTracker;
-        public RetryTracker retryTracker;
+        private RetryTracker retryTracker;
         private int maxRetries = DEFAULT_MAX_RETRIES;
 
         Builder sender(Sender sender) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -87,12 +87,11 @@ class FileSender {
         private RetryTracker(int maxRetries) {
             this.maxRetries = maxRetries;
         }
-
-        public void clear(File file) {
+        void clear(File file) {
             attempts.remove(file);
         }
 
-        public boolean incrementAndCheckMax(File file) {
+        boolean incrementAndCheckMax(File file) {
             Integer count = attempts.merge(file, 1, (cur, x) -> cur + 1);
             boolean exceededRetries = count >= maxRetries;
             if(exceededRetries){

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -1,0 +1,135 @@
+package com.splunk.rum;
+
+import static com.splunk.rum.SplunkRum.LOG_TAG;
+import static java.util.Collections.emptyList;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import zipkin2.Call;
+import zipkin2.reporter.Sender;
+
+class FileSender {
+
+    private final static int DEFAULT_MAX_RETRIES = 10;
+
+    private final Sender sender;
+    private final FileUtils fileUtils;
+    private final BandwidthTracker bandwidthTracker;
+    private final RetryTracker retryTracker;
+
+    private FileSender(Builder builder) {
+        this.sender = builder.sender;
+        this.fileUtils = builder.fileUtils;
+        this.bandwidthTracker = builder.bandwidthTracker;
+        this.retryTracker = builder.retryTracker;
+    }
+
+    /**
+     * Reads a file on disk and attempts to send it. Updates the bandwidthTracker with
+     * the bytes read, and return true if the file was sent. It will keep track of
+     * how many attempts the file has had, and if it exceedes the max retries, the file
+     * will be deleted.
+     * @param file File to handle
+     * @return true if the file content was sent successfully
+     */
+    boolean handleFileOnDisk(File file) {
+        Log.d(LOG_TAG, "Reading file content for ingest: " + file);
+        List<byte[]> encodedSpans = readFileCompletely(file);
+        if (encodedSpans.isEmpty()) {
+            return false;
+        }
+
+        boolean sentOk = attemptSend(file, encodedSpans);
+        boolean doneWithRetries = sentOk || retryTracker.incrementAndCheckMax(file);
+        if(doneWithRetries) {
+            retryTracker.clear(file);
+            fileUtils.safeDelete(file);
+        }
+        return sentOk;
+    }
+
+    private boolean attemptSend(File file, List<byte[]> encodedSpans) {
+        try {
+            bandwidthTracker.tick(encodedSpans);
+            Call<Void> httpCall = sender.sendSpans(encodedSpans);
+            httpCall.execute();
+            Log.d(LOG_TAG, "File content " + file + " successfully uploaded");
+            return true;
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "Error sending file content", e);
+            return false;
+        }
+    }
+
+    private List<byte[]> readFileCompletely(File file) {
+        try {
+            return fileUtils.readFileCompletely(file);
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "Error reading span data from file " + file, e);
+            return emptyList();
+        }
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    private static class RetryTracker {
+        private final Map<File,Integer> attempts = new HashMap<>();
+        private final int maxRetries;
+
+        private RetryTracker(int maxRetries) {
+            this.maxRetries = maxRetries;
+        }
+
+        public void clear(File file) {
+            attempts.remove(file);
+        }
+
+        public boolean incrementAndCheckMax(File file) {
+            Integer count = attempts.merge(file, 1, (cur, x) -> cur + 1);
+            return count >= maxRetries;
+        }
+    }
+
+    static class Builder {
+
+        private Sender sender;
+        private FileUtils fileUtils = new FileUtils();
+        private BandwidthTracker bandwidthTracker;
+        public RetryTracker retryTracker;
+        private int maxRetries = DEFAULT_MAX_RETRIES;
+
+        Builder sender(Sender sender) {
+            this.sender = sender;
+            return this;
+        }
+
+        Builder fileUtils(FileUtils fileUtils){
+            this.fileUtils = fileUtils;
+            return this;
+        }
+
+        Builder maxRetries(int maxRetries){
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        Builder bandwidthTracker(BandwidthTracker bandwidthTracker){
+            this.bandwidthTracker = bandwidthTracker;
+            return this;
+        }
+
+        FileSender build() {
+            this.retryTracker = new RetryTracker(maxRetries);
+            return new FileSender(this);
+        }
+    }
+
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -275,10 +275,16 @@ class RumInitializer {
                 .endpoint(getEndpoint())
                 .build();
         File spanFilesPath = FileUtils.getSpansDirectory(application);
+        BandwidthTracker bandwidthTracker = new BandwidthTracker();
 
+        FileSender fileSender = FileSender.builder()
+                .sender(sender)
+                .bandwidthTracker(bandwidthTracker)
+                .build();
         DiskToZipkinExporter diskToZipkinExporter = DiskToZipkinExporter.builder()
                 .connectionUtil(connectionUtil)
-                .sender(sender)
+                .fileSender(fileSender)
+                .bandwidthTracker(bandwidthTracker)
                 .spanFilesPath(spanFilesPath)
                 .build();
         diskToZipkinExporter.startPolling();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
@@ -1,12 +1,11 @@
 package com.splunk.rum;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static java.util.Collections.singletonList;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,27 +14,15 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
-
-import zipkin2.Call;
-import zipkin2.reporter.Sender;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DiskToZipkinExporterTest {
 
     static final int BANDWIDTH_LIMIT = 20 * 1024;
     static final File spanFilesPath = new File("/path/to/thing");
-    private final byte[] span1 = "span1".getBytes(StandardCharsets.UTF_8);
-    private final byte[] span2 = "span2".getBytes(StandardCharsets.UTF_8);
-    private final byte[] span3 = "span3".getBytes(StandardCharsets.UTF_8);
     private final File file1 = new File(spanFilesPath.getAbsolutePath() + File.separator + "file1.spans");
     private final File file2 = new File(spanFilesPath.getAbsolutePath() + File.separator + "file2.spans");
-    private final List<byte[]> file1Spans = singletonList(span1);
-    private final List<byte[]> file2Spans = Arrays.asList(span2, span3);
     private final File imposter = new File(spanFilesPath.getAbsolutePath() + File.separator + "someImposterFile.dll");
 
     @Mock
@@ -45,7 +32,7 @@ public class DiskToZipkinExporterTest {
     @Mock
     private CurrentNetwork currentNetwork;
     @Mock
-    Sender sender;
+    FileSender sender;
     @Mock
     private BandwidthTracker bandwidthTracker;
 
@@ -58,42 +45,32 @@ public class DiskToZipkinExporterTest {
         when(fileUtils.isRegularFile(file1)).thenReturn(true);
         when(fileUtils.isRegularFile(file2)).thenReturn(true);
         when(fileUtils.isRegularFile(imposter)).thenReturn(true);
-        when(fileUtils.readFileCompletely(file1)).thenReturn(file1Spans);
-        when(fileUtils.readFileCompletely(file2)).thenReturn(file2Spans);
     }
 
     @Test
     public void testHappyPathExport() throws Exception {
-
-        Call<Void> call1 = mock(Call.class);
-        Call<Void> call2 = mock(Call.class);
-
-        when(sender.sendSpans(file1Spans)).thenReturn(call1);
-        when(sender.sendSpans(file2Spans)).thenReturn(call2);
+        when(sender.handleFileOnDisk(file1)).thenReturn(true);
+        when(sender.handleFileOnDisk(file2)).thenReturn(true);
 
         DiskToZipkinExporter exporter = buildExporter();
 
         exporter.doExportCycle();
-        verify(call1).execute();
-        verify(call2).execute();
-        verify(fileUtils).safeDelete(file1);
-        verify(fileUtils).safeDelete(file2);
-        verify(fileUtils, never()).readFileCompletely(imposter);
-        verify(bandwidthTracker).tick(file1Spans);
-        verify(bandwidthTracker).tick(file2Spans);
+        verify(sender).handleFileOnDisk(file1);
+        verify(sender).handleFileOnDisk(file2);
+        verify(bandwidthTracker, never()).tick(anyList());
     }
 
     @Test
     public void fileFailureSkipsSubsequentFiles() throws Exception {
 
-        when(fileUtils.readFileCompletely(file1)).thenThrow(new IOException("no file"));
+        when(sender.handleFileOnDisk(file1)).thenReturn(false);
 
         DiskToZipkinExporter exporter = buildExporter();
 
         exporter.doExportCycle();
 
-        verify(fileUtils, never()).readFileCompletely(file2);
-        verifyNoMoreInteractions(sender);
+        verify(sender).handleFileOnDisk(file1);
+        verify(sender, never()).handleFileOnDisk(file2);
     }
 
     @Test
@@ -116,8 +93,7 @@ public class DiskToZipkinExporterTest {
 
         exporter.doExportCycle();
 
-        verify(fileUtils, never()).readFileCompletely(any());
-        verifyNoMoreInteractions(sender);
+        verify(sender, never()).handleFileOnDisk(any());
     }
 
     @Test
@@ -126,31 +102,13 @@ public class DiskToZipkinExporterTest {
         DiskToZipkinExporter exporter = buildExporter();
 
         exporter.doExportCycle();
-        verify(fileUtils, never()).readFileCompletely(any());
-        verify(fileUtils, never()).safeDelete(any());
-        verifyNoMoreInteractions(sender);
-    }
-
-    @Test
-    public void testSenderFailure() throws Exception {
-        Call<Void> call1 = mock(Call.class);
-        Call<Void> call2 = mock(Call.class);
-
-        when(sender.sendSpans(file1Spans)).thenReturn(call1);
-        when(call1.execute()).thenThrow(new IOException("Failure is yours to enjoy"));
-
-        DiskToZipkinExporter exporter = buildExporter();
-
-        exporter.doExportCycle();
-        verify(fileUtils).safeDelete(file1);
-        verify(fileUtils, never()).readFileCompletely(file2);
-        verify(fileUtils, never()).safeDelete(file2);
+        verify(sender, never()).handleFileOnDisk(any());
     }
 
     private DiskToZipkinExporter buildExporter() {
         return DiskToZipkinExporter.builder()
                 .fileUtils(fileUtils)
-                .sender(sender)
+                .fileSender(sender)
                 .bandwidthLimit(BANDWIDTH_LIMIT)
                 .bandwidthTracker(bandwidthTracker)
                 .spanFilesPath(spanFilesPath)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
@@ -1,0 +1,115 @@
+package com.splunk.rum;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static java.util.Collections.emptyList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import zipkin2.Call;
+import zipkin2.reporter.Sender;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileSenderTest {
+
+    private final byte[] span1 = "span1".getBytes(StandardCharsets.UTF_8);
+    private final byte[] span2 = "span2".getBytes(StandardCharsets.UTF_8);
+    private final byte[] span3 = "span3".getBytes(StandardCharsets.UTF_8);
+    private final File file = new File("meep");
+    private final List<byte[]> fileSpans = Arrays.asList(span1, span2, span3);
+
+    @Mock
+    private FileUtils fileUtils;
+    @Mock
+    private BandwidthTracker bandwidthTracker;
+    @Mock
+    private Sender delegate;
+    @Mock
+    private Call<Void> httpCall;
+
+    @Before
+    public void setup() throws Exception {
+        when(fileUtils.readFileCompletely(file)).thenReturn(fileSpans);
+        when(delegate.sendSpans(fileSpans)).thenReturn(httpCall);
+    }
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        File file = new File("/asdflkajsdfoij");
+        when(fileUtils.readFileCompletely(file)).thenReturn(emptyList());
+        FileSender sender = buildSender();
+        boolean result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testHappyPathSendSpans() {
+        FileSender sender = buildSender();
+        boolean result = sender.handleFileOnDisk(file);
+        assertTrue(result);
+        verify(bandwidthTracker).tick(fileSpans);
+    }
+
+    @Test
+    public void testSendFailsButNotExceeded() throws Exception {
+        when(httpCall.execute()).thenThrow(new IOException("boom"));
+        FileSender sender = buildSender();
+        boolean result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+        verify(fileUtils, never()).safeDelete(any());
+    }
+
+    @Test
+    public void testSenderFailureRetriesExhausted() throws Exception {
+        when(httpCall.execute()).thenThrow(new IOException("boom"));
+        FileSender sender = buildSender(3);
+        boolean result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+        verify(fileUtils, never()).safeDelete(any());
+        result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+        verify(fileUtils, never()).safeDelete(any());
+        result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+        verify(fileUtils).safeDelete(file);
+    }
+
+    @Test
+    public void testReadFileFails() throws IOException {
+        when(fileUtils.readFileCompletely(file)).thenThrow(new IOException("boom"));
+        FileSender sender = buildSender();
+        boolean result = sender.handleFileOnDisk(file);
+        assertFalse(result);
+        verifyNoMoreInteractions(bandwidthTracker);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    private FileSender buildSender() {
+        return buildSender(10);
+    }
+
+    private FileSender buildSender(int maxRetries) {
+        return FileSender.builder()
+                .bandwidthTracker(bandwidthTracker)
+                .maxRetries(maxRetries)
+                .sender(delegate)
+                .fileUtils(fileUtils)
+                .build();
+    }
+
+}


### PR DESCRIPTION
In the event of a file sending failure, the file will be retried up to 10 times. This is not yet configurable through the API (erred on the side of keeping it simple until needed).

With the standard attempt rate at 5 seconds, a splunk ingest outage of even 1 minute would result in mobile RUM data loss. Should we consider bumping the max attempt count up to 500 or 1000?

In the event that all retries for a file have been exhausted, then a warning is logged and the file is deleted.