### PR TITLE
Crash reporting enhancements

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -57,6 +57,10 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 
 class RumInitializer {
 
+    // we're setting a fairly large length limit to capture long stack traces; ~256 lines,
+    // assuming 128 chars per line
+    static final int MAX_ATTRIBUTE_LENGTH = 256 * 128;
+
     private final Config config;
     private final Application application;
     private final AppStartupTimer startupTimer;
@@ -295,7 +299,9 @@ class RumInitializer {
                         .addSpanProcessor(batchSpanProcessor)
                         .addSpanProcessor(attributeAppender)
                         .setSpanLimits(
-                                SpanLimits.builder().setMaxAttributeValueLength(2048).build())
+                                SpanLimits.builder()
+                                        .setMaxAttributeValueLength(MAX_ATTRIBUTE_LENGTH)
+                                        .build())
                         .setResource(resource);
         initializationEvents.add(
                 new RumInitializer.InitializationEvent(

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -128,7 +128,10 @@ public class RumInitializerTest {
 
         AttributeKey<String> longAttributeKey = stringKey("longAttribute");
         splunkRum.addRumEvent(
-                "testEvent", Attributes.of(longAttributeKey, Strings.repeat("a", 3000)));
+                "testEvent",
+                Attributes.of(
+                        longAttributeKey,
+                        Strings.repeat("a", RumInitializer.MAX_ATTRIBUTE_LENGTH + 1)));
 
         splunkRum.flushSpans();
         List<SpanData> spans = testExporter.getFinishedSpanItems();
@@ -137,7 +140,7 @@ public class RumInitializerTest {
         SpanData eventSpan = spans.get(0);
         assertEquals("testEvent", eventSpan.getName());
         String truncatedValue = eventSpan.getAttributes().get(longAttributeKey);
-        assertEquals(Strings.repeat("a", 2048), truncatedValue);
+        assertEquals(Strings.repeat("a", RumInitializer.MAX_ATTRIBUTE_LENGTH), truncatedValue);
     }
 
     /** Verify that we have buffering in place in our exporter implementation. */


### PR DESCRIPTION
This PR contains 2 changes:
* the attribute value length was increased, so that bigger exception stack traces would fit in
* only the first uncaught exception is treated as a crash, every next one will be marked as an ordinary error