### PR TITLE
Crash handler join() async flush result

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
@@ -20,8 +20,11 @@ import androidx.annotation.NonNull;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class CrashReporter {
@@ -73,7 +76,8 @@ class CrashReporter {
                     .setStatus(StatusCode.ERROR)
                     .end();
             // do our best to make sure the crash makes it out of the VM
-            sdkTracerProvider.forceFlush();
+            CompletableResultCode result = sdkTracerProvider.forceFlush();
+            result.join(10, TimeUnit.SECONDS);
             // preserve any existing behavior:
             if (existingHandler != null) {
                 existingHandler.uncaughtException(t, e);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 


### PR DESCRIPTION
The `SdkTracerProvider.forceFlush()` method is async, and it returns an instance of  `CompletableResultCode`. In some async implementations, the operation is not actually attempted until the result is awaited...so we ensure that now. 

Even if that isn't the case for this async implementation (I actually don't know), there's still a race with the virtual machine exiting before the flush completes....so we try and hold out for that.

Using the sample app and the emulator, I was not able to ingest crash data until this change was made.