### PR TITLE
Add runtime details to crash span

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
@@ -17,9 +17,10 @@
 package com.splunk.rum;
 
 import androidx.annotation.NonNull;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -28,12 +29,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class CrashReporter {
 
-    static void initializeCrashReporting(Tracer tracer, OpenTelemetrySdk openTelemetrySdk) {
+    static void initializeCrashReporting(
+            Tracer tracer, SdkTracerProvider sdkTracerProvider, RuntimeDetails runtimeDetails) {
         Thread.UncaughtExceptionHandler existingHandler =
                 Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(
                 new CrashReportingExceptionHandler(
-                        tracer, openTelemetrySdk.getSdkTracerProvider(), existingHandler));
+                        tracer, sdkTracerProvider, existingHandler, runtimeDetails));
     }
 
     // visible for testing
@@ -41,15 +43,18 @@ class CrashReporter {
         private final Tracer tracer;
         private final Thread.UncaughtExceptionHandler existingHandler;
         private final SdkTracerProvider sdkTracerProvider;
+        private final RuntimeDetails runtimeDetails;
         private final AtomicBoolean crashHappened = new AtomicBoolean(false);
 
         CrashReportingExceptionHandler(
                 Tracer tracer,
                 SdkTracerProvider sdkTracerProvider,
-                Thread.UncaughtExceptionHandler existingHandler) {
+                Thread.UncaughtExceptionHandler existingHandler,
+                RuntimeDetails runtimeDetails) {
             this.tracer = tracer;
             this.existingHandler = existingHandler;
             this.sdkTracerProvider = sdkTracerProvider;
+            this.runtimeDetails = runtimeDetails;
         }
 
         @Override
@@ -65,18 +70,27 @@ class CrashReporter {
                             : SplunkRum.COMPONENT_ERROR;
 
             String exceptionType = e.getClass().getSimpleName();
-            tracer.spanBuilder(exceptionType)
-                    .setAttribute(SemanticAttributes.THREAD_ID, t.getId())
-                    .setAttribute(SemanticAttributes.THREAD_NAME, t.getName())
-                    .setAttribute(SemanticAttributes.EXCEPTION_ESCAPED, true)
-                    .setAttribute(SplunkRum.COMPONENT_KEY, component)
-                    .startSpan()
-                    .recordException(e)
-                    .setStatus(StatusCode.ERROR)
-                    .end();
+            SpanBuilder builder =
+                    tracer.spanBuilder(exceptionType)
+                            .setAttribute(SemanticAttributes.THREAD_ID, t.getId())
+                            .setAttribute(SemanticAttributes.THREAD_NAME, t.getName())
+                            .setAttribute(SemanticAttributes.EXCEPTION_ESCAPED, true)
+                            .setAttribute(SplunkRum.COMPONENT_KEY, component)
+                            .setAttribute(
+                                    SplunkRum.STORAGE_SPACE_FREE_KEY,
+                                    runtimeDetails.getCurrentStorageFreeSpaceInBytes())
+                            .setAttribute(
+                                    SplunkRum.HEAP_FREE_KEY,
+                                    runtimeDetails.getCurrentFreeHeapInBytes());
+
+            Double currentBatteryPercent = runtimeDetails.getCurrentBatteryPercent();
+            if (currentBatteryPercent != null) {
+                builder.setAttribute(SplunkRum.BATTERY_PERCENT_KEY, currentBatteryPercent);
+            }
+            builder.startSpan().recordException(e).setStatus(StatusCode.ERROR).end();
             // do our best to make sure the crash makes it out of the VM
-            CompletableResultCode result = sdkTracerProvider.forceFlush();
-            result.join(10, TimeUnit.SECONDS);
+            CompletableResultCode flushResult = sdkTracerProvider.forceFlush();
+            flushResult.join(10, TimeUnit.SECONDS);
             // preserve any existing behavior:
             if (existingHandler != null) {
                 existingHandler.uncaughtException(t, e);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CrashReporter.java
@@ -21,7 +21,6 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.concurrent.TimeUnit;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -162,7 +162,10 @@ class RumInitializer {
                         "activityLifecycleCallbacksInitialized", timingClock.now()));
 
         if (builder.crashReportingEnabled) {
-            CrashReporter.initializeCrashReporting(tracer, openTelemetrySdk);
+            RuntimeDetails runtimeDetails =
+                    RuntimeDetails.create(application.getApplicationContext());
+            CrashReporter.initializeCrashReporting(
+                    tracer, openTelemetrySdk.getSdkTracerProvider(), runtimeDetails);
             initializationEvents.add(
                     new RumInitializer.InitializationEvent(
                             "crashReportingInitialized", timingClock.now()));

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
@@ -23,12 +23,11 @@ import android.content.IntentFilter;
 import android.os.BatteryManager;
 import androidx.annotation.Nullable;
 import java.io.File;
-import java.util.concurrent.atomic.AtomicReference;
 
 /** Represents details about the runtime environment at a time */
 final class RuntimeDetails extends BroadcastReceiver {
 
-    private final AtomicReference<Double> batteryPercent = new AtomicReference<>();
+    private volatile Double batteryPercent = null;
     private final File filesDir;
 
     static RuntimeDetails create(Context context) {
@@ -54,13 +53,13 @@ final class RuntimeDetails extends BroadcastReceiver {
 
     @Nullable
     Double getCurrentBatteryPercent() {
-        return batteryPercent.get();
+        return batteryPercent;
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
         int level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
         int scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
-        batteryPercent.set(level * 100.0d / (float) scale);
+        batteryPercent = level * 100.0d / (float) scale;
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+import androidx.annotation.Nullable;
+import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Represents details about the runtime environment at a time */
+final class RuntimeDetails extends BroadcastReceiver {
+
+    private final AtomicReference<Double> batteryPercent = new AtomicReference<>();
+    private final File filesDir;
+
+    static RuntimeDetails create(Context context) {
+        IntentFilter batteryChangedFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        File filesDir = context.getFilesDir();
+        RuntimeDetails runtimeDetails = new RuntimeDetails(filesDir);
+        context.registerReceiver(runtimeDetails, batteryChangedFilter);
+        return runtimeDetails;
+    }
+
+    private RuntimeDetails(File filesDir) {
+        this.filesDir = filesDir;
+    }
+
+    long getCurrentStorageFreeSpaceInBytes() {
+        return filesDir.getFreeSpace();
+    }
+
+    long getCurrentFreeHeapInBytes() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.freeMemory();
+    }
+
+    @Nullable
+    Double getCurrentBatteryPercent() {
+        return batteryPercent.get();
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+        int scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+        batteryPercent.set(level * 100.0d / (float) scale);
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RuntimeDetails.java
@@ -27,7 +27,7 @@ import java.io.File;
 /** Represents details about the runtime environment at a time */
 final class RuntimeDetails extends BroadcastReceiver {
 
-    private volatile Double batteryPercent = null;
+    private @Nullable volatile Double batteryPercent = null;
     private final File filesDir;
 
     static RuntimeDetails create(Context context) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -17,6 +17,7 @@
 package com.splunk.rum;
 
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Objects.requireNonNull;
 
@@ -60,6 +61,10 @@ public class SplunkRum {
     static final AttributeKey<String> START_TYPE_KEY = stringKey("start.type");
     static final AttributeKey<Double> LOCATION_LATITUDE_KEY = doubleKey("location.lat");
     static final AttributeKey<Double> LOCATION_LONGITUDE_KEY = doubleKey("location.long");
+
+    static final AttributeKey<Long> STORAGE_SPACE_FREE_KEY = longKey("storage.free");
+    static final AttributeKey<Long> HEAP_FREE_KEY = longKey("heap.free");
+    static final AttributeKey<Double> BATTERY_PERCENT_KEY = doubleKey("battery.percent");
 
     static final String COMPONENT_APPSTART = "appstart";
     static final String COMPONENT_CRASH = "crash";

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.app.Application;
+import android.content.Context;
 import android.os.Looper;
 import com.google.common.base.Strings;
 import io.opentelemetry.api.common.AttributeKey;
@@ -54,6 +55,10 @@ public class RumInitializerTest {
                         .setApplicationName("testApp")
                         .setRumAccessToken("accessToken");
         Application application = mock(Application.class);
+        Context context = mock(Context.class);
+
+        when(application.getApplicationContext()).thenReturn(context);
+
         InMemorySpanExporter testExporter = InMemorySpanExporter.create();
         AppStartupTimer startupTimer = new AppStartupTimer();
         RumInitializer testInitializer =
@@ -108,6 +113,10 @@ public class RumInitializerTest {
                         .setApplicationName("testApp")
                         .setRumAccessToken("accessToken");
         Application application = mock(Application.class);
+        Context context = mock(Context.class);
+
+        when(application.getApplicationContext()).thenReturn(context);
+
         InMemorySpanExporter testExporter = InMemorySpanExporter.create();
         AppStartupTimer startupTimer = new AppStartupTimer();
         RumInitializer testInitializer =
@@ -209,6 +218,9 @@ public class RumInitializerTest {
                         .setApplicationName("test");
         Application application = mock(Application.class);
         ConnectionUtil connectionUtil = mock(ConnectionUtil.class, RETURNS_DEEP_STUBS);
+        Context context = mock(Context.class);
+
+        when(application.getApplicationContext()).thenReturn(context);
         when(connectionUtil.refreshNetworkStatus().isOnline()).thenReturn(true);
         ConnectionUtil.Factory connectionUtilFactory = mock(ConnectionUtil.Factory.class);
         when(connectionUtilFactory.createAndStart(application)).thenReturn(connectionUtil);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RuntimeDetailsTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RuntimeDetailsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+import java.io.File;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RuntimeDetailsTest {
+
+    private Context context;
+
+    @Before
+    public void setup() {
+        context = mock(Context.class);
+    }
+
+    @Test
+    public void testBattery() {
+        Intent intent = mock(Intent.class);
+
+        Integer level = 690;
+        when(intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)).thenReturn(level);
+        when(intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)).thenReturn(1000);
+
+        RuntimeDetails details = RuntimeDetails.create(context);
+
+        details.onReceive(context, intent);
+        Double result = details.getCurrentBatteryPercent();
+        assertEquals(69.0d, result, 0.001);
+    }
+
+    @Test
+    public void testFreeSpace() {
+        File filesDir = mock(File.class);
+
+        when(context.getFilesDir()).thenReturn(filesDir);
+        when(filesDir.getFreeSpace()).thenReturn(4200L);
+
+        RuntimeDetails details = RuntimeDetails.create(context);
+
+        long result = details.getCurrentStorageFreeSpaceInBytes();
+        assertEquals(4200L, result);
+    }
+}


### PR DESCRIPTION
The crash span will now contain the following 3 additional attributes:

* `storage.free` - the free space on the device, in bytes
* `heap.free` - the amount of free heap for the runtime
* `battery.percent` - the battery level in percent

Developers can use this runtime information when troubleshooting root cause of crashes.