### PR TITLE
Minor API fix

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -138,6 +138,17 @@ public class SplunkRum {
     }
 
     /**
+     * Initialize a no-op version of the SplunkRum API, including the instance of OpenTelemetry that
+     * is available. This can be useful for testing, or configuring your app without RUM enabled,
+     * but still using the APIs.
+     *
+     * @return A no-op instance of {@link SplunkRum}
+     */
+    public static SplunkRum noop() {
+        return NoOpSplunkRum.INSTANCE;
+    }
+
+    /**
      * Wrap the provided {@link OkHttpClient} with OpenTelemetry and RUM instrumentation. Since
      * {@link Call.Factory} is the primary useful interface implemented by the OkHttpClient, this
      * should be a drop-in replacement for any usages of OkHttpClient.
@@ -308,17 +319,6 @@ public class SplunkRum {
     // (currently) for testing only
     void flushSpans() {
         openTelemetrySdk.getSdkTracerProvider().forceFlush().join(1, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Initialize a no-op version of the SplunkRum API, including the instance of OpenTelemetry that
-     * is available. This can be useful for testing, or configuring your app without RUM enabled,
-     * but still using the APIs.
-     *
-     * @return A no-op instance of {@link SplunkRum}
-     */
-    public static SplunkRum noop() {
-        return NoOpSplunkRum.INSTANCE;
     }
 
     /**

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -160,7 +160,7 @@ public final class SplunkRumBuilder {
      *
      * @return {@code this}
      */
-    public SplunkRumBuilder disableNetworkMonitorEnabled() {
+    public SplunkRumBuilder disableNetworkMonitor() {
         this.networkMonitorEnabled = false;
         return this;
     }


### PR DESCRIPTION
Renamed `disableNetworkMonitorEnabled` to `disableNetworkMonitor`; moved a static method higher, where other static methods are located