### PR TITLE
Add ability to limit disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Version 0.14.0 [Unreleased]
 
+* Add ability to limit storage usage for buffered telemetry (#TBD)
+
 ## Version 0.13.0
 
 * Update RUM property to support GDI spec 1.2 (#198)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ when initializing your instance of the SplunkRum API:
 - `diskBufferingEnabled(boolean)` : 
   Enables the storage-based buffering of telemetry. 
   This setting is useful when instrumenting applications that might work offline for extended periods of time.
+- `limitDiskUsageMegabytes(int)` :
+  When disk buffering is enabled, this can be used to adjust the maximum amount of storage
+  that will be used. Default = 25MB.
+
 
 #### APIs provided by the `SplunkRum` instance:
 

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -36,6 +36,7 @@ public class SampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
         Config config = SplunkRum.newConfigBuilder()
                 // note: for these values to be resolved, put them in your local.properties file as
                 // rum.beacon.url and rum.access.token
@@ -46,6 +47,7 @@ public class SampleApplication extends Application {
                 .debugEnabled(true)
                 .diskBufferingEnabled(true)
                 .deploymentEnvironment("demo")
+                .limitDiskUsageMegabytes(1)
                 .globalAttributes(
                         Attributes.builder()
                                 .put("vendor", "Splunk")

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB;
+
 import android.util.Log;
 
 import java.time.Duration;
@@ -48,6 +50,7 @@ public class Config {
     private final boolean slowRenderingDetectionEnabled;
     private final Duration slowRenderingDetectionPollInterval;
     private final boolean diskBufferingEnabled;
+    private final int maxUsageMegabytes;
 
     private Config(Builder builder) {
         this.beaconEndpoint = builder.beaconEndpoint;
@@ -62,6 +65,7 @@ public class Config {
         this.slowRenderingDetectionEnabled = builder.slowRenderingDetectionEnabled;
         this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
         this.diskBufferingEnabled = builder.diskBufferingEnabled;
+        this.maxUsageMegabytes = builder.maxUsageMegabytes;
     }
 
     private Attributes addDeploymentEnvironment(Builder builder) {
@@ -156,6 +160,14 @@ public class Config {
     }
 
     /**
+     * Returns the max number of megabytes that will be used to buffer telemetry data in storage.
+     * If this value is exceeded, older telemetry will be deleted until the usage is reduced.
+     */
+    public int getMaxUsageMegabytes() {
+        return maxUsageMegabytes;
+    }
+
+    /**
      * Create a new instance of the {@link Builder} class. All default configuration options will be pre-populated.
      */
     public static Builder builder() {
@@ -201,6 +213,7 @@ public class Config {
         private final SpanFilterBuilder spanFilterBuilder = new SpanFilterBuilder();
         private String realm;
         private Duration slowRenderingDetectionPollInterval = DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
+        private int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;
 
         /**
          * Create a new instance of {@link Config} from the options provided.
@@ -377,6 +390,11 @@ public class Config {
          */
         public Builder filterSpans(Consumer<SpanFilterBuilder> configurer) {
             configurer.accept(spanFilterBuilder);
+            return this;
+        }
+
+        public Builder limitDiskUsageMegabytes(int maxUsageMegabytes) {
+            this.maxUsageMegabytes = maxUsageMegabytes;
             return this;
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -393,6 +393,10 @@ public class Config {
             return this;
         }
 
+        /**
+         * Sets the limit of the max number of megabytes that will be used to buffer telemetry data in storage.
+         * When this value is exceeded, older telemetry will be deleted until the usage is reduced.
+         */
         public Builder limitDiskUsageMegabytes(int maxUsageMegabytes) {
             this.maxUsageMegabytes = maxUsageMegabytes;
             return this;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
@@ -1,0 +1,92 @@
+package com.splunk.rum;
+
+import static com.splunk.rum.SplunkRum.LOG_TAG;
+import static java.util.Comparator.comparingLong;
+
+import android.util.Log;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class DeviceSpanStorageLimiter {
+    private static final int DEFAULT_MAX_STORAGE_USE_MB = 25;
+    private final File path;
+    private final int maxStorageUseMb;
+    private final FileUtils fileUtils;
+
+    private DeviceSpanStorageLimiter(Builder builder) {
+        this.path = builder.path;
+        this.maxStorageUseMb = builder.maxStorageUseMb;
+        this.fileUtils = builder.fileUtils;
+    }
+
+    /**
+     * Ensures that the storage currently used by spans has not exceeded the limit.
+     * If it does, it will delete older files until the limit is no longer exceeded.
+     *
+     * @return - true if the free space is under the limit (including when files have
+     * been deleted to return back under the limit), false if not enough space could be
+     * freed to get us back under out limit.
+     */
+    boolean ensureFreeSpace() {
+        tryFreeingSpace();
+        return path.getFreeSpace() > limitInBytes();
+    }
+
+    private void tryFreeingSpace() {
+        long currentUsageInBytes = fileUtils.getTotalFileSizeInBytes(path);
+        if (underLimit(currentUsageInBytes)) {
+            return; // nothing to do
+        }
+        List<File> files = fileUtils.listSpanFiles(path)
+                .sorted(comparingLong(fileUtils::getModificationTime))
+                .collect(Collectors.toList());
+        for (File file : files) {
+            Log.w(LOG_TAG, "Too much data buffered, dropping file " + file);
+            long fileSize = fileUtils.getFileSize(file);
+            fileUtils.safeDelete(file);
+            currentUsageInBytes -= fileSize;
+            if (underLimit(currentUsageInBytes)) {
+                return;
+            }
+        }
+    }
+
+    private boolean underLimit(long currentUsageInBytes) {
+        return currentUsageInBytes < limitInBytes();
+    }
+
+    private long limitInBytes() {
+        return maxStorageUseMb * 1024L * 1024L;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static class Builder {
+        private File path;
+        private int maxStorageUseMb = DEFAULT_MAX_STORAGE_USE_MB;
+        private FileUtils fileUtils = new FileUtils();
+
+        Builder path(File path) {
+            this.path = path;
+            return this;
+        }
+
+        Builder maxStorageUseMb(int maxStorageUseMb) {
+            this.maxStorageUseMb = maxStorageUseMb;
+            return this;
+        }
+
+        Builder fileUtils(FileUtils fileUtils) {
+            this.fileUtils = fileUtils;
+            return this;
+        }
+
+        DeviceSpanStorageLimiter build() {
+            return new DeviceSpanStorageLimiter(this);
+        }
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
@@ -25,12 +25,16 @@ class DeviceSpanStorageLimiter {
      * Ensures that the storage currently used by spans has not exceeded the limit.
      * If it does, it will delete older files until the limit is no longer exceeded.
      *
+     * This method also looks at the free space on the device and will return false if
+     * the available free space is less than our max storage.
+     *
      * @return - true if the free space is under the limit (including when files have
      * been deleted to return back under the limit), false if not enough space could be
      * freed to get us back under out limit.
      */
     boolean ensureFreeSpace() {
         tryFreeingSpace();
+        // play nice if disk is getting full
         return path.getFreeSpace() > limitInBytes();
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 class DeviceSpanStorageLimiter {
-    private static final int DEFAULT_MAX_STORAGE_USE_MB = 25;
+    static final int DEFAULT_MAX_STORAGE_USE_MB = 25;
     private final File path;
     private final int maxStorageUseMb;
     private final FileUtils fileUtils;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
@@ -85,9 +85,7 @@ class DiskToZipkinExporter {
     }
 
     private List<File> getPendingFiles() {
-        return fileUtils.listFiles(spanFilesPath)
-                .filter(fileUtils::isRegularFile)
-                .filter(file -> file.toString().endsWith(".spans"))
+        return fileUtils.listSpanFiles(spanFilesPath)
                 .sorted(Comparator.comparing(File::getName))
                 .collect(Collectors.toList());
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
@@ -3,11 +3,15 @@ package com.splunk.rum;
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 
 import android.app.Application;
+import android.system.ErrnoException;
+import android.system.Os;
+import android.system.StructStat;
 import android.util.AtomicFile;
 import android.util.Log;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -16,19 +20,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 // Basic wrapper around filesystem operations, primarily for testing
 class FileUtils {
 
-    static File getSpansDirectory(Application application){
+    static File getSpansDirectory(Application application) {
         File filesDir = application.getApplicationContext().getFilesDir();
         return new File(filesDir, "spans");
     }
 
     void writeAsLines(File file, List<byte[]> blocksOfData) throws IOException {
         AtomicFile outfile = new AtomicFile(file);
-        try(FileOutputStream out = outfile.startWrite()){
+        try (FileOutputStream out = outfile.startWrite()) {
             for (byte[] encodedSpan : blocksOfData) {
                 out.write(encodedSpan);
                 out.write('\n');
@@ -39,10 +44,10 @@ class FileUtils {
 
     List<byte[]> readFileCompletely(File file) throws IOException {
         List<byte[]> result = new ArrayList<>();
-        try(FileReader fileReader = new FileReader(file)){
-            try(BufferedReader buff = new BufferedReader(fileReader)){
+        try (FileReader fileReader = new FileReader(file)) {
+            try (BufferedReader buff = new BufferedReader(fileReader)) {
                 String line;
-                while((line = buff.readLine()) != null){
+                while ((line = buff.readLine()) != null) {
                     result.add(line.getBytes(StandardCharsets.UTF_8));
                 }
             }
@@ -52,18 +57,49 @@ class FileUtils {
 
     Stream<File> listFiles(File dir) {
         File[] files = dir.listFiles();
-        if(files == null) {
+        if (files == null) {
             return Stream.empty();
         }
         return Arrays.stream(files);
     }
 
-    boolean isRegularFile(File file){
+    Stream<File> listSpanFiles(File dir) {
+        return listFiles(dir)
+                .filter(this::isRegularFile)
+                .filter(file -> file.toString().endsWith(".spans"));
+    }
+
+    long getTotalFileSizeInBytes(File dir) {
+        return listFiles(dir)
+                .reduce(0L, (acc, file) -> acc + getFileSize(file), Long::sum);
+    }
+
+    long getFileSize(File file) {
+        try {
+            StructStat structStat = Os.stat(file.getCanonicalPath());
+            return structStat.st_size;
+        } catch (ErrnoException | IOException e) {
+            Log.w(LOG_TAG, "Error getting file size for " + file, e);
+            return 0L;
+        }
+    }
+
+    long getModificationTime(File file) {
+        try {
+            StructStat structStat = Os.stat(file.getCanonicalPath());
+            return structStat.st_mtime;
+        } catch (ErrnoException | IOException e) {
+            Log.w(LOG_TAG, "Error getting file size for " + file, e);
+            return 0L;
+        }
+    }
+
+    boolean isRegularFile(File file) {
         return file.isFile();
     }
 
     void safeDelete(File file) {
-        if(!file.delete()){
+        if (!file.delete()) {
             Log.w(LOG_TAG, "Error deleting file " + file);
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -308,9 +308,7 @@ class RumInitializer {
     }
 
     SpanExporter getToDiskExporter(){
-        return new LazyInitSpanExporter(() -> {
-            return ZipkinWriteToDiskExporterFactory.create(application);
-        });
+        return new LazyInitSpanExporter(() -> ZipkinWriteToDiskExporterFactory.create(application, config));
     }
 
     //visible for testing

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
@@ -27,7 +27,16 @@ class ZipkinWriteToDiskExporterFactory {
             }
         }
 
-        Sender sender = new ZipkinToDiskSender(spansPath);
+        FileUtils fileUtils = new FileUtils();
+        DeviceSpanStorageLimiter limiter = DeviceSpanStorageLimiter.builder()
+                .fileUtils(fileUtils)
+                .path(spansPath)
+                .build();
+        Sender sender = ZipkinToDiskSender.builder()
+                .path(spansPath)
+                .fileUtils(fileUtils)
+                .storageLimiter(limiter)
+                .build();
         return ZipkinSpanExporter.builder()
                 .setEncoder(new CustomZipkinEncoder())
                 .setSender(sender)

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
@@ -18,7 +18,7 @@ class ZipkinWriteToDiskExporterFactory {
     private ZipkinWriteToDiskExporterFactory(){
     }
 
-    static ZipkinSpanExporter create(Application application) {
+    static ZipkinSpanExporter create(Application application, Config config) {
         File spansPath = FileUtils.getSpansDirectory(application);
         if (!spansPath.exists()) {
             if(!spansPath.mkdirs()){
@@ -31,6 +31,7 @@ class ZipkinWriteToDiskExporterFactory {
         DeviceSpanStorageLimiter limiter = DeviceSpanStorageLimiter.builder()
                 .fileUtils(fileUtils)
                 .path(spansPath)
+                .maxStorageUseMb(config.getMaxUsageMegabytes())
                 .build();
         Sender sender = ZipkinToDiskSender.builder()
                 .path(spansPath)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
@@ -1,0 +1,89 @@
+package com.splunk.rum;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeviceSpanStorageLimiterTest {
+
+    private static final int MAX_STORAGE_USE_MB = 3;
+    private static final long MAX_STORAGE_USE_BYTES = MAX_STORAGE_USE_MB * 1024 * 1024;
+    @Mock
+    private FileUtils fileUtils;
+    @Mock
+    private File path;
+    private DeviceSpanStorageLimiter limiter;
+
+    @Before
+    public void setup(){
+        limiter = DeviceSpanStorageLimiter.builder()
+                .fileUtils(fileUtils)
+                .path(path)
+                .maxStorageUseMb(MAX_STORAGE_USE_MB)
+                .build();
+    }
+
+    @Test
+    public void ensureFreeSpace_littleUsageEnoughFreeSpace() {
+        when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(10 * 1024L);
+        when(path.getFreeSpace()).thenReturn(99L);// Disk is very full
+        assertFalse(limiter.ensureFreeSpace());
+        verify(fileUtils, never()).safeDelete(any());
+    }
+
+    @Test
+    public void ensureFreeSpace_littleUsageButNotEnoughFreeSpace() {
+        when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(10 * 1024L);
+        when(path.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES*99);// lots of room
+        assertTrue(limiter.ensureFreeSpace());
+        verify(fileUtils, never()).safeDelete(any());
+    }
+
+    @Test
+    public void ensureFreeSpace_underLimit() {
+        when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(MAX_STORAGE_USE_BYTES - 1);
+        when(path.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES + 1);
+        boolean result = limiter.ensureFreeSpace();
+        assertTrue(result);
+        verify(fileUtils, never()).safeDelete(any());
+    }
+
+    @Test
+    public void ensureFreeSpace_overLimitHappyDeletion() {
+        File file1 = new File("oldest");
+        File file2 = new File("younger");
+        File file3 = new File("newest");
+
+        when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(MAX_STORAGE_USE_BYTES + 1);
+        when(fileUtils.getModificationTime(file1)).thenReturn(1000L);
+        when(fileUtils.getModificationTime(file2)).thenReturn(1001L);
+        when(fileUtils.getModificationTime(file3)).thenReturn(1002L);
+        when(fileUtils.getFileSize(isA(File.class))).thenReturn(1L);
+        when(fileUtils.listSpanFiles(path)).thenReturn(Stream.of(file3, file1, file2));
+        when(path.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES + 1);
+
+        boolean result = limiter.ensureFreeSpace();
+
+        verify(fileUtils).safeDelete(file1);
+        verify(fileUtils).safeDelete(file2);
+        verify(fileUtils, never()).safeDelete(file3);
+        assertTrue(result);
+    }
+
+
+
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
@@ -41,10 +41,7 @@ public class DiskToZipkinExporterTest {
         when(connectionUtil.refreshNetworkStatus()).thenReturn(currentNetwork);
         when(currentNetwork.isOnline()).thenReturn(true);
         Stream<File> files = Stream.of(file1, imposter, file2);
-        when(fileUtils.listFiles(spanFilesPath)).thenReturn(files);
-        when(fileUtils.isRegularFile(file1)).thenReturn(true);
-        when(fileUtils.isRegularFile(file2)).thenReturn(true);
-        when(fileUtils.isRegularFile(imposter)).thenReturn(true);
+        when(fileUtils.listSpanFiles(spanFilesPath)).thenReturn(files);
     }
 
     @Test
@@ -98,7 +95,7 @@ public class DiskToZipkinExporterTest {
 
     @Test
     public void testOtherExceptionsHandled() throws Exception {
-        when(fileUtils.listFiles(spanFilesPath)).thenThrow(new RuntimeException("unexpected!"));
+        when(fileUtils.listSpanFiles(spanFilesPath)).thenThrow(new RuntimeException("unexpected!"));
         DiskToZipkinExporter exporter = buildExporter();
 
         exporter.doExportCycle();


### PR DESCRIPTION
When through-disk buffering is enabled, we want to prevent filling. up the disk if the telemetry cannot be exported for long periods of time (like when camping or in airplane mode). This introduces a default 25MB limit for telemetry on disk, along with a configuration option to adjust this limit. 

When the limit has been reached, older telemetry will be deleted to make room for new telemetry. This effectively creates a time-based ring buffer for telemetry.