### PR TITLE
Disable desugaring for volley

### DIFF
--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -28,8 +28,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility(JavaVersion.VERSION_1_8)
         targetCompatibility(JavaVersion.VERSION_1_8)
     }
@@ -74,7 +72,6 @@ dependencies {
     testImplementation("com.google.mockwebserver:mockwebserver:20130706")
     testImplementation("com.android.volley:volley:1.2.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Currently executing `./gradlew tasks` fails with
```
* What went wrong:
Execution failed for task ':tasks'.
> Could not create task ':splunk-otel-android-volley:l8DexDesugarLibDebugAndroidTest'.
   > coreLibraryDesugaring configuration contains no dependencies. If you intend to enable core library desugaring, please add dependencies to coreLibraryDesugaring configuration.
```
An alternative fix would be to add `coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")` As currently volley does not need desugaring (build would fail if it really needed it) I just removed the desugaring.