### PR TITLE
Make Carrier final and add toString()

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/Carrier.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/Carrier.java
@@ -23,7 +23,7 @@ import androidx.annotation.RequiresApi;
 import java.util.Objects;
 
 @RequiresApi(api = Build.VERSION_CODES.P)
-class Carrier {
+final class Carrier {
 
     private final int id;
     private final @Nullable String name;
@@ -82,6 +82,26 @@ class Carrier {
     @Override
     public int hashCode() {
         return Objects.hash(id, name, mobileCountryCode, mobileNetworkCode, isoCountryCode);
+    }
+
+    @Override
+    public String toString() {
+        return "Carrier{"
+                + "id="
+                + id
+                + ", name='"
+                + name
+                + '\''
+                + ", mobileCountryCode='"
+                + mobileCountryCode
+                + '\''
+                + ", mobileNetworkCode='"
+                + mobileNetworkCode
+                + '\''
+                + ", isoCountryCode='"
+                + isoCountryCode
+                + '\''
+                + '}';
     }
 
     static class Builder {


### PR DESCRIPTION
I noticed some warnings from errorprone about the `equals()` using `getClass()` instead of `instanceof`. That warning goes away when the class is final, which it really should be anyway. Once that happens, a new warning crops up about `toString()` not being helpful....so I generated that as well.