### PR TITLE
Use docker image from corporate cache in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
     file: '/prodsec/.oss-scan.yml'
 
 image:
-  name: "openjdk:11.0.11-9-jdk"
+  name: "docker-hub.repo.splunkdev.net/openjdk:11.0.11-9-jdk"
 
 variables:
   ANDROID_COMPILE_SDK: "30"


### PR DESCRIPTION
Should help with reducing the `toomanyrequests` problems.