### PR TITLE
Add nullaway and errorprone checks

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,4 +23,6 @@ dependencies {
     implementation("com.android.tools.build:gradle:7.2.2")
 
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.9.0")
+    implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.2")
+    implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.3.0")
 }

--- a/buildSrc/src/main/kotlin/splunk.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.errorprone-conventions.gradle.kts
@@ -1,0 +1,38 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
+import net.ltgt.gradle.nullaway.nullaway
+
+plugins {
+    id("net.ltgt.errorprone")
+    id("net.ltgt.nullaway")
+}
+
+dependencies {
+    errorprone("com.uber.nullaway:nullaway:0.9.9")
+    errorprone("com.google.errorprone:error_prone_core:2.15.0")
+    errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+}
+
+nullaway {
+    annotatedPackages.add("com.splunk.rum")
+}
+
+tasks {
+    withType<JavaCompile>().configureEach {
+        options.errorprone {
+            if (name.toLowerCase().contains("test")) {
+                // just disable all error prone checks for test
+                isEnabled.set(false);
+            }
+
+            nullaway {
+                severity.set(CheckSeverity.ERROR)
+            }
+
+            // Builder 'return this;' pattern
+            disable("CanIgnoreReturnValueSuggester")
+            // Common to avoid an allocation
+            disable("MixedMutabilityReturnType")
+        }
+    }
+}

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -3,6 +3,7 @@ import java.time.Duration
 plugins {
     id("com.android.library")
     id("splunk.android-library-conventions")
+    id("splunk.errorprone-conventions")
 }
 
 android {

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/RequestWrapper.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/RequestWrapper.java
@@ -16,6 +16,7 @@
 
 package com.splunk.rum;
 
+import androidx.annotation.Nullable;
 import com.android.volley.Request;
 import java.net.URL;
 import java.util.HashMap;
@@ -28,7 +29,7 @@ import java.util.Map;
 public final class RequestWrapper {
     private final Request<?> request;
     private final Map<String, String> additionalHeaders;
-    private URL url;
+    @Nullable private URL url;
 
     RequestWrapper(Request<?> request, Map<String, String> additionalHeaders) {
         this.request = request;
@@ -39,6 +40,7 @@ public final class RequestWrapper {
         this.url = url;
     }
 
+    @Nullable
     URL getUrl() {
         return url;
     }

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesGetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesGetter.java
@@ -43,6 +43,7 @@ enum VolleyHttpClientAttributesGetter
         return null;
     }
 
+    @Nullable
     @Override
     public String method(RequestWrapper requestWrapper) {
         Request<?> request = requestWrapper.getRequest();

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesGetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyNetClientAttributesGetter.java
@@ -30,11 +30,13 @@ enum VolleyNetClientAttributesGetter
         return SemanticAttributes.NetTransportValues.IP_TCP;
     }
 
+    @Nullable
     @Override
     public String peerName(RequestWrapper requestWrapper, @Nullable HttpResponse httpResponse) {
         return requestWrapper.getUrl() != null ? requestWrapper.getUrl().getHost() : null;
     }
 
+    @Nullable
     @Override
     public Integer peerPort(RequestWrapper requestWrapper, @Nullable HttpResponse httpResponse) {
         return requestWrapper.getUrl() != null ? requestWrapper.getUrl().getPort() : null;

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseAttributesExtractor.java
@@ -63,6 +63,7 @@ class VolleyResponseAttributesExtractor
         }
     }
 
+    @Nullable
     private String getHeader(HttpResponse response, String headerName) {
         for (Header header : response.getHeaders()) {
             if (header.getName().equals(headerName)) {

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("splunk.android-library-conventions")
+    id("splunk.errorprone-conventions")
 }
 
 android {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActiveSpan.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActiveSpan.java
@@ -16,6 +16,7 @@
 
 package com.splunk.rum;
 
+import androidx.annotation.Nullable;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import java.util.function.Supplier;
@@ -23,8 +24,8 @@ import java.util.function.Supplier;
 class ActiveSpan {
     private final VisibleScreenTracker visibleScreenTracker;
 
-    private Span span;
-    private Scope scope;
+    @Nullable private Span span;
+    @Nullable private Scope scope;
 
     ActiveSpan(VisibleScreenTracker visibleScreenTracker) {
         this.visibleScreenTracker = visibleScreenTracker;
@@ -34,6 +35,8 @@ class ActiveSpan {
         return span != null;
     }
 
+    // it's fine to not close the scope here, will be closed in endActiveSpan()
+    @SuppressWarnings("MustBeClosedChecker")
     void startSpan(Supplier<Span> spanCreator) {
         // don't start one if there's already one in progress
         if (span != null) {
@@ -65,7 +68,7 @@ class ActiveSpan {
             return;
         }
         String previouslyVisibleScreen = visibleScreenTracker.getPreviouslyVisibleScreen();
-        if (!screenName.equals(previouslyVisibleScreen)) {
+        if (previouslyVisibleScreen != null && !screenName.equals(previouslyVisibleScreen)) {
             span.setAttribute(SplunkRum.LAST_SCREEN_NAME_KEY, previouslyVisibleScreen);
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityCallbacks.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import static java.util.Objects.requireNonNull;
+
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
@@ -43,11 +45,11 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     private int numberOfOpenActivities = 0;
 
     private ActivityCallbacks(Builder builder) {
-        this.tracer = builder.tracer;
-        this.visibleScreenTracker = builder.visibleScreenTracker;
-        this.startupTimer = builder.startupTimer;
-        this.appStateListeners = builder.appStateListeners;
-        this.slowRenderingDetector = builder.slowRenderingDetector;
+        this.tracer = requireNonNull(builder.tracer);
+        this.visibleScreenTracker = requireNonNull(builder.visibleScreenTracker);
+        this.startupTimer = requireNonNull(builder.startupTimer);
+        this.appStateListeners = requireNonNull(builder.appStateListeners);
+        this.slowRenderingDetector = requireNonNull(builder.slowRenderingDetector);
     }
 
     public static Builder builder() {
@@ -212,11 +214,11 @@ class ActivityCallbacks implements Application.ActivityLifecycleCallbacks {
     }
 
     static class Builder {
-        private Tracer tracer;
-        private VisibleScreenTracker visibleScreenTracker;
-        private AppStartupTimer startupTimer;
-        private List<AppStateListener> appStateListeners;
-        private SlowRenderingDetector slowRenderingDetector;
+        @Nullable private Tracer tracer;
+        @Nullable private VisibleScreenTracker visibleScreenTracker;
+        @Nullable private AppStartupTimer startupTimer;
+        @Nullable private List<AppStateListener> appStateListeners;
+        @Nullable private SlowRenderingDetector slowRenderingDetector;
 
         public ActivityCallbacks build() {
             return new ActivityCallbacks(this);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ActivityTracer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ActivityTracer.java
@@ -18,6 +18,7 @@ package com.splunk.rum;
 
 import android.app.Activity;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -110,7 +111,7 @@ class ActivityTracer {
         return createSpanWithParent(spanName, null);
     }
 
-    private Span createSpanWithParent(String spanName, Span parentSpan) {
+    private Span createSpanWithParent(String spanName, @Nullable Span parentSpan) {
         final SpanBuilder spanBuilder =
                 tracer.spanBuilder(spanName)
                         .setAttribute(ACTIVITY_NAME_KEY, activityName)

--- a/splunk-otel-android/src/main/java/com/splunk/rum/AppStartupTimer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/AppStartupTimer.java
@@ -34,8 +34,8 @@ class AppStartupTimer {
     final RumInitializer.AnchoredClock startupClock =
             RumInitializer.AnchoredClock.create(Clock.getDefault());
     private final long firstPossibleTimestamp = startupClock.now();
-    private volatile Span overallAppStartSpan = null;
-    private volatile Runnable completionCallback = null;
+    @Nullable private volatile Span overallAppStartSpan = null;
+    @Nullable private volatile Runnable completionCallback = null;
     // whether activity has been created
     // accessed only from UI thread
     private boolean uiInitStarted = false;
@@ -78,6 +78,7 @@ class AppStartupTimer {
     }
 
     void end() {
+        Span overallAppStartSpan = this.overallAppStartSpan;
         if (overallAppStartSpan != null && !uiInitTooLate && !isStartedFromBackground) {
             runCompletionCallback();
             overallAppStartSpan.end(startupClock.now(), TimeUnit.NANOSECONDS);
@@ -92,6 +93,7 @@ class AppStartupTimer {
 
     // visibleForTesting
     void runCompletionCallback() {
+        Runnable completionCallback = this.completionCallback;
         if (completionCallback != null) {
             completionCallback.run();
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BandwidthTracker.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BandwidthTracker.java
@@ -32,7 +32,7 @@ class BandwidthTracker {
     private final ArrayDeque<Long> sizes = new ArrayDeque<>();
 
     BandwidthTracker() {
-        this(Clock.systemDefaultZone());
+        this(Clock.systemUTC());
     }
 
     // Exists for testing

--- a/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Config.java
@@ -17,14 +17,14 @@
 package com.splunk.rum;
 
 import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB;
+import static java.util.Objects.requireNonNull;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.time.Duration;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Configuration class for the Splunk Android RUM (Real User Monitoring) library.
@@ -46,7 +46,6 @@ public class Config {
     private final boolean networkMonitorEnabled;
     private final boolean anrDetectionEnabled;
     private final Attributes globalAttributes;
-    private final Function<SpanExporter, SpanExporter> spanFilterExporterDecorator;
     private final Consumer<SpanFilterBuilder> spanFilterBuilderConfigurer;
     private final boolean slowRenderingDetectionEnabled;
     private final Duration slowRenderingDetectionPollInterval;
@@ -56,17 +55,16 @@ public class Config {
     private final double sessionBasedSamplerRatio;
 
     private Config(Builder builder) {
-        this.beaconEndpoint = builder.beaconEndpoint;
-        this.rumAccessToken = builder.rumAccessToken;
+        this.beaconEndpoint = requireNonNull(builder.beaconEndpoint);
+        this.rumAccessToken = requireNonNull(builder.rumAccessToken);
         this.debugEnabled = builder.debugEnabled;
-        this.applicationName = builder.applicationName;
+        this.applicationName = requireNonNull(builder.applicationName);
         this.crashReportingEnabled = builder.crashReportingEnabled;
         this.globalAttributes = addDeploymentEnvironment(builder);
         this.networkMonitorEnabled = builder.networkMonitorEnabled;
         this.anrDetectionEnabled = builder.anrDetectionEnabled;
         this.slowRenderingDetectionPollInterval = builder.slowRenderingDetectionPollInterval;
         this.slowRenderingDetectionEnabled = builder.slowRenderingDetectionEnabled;
-        this.spanFilterExporterDecorator = builder.spanFilterBuilder.build();
         this.spanFilterBuilderConfigurer = builder.spanFilterBuilderConfigurer;
         this.diskBufferingEnabled = builder.diskBufferingEnabled;
         this.maxUsageMegabytes = builder.maxUsageMegabytes;
@@ -227,16 +225,16 @@ public class Config {
         private boolean anrDetectionEnabled = true;
         private boolean slowRenderingDetectionEnabled = true;
         private boolean diskBufferingEnabled = false;
-        private String beaconEndpoint;
-        private String rumAccessToken;
+        @Nullable private String beaconEndpoint;
+        @Nullable private String rumAccessToken;
         private boolean debugEnabled = false;
-        private String applicationName;
+        @Nullable private String applicationName;
         private boolean crashReportingEnabled = true;
         private Attributes globalAttributes = Attributes.empty();
-        private String deploymentEnvironment;
+        @Nullable private String deploymentEnvironment;
         private final SpanFilterBuilder spanFilterBuilder = new SpanFilterBuilder();
         private Consumer<SpanFilterBuilder> spanFilterBuilderConfigurer = f -> {};
-        private String realm;
+        @Nullable private String realm;
         private Duration slowRenderingDetectionPollInterval =
                 DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
         private int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConnectionUtil.java
@@ -25,6 +25,7 @@ import android.net.NetworkRequest;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.util.function.Supplier;
 
 // note: based on ideas from stack overflow:
@@ -38,8 +39,8 @@ class ConnectionUtil {
 
     private final NetworkDetector networkDetector;
 
-    private volatile CurrentNetwork currentNetwork;
-    private volatile ConnectionStateListener connectionStateListener;
+    private volatile CurrentNetwork currentNetwork = UNKNOWN_NETWORK;
+    @Nullable private volatile ConnectionStateListener connectionStateListener;
 
     ConnectionUtil(NetworkDetector networkDetector) {
         this.networkDetector = networkDetector;
@@ -111,6 +112,8 @@ class ConnectionUtil {
         public void onAvailable(@NonNull Network network) {
             Log.d(SplunkRum.LOG_TAG, "onAvailable: ");
             CurrentNetwork activeNetwork = refreshNetworkStatus();
+            ConnectionStateListener connectionStateListener =
+                    ConnectionUtil.this.connectionStateListener;
             if (connectionStateListener != null) {
                 connectionStateListener.onAvailable(true, activeNetwork);
                 Log.d(
@@ -131,6 +134,8 @@ class ConnectionUtil {
             // state at the right time during this event.
             CurrentNetwork activeNetwork = NO_NETWORK;
             currentNetwork = activeNetwork;
+            ConnectionStateListener connectionStateListener =
+                    ConnectionUtil.this.connectionStateListener;
             if (connectionStateListener != null) {
                 connectionStateListener.onAvailable(false, activeNetwork);
                 Log.d(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CurrentNetwork.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CurrentNetwork.java
@@ -16,14 +16,15 @@
 
 package com.splunk.rum;
 
+import androidx.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
-class CurrentNetwork {
+final class CurrentNetwork {
     private final NetworkState state;
-    private final String subType;
+    @Nullable private final String subType;
 
-    CurrentNetwork(NetworkState state, String subType) {
+    CurrentNetwork(NetworkState state, @Nullable String subType) {
         this.state = state;
         this.subType = subType;
     }
@@ -32,11 +33,11 @@ class CurrentNetwork {
         return getState() != NetworkState.NO_NETWORK_AVAILABLE;
     }
 
-    public NetworkState getState() {
+    NetworkState getState() {
         return state;
     }
 
-    public Optional<String> getSubType() {
+    Optional<String> getSubType() {
         return Optional.ofNullable(subType);
     }
 
@@ -47,8 +48,12 @@ class CurrentNetwork {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CurrentNetwork)) {
+            return false;
+        }
         CurrentNetwork that = (CurrentNetwork) o;
         return state == that.state && Objects.equals(subType, that.subType);
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
@@ -58,7 +58,7 @@ class CustomZipkinEncoder implements BytesEncoder<Span> {
         // note: this can be optimized, if necessary. Let's keep it simple for now.
         byte[] rawBytes = JsonCodec.write(this.writer, span);
         String renamedResult =
-                new String(rawBytes)
+                new String(rawBytes, StandardCharsets.UTF_8)
                         .replace(
                                 "\"name\":\"" + span.name() + "\"",
                                 "\"name\":\"" + properSpanName + "\"");

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
@@ -18,8 +18,10 @@ package com.splunk.rum;
 
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 import static java.util.Comparator.comparingLong;
+import static java.util.Objects.requireNonNull;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,7 +33,7 @@ class DeviceSpanStorageLimiter {
     private final FileUtils fileUtils;
 
     private DeviceSpanStorageLimiter(Builder builder) {
-        this.path = builder.path;
+        this.path = requireNonNull(builder.path);
         this.maxStorageUseMb = builder.maxStorageUseMb;
         this.fileUtils = builder.fileUtils;
     }
@@ -87,7 +89,7 @@ class DeviceSpanStorageLimiter {
     }
 
     static class Builder {
-        private File path;
+        @Nullable private File path;
         private int maxStorageUseMb = DEFAULT_MAX_STORAGE_USE_MB;
         private FileUtils fileUtils = new FileUtils();
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
@@ -18,8 +18,10 @@ package com.splunk.rum;
 
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import java.io.File;
 import java.util.Comparator;
 import java.util.List;
@@ -46,14 +48,16 @@ class DiskToZipkinExporter {
 
     DiskToZipkinExporter(Builder builder) {
         this.threadPool = builder.threadPool;
-        this.connectionUtil = builder.connectionUtil;
-        this.fileSender = builder.fileSender;
-        this.spanFilesPath = builder.spanFilesPath;
+        this.connectionUtil = requireNonNull(builder.connectionUtil);
+        this.fileSender = requireNonNull(builder.fileSender);
+        this.spanFilesPath = requireNonNull(builder.spanFilesPath);
         this.fileUtils = builder.fileUtils;
-        this.bandwidthTracker = builder.bandwidthTracker;
+        this.bandwidthTracker = requireNonNull(builder.bandwidthTracker);
         this.bandwidthLimit = builder.bandwidthLimit;
     }
 
+    // the returned future is very unlikely to fail
+    @SuppressWarnings("FutureReturnValueIgnored")
     void startPolling() {
         threadPool.scheduleAtFixedRate(this::doExportCycle, 5, 5, TimeUnit.SECONDS);
     }
@@ -116,11 +120,11 @@ class DiskToZipkinExporter {
     }
 
     static class Builder {
-        private FileSender fileSender;
-        private BandwidthTracker bandwidthTracker;
+        @Nullable private FileSender fileSender;
+        @Nullable private BandwidthTracker bandwidthTracker;
         private ScheduledExecutorService threadPool = Executors.newSingleThreadScheduledExecutor();
-        private ConnectionUtil connectionUtil;
-        private File spanFilesPath;
+        @Nullable private ConnectionUtil connectionUtil;
+        @Nullable private File spanFilesPath;
         private FileUtils fileUtils = new FileUtils();
         private double bandwidthLimit = DEFAULT_MAX_UNCOMPRESSED_BANDWIDTH;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -41,11 +41,11 @@ class FileSender {
     private final BandwidthTracker bandwidthTracker;
     private final RetryTracker retryTracker;
 
-    private FileSender(Builder builder, RetryTracker retryTracker) {
+    private FileSender(Builder builder) {
         this.sender = requireNonNull(builder.sender);
         this.fileUtils = builder.fileUtils;
         this.bandwidthTracker = requireNonNull(builder.bandwidthTracker);
-        this.retryTracker = retryTracker;
+        this.retryTracker = builder.buildRetryTracker();
     }
 
     /**
@@ -186,7 +186,11 @@ class FileSender {
         }
 
         FileSender build() {
-            return new FileSender(this, new RetryTracker(maxRetries, backoff));
+            return new FileSender(this);
+        }
+
+        private RetryTracker buildRetryTracker() {
+            return new RetryTracker(maxRetries, backoff);
         }
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -18,8 +18,10 @@ package com.splunk.rum;
 
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,11 +41,11 @@ class FileSender {
     private final BandwidthTracker bandwidthTracker;
     private final RetryTracker retryTracker;
 
-    private FileSender(Builder builder) {
-        this.sender = builder.sender;
+    private FileSender(Builder builder, RetryTracker retryTracker) {
+        this.sender = requireNonNull(builder.sender);
         this.fileUtils = builder.fileUtils;
-        this.bandwidthTracker = builder.bandwidthTracker;
-        this.retryTracker = builder.retryTracker;
+        this.bandwidthTracker = requireNonNull(builder.bandwidthTracker);
+        this.retryTracker = retryTracker;
     }
 
     /**
@@ -151,10 +153,9 @@ class FileSender {
 
     static class Builder {
 
-        private Sender sender;
+        @Nullable private Sender sender;
         private FileUtils fileUtils = new FileUtils();
-        private BandwidthTracker bandwidthTracker;
-        private RetryTracker retryTracker;
+        @Nullable private BandwidthTracker bandwidthTracker;
         private int maxRetries = DEFAULT_MAX_RETRIES;
         private Consumer<Integer> backoff = new DefaultBackoff();
 
@@ -185,8 +186,7 @@ class FileSender {
         }
 
         FileSender build() {
-            this.retryTracker = new RetryTracker(maxRetries, backoff);
-            return new FileSender(this);
+            return new FileSender(this, new RetryTracker(maxRetries, backoff));
         }
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
@@ -26,9 +26,11 @@ import android.util.AtomicFile;
 import android.util.Log;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,12 +58,12 @@ class FileUtils {
 
     List<byte[]> readFileCompletely(File file) throws IOException {
         List<byte[]> result = new ArrayList<>();
-        try (FileReader fileReader = new FileReader(file)) {
-            try (BufferedReader buff = new BufferedReader(fileReader)) {
-                String line;
-                while ((line = buff.readLine()) != null) {
-                    result.add(line.getBytes(StandardCharsets.UTF_8));
-                }
+        try (Reader fileReader =
+                        new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
+                BufferedReader buff = new BufferedReader(fileReader)) {
+            String line;
+            while ((line = buff.readLine()) != null) {
+                result.add(line.getBytes(StandardCharsets.UTF_8));
             }
         }
         return result;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSlowRenderingDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSlowRenderingDetector.java
@@ -16,18 +16,17 @@
 
 package com.splunk.rum;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import android.app.Activity;
 
-/**
- * This annotation can be used to customize the {@code screen.name} attribute for an instrumented
- * Fragment or Activity.
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface RumScreenName {
-    /** Return the customized screen name. */
-    String value();
+enum NoOpSlowRenderingDetector implements SlowRenderingDetector {
+    INSTANCE;
+
+    @Override
+    public void add(Activity activity) {}
+
+    @Override
+    public void stop(Activity activity) {}
+
+    @Override
+    public void start() {}
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/NoOpSplunkRum.java
@@ -30,6 +30,8 @@ import okhttp3.OkHttpClient;
 class NoOpSplunkRum extends SplunkRum {
     static final NoOpSplunkRum INSTANCE = new NoOpSplunkRum();
 
+    // passing null values here is fine, they'll never get used anyway
+    @SuppressWarnings("NullAway")
     private NoOpSplunkRum() {
         super(null, null, null);
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ServerTimingHeaderParser.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ServerTimingHeaderParser.java
@@ -16,6 +16,7 @@
 
 package com.splunk.rum;
 
+import androidx.annotation.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,7 +36,7 @@ class ServerTimingHeaderParser {
      *     <p>This will also consider single-quotes valid for delimiting the "desc" section, even
      *     though it's not to spec.
      */
-    String[] parse(String header) {
+    String[] parse(@Nullable String header) {
         if (header == null) {
             return UNPARSEABLE_RESULT;
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetector.java
@@ -19,23 +19,10 @@ package com.splunk.rum;
 import android.app.Activity;
 
 interface SlowRenderingDetector {
-    SlowRenderingDetector NO_OP = new NoOp();
 
     void add(Activity activity);
 
     void stop(Activity activity);
 
     void start();
-
-    class NoOp implements SlowRenderingDetector {
-
-        @Override
-        public void add(Activity activity) {}
-
-        @Override
-        public void stop(Activity activity) {}
-
-        @Override
-        public void start() {}
-    }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -86,6 +86,8 @@ class SlowRenderingDetectorImpl implements SlowRenderingDetector {
         }
     }
 
+    // the returned future is very unlikely to fail
+    @SuppressWarnings("FutureReturnValueIgnored")
     @Override
     public void start() {
         executorService.scheduleAtFixedRate(
@@ -108,9 +110,13 @@ class SlowRenderingDetectorImpl implements SlowRenderingDetector {
             Log.w(LOG_TAG, "Exception while processing frame metrics", e);
         }
         synchronized (lock) {
-            for (Activity activity : activities) {
-                frameMetrics.remove(activity);
-                frameMetrics.add(activity);
+            try {
+                for (Activity activity : activities) {
+                    frameMetrics.remove(activity);
+                    frameMetrics.add(activity);
+                }
+            } catch (Exception e) {
+                Log.w(LOG_TAG, "Exception updating observed activities", e);
             }
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -18,6 +18,7 @@ package com.splunk.rum;
 
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.location.Location;
@@ -70,7 +71,7 @@ public class SplunkRum {
     static final AttributeKey<String> LINK_TRACE_ID_KEY = stringKey("link.traceId");
     static final AttributeKey<String> LINK_SPAN_ID_KEY = stringKey("link.spanId");
 
-    private static SplunkRum INSTANCE;
+    @Nullable private static SplunkRum INSTANCE;
 
     private final SessionId sessionId;
     private final OpenTelemetrySdk openTelemetrySdk;
@@ -145,9 +146,7 @@ public class SplunkRum {
         return INSTANCE;
     }
 
-    /**
-     * @return true if the Splunk RUM library has been successfully initialized.
-     */
+    /** Returns {@code true} if the Splunk RUM library has been successfully initialized. */
     public static boolean isInitialized() {
         return INSTANCE != null;
     }
@@ -325,7 +324,8 @@ public class SplunkRum {
      */
     public void updateGlobalAttributes(Consumer<AttributesBuilder> attributesUpdater) {
         while (true) {
-            Attributes oldAttributes = globalAttributes.get();
+            // we're absolutely certain this will never be null
+            Attributes oldAttributes = requireNonNull(globalAttributes.get());
 
             AttributesBuilder builder = oldAttributes.toBuilder();
             attributesUpdater.accept(builder);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -20,6 +20,7 @@ import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB
 
 import android.app.Application;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
@@ -33,10 +34,10 @@ public final class SplunkRumBuilder {
     private static final Duration DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL =
             Duration.ofSeconds(1);
 
-    String applicationName;
-    String beaconEndpoint;
-    String rumAccessToken;
-    private String realm;
+    @Nullable String applicationName;
+    @Nullable String beaconEndpoint;
+    @Nullable String rumAccessToken;
+    @Nullable private String realm;
     boolean debugEnabled = false;
     boolean diskBufferingEnabled = false;
     boolean crashReportingEnabled = true;
@@ -45,7 +46,7 @@ public final class SplunkRumBuilder {
     boolean slowRenderingDetectionEnabled = true;
     Duration slowRenderingDetectionPollInterval = DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
     private Attributes globalAttributes = Attributes.empty();
-    private String deploymentEnvironment;
+    @Nullable private String deploymentEnvironment;
     private final SpanFilterBuilder spanFilterBuilder = new SpanFilterBuilder();
     int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;
     boolean sessionBasedSamplerEnabled = false;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/VisibleScreenTracker.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/VisibleScreenTracker.java
@@ -17,6 +17,7 @@
 package com.splunk.rum;
 
 import android.app.Activity;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
@@ -40,6 +41,7 @@ class VisibleScreenTracker {
     private final AtomicReference<String> lastResumedFragment = new AtomicReference<>();
     private final AtomicReference<String> previouslyLastResumedFragment = new AtomicReference<>();
 
+    @Nullable
     String getPreviouslyVisibleScreen() {
         String previouslyLastFragment = previouslyLastResumedFragment.get();
         if (previouslyLastFragment != null) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
@@ -16,10 +16,13 @@
 
 package com.splunk.rum;
 
+import static java.util.Objects.requireNonNull;
+
 import android.util.Log;
+import androidx.annotation.Nullable;
+import io.opentelemetry.sdk.common.Clock;
 import java.io.File;
 import java.io.IOException;
-import java.time.Clock;
 import java.util.List;
 import zipkin2.Call;
 import zipkin2.codec.Encoding;
@@ -33,10 +36,10 @@ class ZipkinToDiskSender extends Sender {
     private final DeviceSpanStorageLimiter storageLimiter;
 
     private ZipkinToDiskSender(Builder builder) {
-        this.path = builder.path;
+        this.path = requireNonNull(builder.path);
         this.fileUtils = builder.fileUtils;
         this.clock = builder.clock;
-        this.storageLimiter = builder.storageLimiter;
+        this.storageLimiter = requireNonNull(builder.storageLimiter);
     }
 
     @Override
@@ -64,7 +67,7 @@ class ZipkinToDiskSender extends Sender {
                             + " spans: Too much telemetry has been buffered or not enough space on device.");
             return Call.create(null);
         }
-        long now = clock.millis();
+        long now = clock.now();
         File filename = createFilename(now);
         try {
             fileUtils.writeAsLines(filename, encodedSpans);
@@ -83,10 +86,10 @@ class ZipkinToDiskSender extends Sender {
     }
 
     static class Builder {
-        private File path;
+        @Nullable private File path;
         private FileUtils fileUtils = new FileUtils();
-        private Clock clock = Clock.systemDefaultZone();
-        private DeviceSpanStorageLimiter storageLimiter;
+        private Clock clock = Clock.getDefault();
+        @Nullable private DeviceSpanStorageLimiter storageLimiter;
 
         Builder path(File path) {
             this.path = path;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.common.Clock;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
@@ -50,7 +50,7 @@ public class ZipkinToDiskSenderTest {
 
     @Before
     public void setup() {
-        when(clock.millis()).thenReturn(now);
+        when(clock.now()).thenReturn(now);
         when(limiter.ensureFreeSpace()).thenReturn(true);
     }
 


### PR DESCRIPTION
I thought it would be useful to add null-safety checking; especially so when we're publishing an API. Errorprone did pick up several minor bugs (like missing charsets, broken double checked locking, etc), but it also made using our internal builder classes kinda painful, as most of them have `@Nullable` fields for components that must be present -- I think we could refactor these in a subsequent PR to make them a bit nicer.