### PR TITLE
Add session ID ratio based sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ when initializing your instance of the SplunkRum API:
   When disk buffering is enabled, this can be used to adjust the maximum amount of storage
   that will be used. Default = 25MB.
 - `sessionBasedSamplingEnabled(boolean)` :
-  Enables session ID based sampling for traces. Ratio must be set with `sessionBasedSamplingRatio`,
-  as the default ratio includes all sessions. Sampling is only applied if the spans created via 
-  `SplunkRum` APIs are root spans. If a custom parent span context was created, then the sampling 
-  flag of the parent span is respected instead.
+  Set sampling ratio for session ID based sampling. This is a probability of a session being 
+  included between between 0.0 (all dropped) and 1.0 (all included). Default is 1. Sampling is only
+  applied if the spans created via `SplunkRum` APIs are root spans. If a custom parent span context
+  was created, then the sampling flag of the parent span is respected instead.
 - `sessionBasedSamplingRatio(double)` :
   Set sampling ratio for session ID based sampling. This is a probability of a session being
   included between between 0.0 (all dropped) and 1.0 (all included). Default is 1.

--- a/README.md
+++ b/README.md
@@ -254,14 +254,11 @@ when initializing your instance of the SplunkRum API:
 - `limitDiskUsageMegabytes(int)` :
   When disk buffering is enabled, this can be used to adjust the maximum amount of storage
   that will be used. Default = 25MB.
-- `sessionBasedSamplingEnabled(boolean)` :
-  Set sampling ratio for session ID based sampling. This is a probability of a session being 
-  included between between 0.0 (all dropped) and 1.0 (all included). Default is 1. Sampling is only
+- `enableSessionBasedSampling(double)` :
+  Enable session ID based sampling and set its sampling ratio. The ratio is a probability of a
+  session being included between between 0.0 (all dropped) and 1.0 (all included). Sampling is only
   applied if the spans created via `SplunkRum` APIs are root spans. If a custom parent span context
   was created, then the sampling flag of the parent span is respected instead.
-- `sessionBasedSamplingRatio(double)` :
-  Set sampling ratio for session ID based sampling. This is a probability of a session being
-  included between between 0.0 (all dropped) and 1.0 (all included). Default is 1.
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,14 @@ when initializing your instance of the SplunkRum API:
 - `limitDiskUsageMegabytes(int)` :
   When disk buffering is enabled, this can be used to adjust the maximum amount of storage
   that will be used. Default = 25MB.
-
+- `sessionBasedSamplingEnabled(boolean)` :
+  Enables session ID based sampling for traces. Ratio must be set with `sessionBasedSamplingRatio`,
+  as the default ratio includes all sessions. Sampling is only applied if the spans created via 
+  `SplunkRum` APIs are root spans. If a custom parent span context was created, then the sampling 
+  flag of the parent span is respected instead.
+- `sessionBasedSamplingRatio(double)` :
+  Set sampling ratio for session ID based sampling. This is a probability of a session being
+  included between between 0.0 (all dropped) and 1.0 (all included). Default is 1.
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/README.md
+++ b/README.md
@@ -256,9 +256,7 @@ when initializing your instance of the SplunkRum API:
   that will be used. Default = 25MB.
 - `enableSessionBasedSampling(double)` :
   Enable session ID based sampling and set its sampling ratio. The ratio is a probability of a
