### PR TITLE
Add SplunkRUM.isInitialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ class MyApplication extends Application {
 Examples of this process can be seen in the sample application included in this repository in
 the `sample-app` submodule.
 
+To check whether the RUM library has been initialized, call `SplunkRUM.isInitialized()`.
+
 ### Instrument WebViews using the Browser RUM agent
 
 Mobile RUM instrumentation and Browser RUM instrumentation can be used

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ class MyApplication extends Application {
 Examples of this process can be seen in the sample application included in this repository in
 the `sample-app` submodule.
 
-To check whether the RUM library has been initialized, call `SplunkRUM.isInitialized()`.
+To check whether the RUM library has been initialized, call `SplunkRum.isInitialized()`.
 
 ### Instrument WebViews using the Browser RUM agent
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -131,6 +131,14 @@ public class SplunkRum {
     }
 
     /**
+     *
+     * @return True if the Splunk RUM library has been successfully initialized.
+     */
+    public static boolean isInitialized() {
+        return INSTANCE != null;
+    }
+
+    /**
      * Get the singleton instance of this class.
      */
     public static SplunkRum getInstance() {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -132,7 +132,7 @@ public class SplunkRum {
 
     /**
      *
-     * @return True if the Splunk RUM library has been successfully initialized.
+     * @return true if the Splunk RUM library has been successfully initialized.
      */
     public static boolean isInitialized() {
         return INSTANCE != null;


### PR DESCRIPTION
Added `SplunkRUM.isInitialized` method and mentioned it in documentation. Since initialization as shown in the documentation makes it effectively thread-safe (unless used from threads started before that), the non-volatility of this (and `getInstance`) doesn't really need to be mentioned explicitly.