-  session being included between between 0.0 (all dropped) and 1.0 (all included). Sampling is only
-  applied if the spans created via `SplunkRum` APIs are root spans. If a custom parent span context
-  was created, then the sampling flag of the parent span is respected instead.
+  session being included between between 0.0 (all dropped) and 1.0 (all included).
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -50,11 +50,8 @@ public class Config {
     private final boolean slowRenderingDetectionEnabled;
     private final Duration slowRenderingDetectionPollInterval;
     private final boolean diskBufferingEnabled;
-<<<<<<< HEAD
     private final int maxUsageMegabytes;
     private final boolean sessionBasedSamplerEnabled;
-=======
->>>>>>> 34aba40 (Remove redundant configuration option.)
     private final double sessionBasedSamplerRatio;
 
     private Config(Builder builder) {
@@ -70,11 +67,8 @@ public class Config {
         this.slowRenderingDetectionEnabled = builder.slowRenderingDetectionEnabled;
         this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
         this.diskBufferingEnabled = builder.diskBufferingEnabled;
-<<<<<<< HEAD
         this.maxUsageMegabytes = builder.maxUsageMegabytes;
         this.sessionBasedSamplerEnabled = builder.sessionBasedSamplerEnabled;
-=======
->>>>>>> 34aba40 (Remove redundant configuration option.)
         this.sessionBasedSamplerRatio = builder.sessionBasedSamplerRatio;
     }
 
@@ -170,7 +164,6 @@ public class Config {
     }
 
     /**
-<<<<<<< HEAD
      * Returns the max number of megabytes that will be used to buffer telemetry data in storage.
      * If this value is exceeded, older telemetry will be deleted until the usage is reduced.
      */
@@ -186,8 +179,6 @@ public class Config {
     }
 
     /**
-=======
->>>>>>> 34aba40 (Remove redundant configuration option.)
      * Get ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions).
      */
     public double getSessionBasedSamplerRatio() {
@@ -447,7 +438,7 @@ public class Config {
          *
          * @return {@code this}.
          */
-        public Builder sessionBasedSamplingRatio(double ratio) {
+        public Builder enableSessionBasedSampling(double ratio) {
             if (ratio < 0.0) {
                 Log.e(SplunkRum.LOG_TAG, "invalid sessionBasedSamplingRatio: " + ratio + " must not be negative");
                 return this;
@@ -456,6 +447,7 @@ public class Config {
                 return this;
             }
 
+            this.sessionBasedSamplerEnabled = true;
             this.sessionBasedSamplerRatio = ratio;
             return this;
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -50,8 +50,11 @@ public class Config {
     private final boolean slowRenderingDetectionEnabled;
     private final Duration slowRenderingDetectionPollInterval;
     private final boolean diskBufferingEnabled;
+<<<<<<< HEAD
     private final int maxUsageMegabytes;
     private final boolean sessionBasedSamplerEnabled;
+=======
+>>>>>>> 34aba40 (Remove redundant configuration option.)
     private final double sessionBasedSamplerRatio;
 
     private Config(Builder builder) {
@@ -67,8 +70,11 @@ public class Config {
         this.slowRenderingDetectionEnabled = builder.slowRenderingDetectionEnabled;
         this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
         this.diskBufferingEnabled = builder.diskBufferingEnabled;
+<<<<<<< HEAD
         this.maxUsageMegabytes = builder.maxUsageMegabytes;
         this.sessionBasedSamplerEnabled = builder.sessionBasedSamplerEnabled;
+=======
+>>>>>>> 34aba40 (Remove redundant configuration option.)
         this.sessionBasedSamplerRatio = builder.sessionBasedSamplerRatio;
     }
 
@@ -164,6 +170,7 @@ public class Config {
     }
 
     /**
+<<<<<<< HEAD
      * Returns the max number of megabytes that will be used to buffer telemetry data in storage.
      * If this value is exceeded, older telemetry will be deleted until the usage is reduced.
      */
@@ -179,6 +186,8 @@ public class Config {
     }
 
     /**
+=======
+>>>>>>> 34aba40 (Remove redundant configuration option.)
      * Get ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions).
      */
     public double getSessionBasedSamplerRatio() {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -51,6 +51,8 @@ public class Config {
     private final Duration slowRenderingDetectionPollInterval;
     private final boolean diskBufferingEnabled;
     private final int maxUsageMegabytes;
+    private final boolean sessionBasedSamplerEnabled;
+    private final double sessionBasedSamplerRatio;
 
     private Config(Builder builder) {
         this.beaconEndpoint = builder.beaconEndpoint;
@@ -66,6 +68,8 @@ public class Config {
         this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
         this.diskBufferingEnabled = builder.diskBufferingEnabled;
         this.maxUsageMegabytes = builder.maxUsageMegabytes;
+        this.sessionBasedSamplerEnabled = builder.sessionBasedSamplerEnabled;
+        this.sessionBasedSamplerRatio = builder.sessionBasedSamplerRatio;
     }
 
     private Attributes addDeploymentEnvironment(Builder builder) {
@@ -168,6 +172,20 @@ public class Config {
     }
 
     /**
+     * Is session-based sampling of traces enabled or not.
+     */
+    public boolean isSessionBasedSamplerEnabled() {
+        return sessionBasedSamplerEnabled;
+    }
+
+    /**
+     * Get ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions).
+     */
+    public double getSessionBasedSamplerRatio() {
+        return sessionBasedSamplerRatio;
+    }
+
+    /**
      * Create a new instance of the {@link Builder} class. All default configuration options will be pre-populated.
      */
     public static Builder builder() {
@@ -214,6 +232,8 @@ public class Config {
         private String realm;
         private Duration slowRenderingDetectionPollInterval = DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
         private int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;
+        private boolean sessionBasedSamplerEnabled = false;
+        private double sessionBasedSamplerRatio = 1.0;
 
         /**
          * Create a new instance of {@link Config} from the options provided.
@@ -399,6 +419,35 @@ public class Config {
          */
         public Builder limitDiskUsageMegabytes(int maxUsageMegabytes) {
             this.maxUsageMegabytes = maxUsageMegabytes;
+            return this;
+        }
+
+        /**
+         * Enable/disable session-based sampling of traces. Disabled by default.
+         *
+         * @return {@code this}.
+         */
+        public Builder sessionBasedSamplingEnabled(boolean enabled) {
+            this.sessionBasedSamplerEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Set ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions). Default is
+         * 1.0.
+         *
+         * @return {@code this}.
+         */
+        public Builder sessionBasedSamplingRatio(double ratio) {
+            if (ratio < 0.0) {
+                Log.e(SplunkRum.LOG_TAG, "invalid sessionBasedSamplingRatio: " + ratio + " must not be negative");
+                return this;
+            } else if (ratio > 1.0) {
+                Log.e(SplunkRum.LOG_TAG, "invalid sessionBasedSamplingRatio: " + ratio + " must not be greater than 1.0");
+                return this;
+            }
+
+            this.sessionBasedSamplerRatio = ratio;
             return this;
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -238,7 +238,7 @@ class RumInitializer {
                 .setResource(resource);
         initializationEvents.add(new RumInitializer.InitializationEvent("tracerProviderBuilderInitialized", timingClock.now()));
 
-        if (config.isSessionBasedSamplerEnabled()) {
+        if (config.getSessionBasedSamplerRatio() != 1.0) {
             tracerProviderBuilder.setSampler(Sampler.parentBased(new SessionIdRatioBasedSampler(config.getSessionBasedSamplerRatio(), sessionId)));
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -238,7 +238,7 @@ class RumInitializer {
                 .setResource(resource);
         initializationEvents.add(new RumInitializer.InitializationEvent("tracerProviderBuilderInitialized", timingClock.now()));
 
-        if (config.getSessionBasedSamplerRatio() != 1.0) {
+        if (config.isSessionBasedSamplerEnabled()) {
             tracerProviderBuilder.setSampler(Sampler.parentBased(new SessionIdRatioBasedSampler(config.getSessionBasedSamplerRatio(), sessionId)));
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -56,7 +56,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
@@ -239,7 +238,7 @@ class RumInitializer {
         initializationEvents.add(new RumInitializer.InitializationEvent("tracerProviderBuilderInitialized", timingClock.now()));
 
         if (config.isSessionBasedSamplerEnabled()) {
-            tracerProviderBuilder.setSampler(Sampler.parentBased(new SessionIdRatioBasedSampler(config.getSessionBasedSamplerRatio(), sessionId)));
+            tracerProviderBuilder.setSampler(new SessionIdRatioBasedSampler(config.getSessionBasedSamplerRatio(), sessionId));
         }
 
         if (config.isDebugEnabled()) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+/**
+ * Session ID ratio based sampler. Uses {@link Sampler#traceIdRatioBased(double)} sampler
+ * internally, but passes sessionId instead of traceId to the underlying sampler in order to use the
+ * same ratio logic but on sessionId instead. This is valid as {@link SessionId} uses
+ * {@link io.opentelemetry.api.trace.TraceId#fromLongs(long, long)} internally to generate random
+ * session IDs.
+ */
+class SessionIdRatioBasedSampler implements Sampler {
+    private final SessionId sessionId;
+    private final Sampler ratioBasedSampler;
+
+    SessionIdRatioBasedSampler(double ratio, SessionId sessionId) {
+        this.sessionId = sessionId;
+        // SessionId uses the same format as TraceId, so we can reuse trace ID ratio sampler.
+        this.ratioBasedSampler = Sampler.traceIdRatioBased(ratio);
+    }
+
+    @Override
+    public SamplingResult shouldSample(Context parentContext, String traceId, String name, SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+        // Replace traceId with sessionId
+        return ratioBasedSampler.shouldSample(parentContext, sessionId.getSessionId(), name, spanKind, attributes, parentLinks);
+    }
+
+    @Override
+    public String getDescription() {
+        return String.format("SessionIdRatioBased{traceIdRatioBased:%s}", this.ratioBasedSampler.getDescription());
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdRatioBasedSamplerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdRatioBasedSamplerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionIdRatioBasedSamplerTest {
+    private static final String HIGH_ID = "00000000000000008fffffffffffffff";
+    private static final String LOW_ID = "00000000000000000000000000000000";
+    private static final IdGenerator idsGenerator = IdGenerator.random();
+
+    private final String traceId = idsGenerator.generateTraceId();
+    private final Context parentContext = Context.root().with(Span.getInvalid());
+    private final List<LinkData> parentLinks = Collections.singletonList(LinkData.create(SpanContext.getInvalid()));
+
+    @Test
+    public void samplerUsesSessionId() {
+        SessionId sessionId = mock(SessionId.class);
+        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, sessionId);
+
+        // Sampler drops if TraceIdRatioBasedSampler would drop this sessionId
+        when(sessionId.getSessionId()).thenReturn(HIGH_ID);
+        assertEquals(shouldSample(sampler), SamplingDecision.DROP);
+
+        // Sampler accepts if TraceIdRatioBasedSampler would accept this sessionId
+        when(sessionId.getSessionId()).thenReturn(LOW_ID);
+        assertEquals(shouldSample(sampler), SamplingDecision.RECORD_AND_SAMPLE);
+    }
+
+    @Test
+    public void zeroRatioDropsAll() {
+        SessionId sessionId = mock(SessionId.class);
+        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.0, sessionId);
+
+        for (String id : Arrays.asList(HIGH_ID, LOW_ID)) {
+            when(sessionId.getSessionId()).thenReturn(id);
+            assertEquals(shouldSample(sampler), SamplingDecision.DROP);
+        }
+    }
+
+    @Test
+    public void oneRatioAcceptsAll() {
+        SessionId sessionId = mock(SessionId.class);
+        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(1.0, sessionId);
+        
+        for (String id : Arrays.asList(HIGH_ID, LOW_ID)) {
+            when(sessionId.getSessionId()).thenReturn(id);
+            assertEquals(shouldSample(sampler), SamplingDecision.RECORD_AND_SAMPLE);
+        }
+    }
+
+    private SamplingDecision shouldSample(Sampler sampler) {
+        return sampler.shouldSample(parentContext, traceId, "name", SpanKind.INTERNAL, Attributes.empty(), parentLinks).getDecision();
+    }
+}


### PR DESCRIPTION
Added a session ID based sampler. This is enabled by setting `sessionBasedSamplingEnabled(boolean)` to `true` and specifying the ratio via `sessionBasedSamplingRatio(double)` to the desired ratio.

Internally it reuses `TraceIdRatioBasedSampler` from `io.opentelemetry:opentelemetry-sdk-trace`, as the logic is identical to what we need (and what is used in `SessionBasedSampler` of `splunk-otel-js-web`), but passes in the current session ID to it instead of `traceId`.