### PR TITLE
Migrate tests to junit5 

### DIFF
--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -40,10 +40,6 @@ android {
     }
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
-
 val otelVersion = "1.19.0"
 val otelAlphaVersion = "$otelVersion-alpha"
 

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -40,6 +40,10 @@ android {
     }
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 val otelVersion = "1.19.0"
 val otelAlphaVersion = "$otelVersion-alpha"
 
@@ -61,14 +65,22 @@ dependencies {
     api("io.opentelemetry:opentelemetry-api")
     api("com.squareup.okhttp3:okhttp:4.10.0")
 
-    testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:4.8.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:4.8.0")
+    testImplementation(platform("org.junit:junit-bom:5.9.1"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation("org.junit.vintage:junit-vintage-engine")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
     testImplementation("org.robolectric:robolectric:4.9")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("org.assertj:assertj-core:3.23.1")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.8")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 extra["pomName"] = "Splunk Otel Android"

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityCallbacksTest.java
@@ -16,37 +16,38 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ActivityCallbacksTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class ActivityCallbacksTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
     private Tracer tracer;
     private VisibleScreenTracker visibleScreenTracker;
     private final AppStartupTimer startupTimer = new AppStartupTimer();
 
-    @Before
+    @BeforeEach
     public void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
         visibleScreenTracker = mock(VisibleScreenTracker.class);
     }
 
     @Test
-    public void appStartup() {
+    void appStartup() {
         startupTimer.start(tracer);
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
@@ -94,7 +95,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityCreation() {
+    void activityCreation() {
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
 
@@ -144,7 +145,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityRestart() {
+    void activityRestart() {
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
 
@@ -186,7 +187,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityResumed() {
+    void activityResumed() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
@@ -223,7 +224,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityDestroyedFromStopped() {
+    void activityDestroyedFromStopped() {
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
 
@@ -259,7 +260,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityDestroyedFromPaused() {
+    void activityDestroyedFromPaused() {
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
 
@@ -315,7 +316,7 @@ public class ActivityCallbacksTest {
     }
 
     @Test
-    public void activityStoppedFromRunning() {
+    void activityStoppedFromRunning() {
         ActivityCallbacks activityCallbacks =
                 new ActivityCallbacks(tracer, visibleScreenTracker, startupTimer);
 
@@ -373,6 +374,6 @@ public class ActivityCallbacksTest {
     private void checkEventExists(List<EventData> events, String eventName) {
         Optional<EventData> event =
                 events.stream().filter(e -> e.getName().equals(eventName)).findAny();
-        assertTrue("Event with name " + eventName + " not found", event.isPresent());
+        assertTrue(event.isPresent(), "Event with name " + eventName + " not found");
     }
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ActivityTracerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ActivityTracerTest.java
@@ -16,34 +16,35 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ActivityTracerTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
     private Tracer tracer;
     private final VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
     private final AppStartupTimer appStartupTimer = new AppStartupTimer();
 
-    @Before
+    @BeforeEach
     public void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void restart_nonInitialActivity() {
+    void restart_nonInitialActivity() {
         ActivityTracer trackableTracer =
                 new ActivityTracer(
                         mock(Activity.class),

--- a/splunk-otel-android/src/test/java/com/splunk/rum/AnrWatcherTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/AnrWatcherTest.java
@@ -25,12 +25,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import android.os.Handler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnrWatcherTest {
+class AnrWatcherTest {
 
     @Test
-    public void mainThreadDisappearing() {
+    void mainThreadDisappearing() {
         Handler handler = mock(Handler.class);
         Thread mainThread = mock(Thread.class);
         SplunkRum splunkRum = mock(SplunkRum.class);
@@ -44,7 +44,7 @@ public class AnrWatcherTest {
     }
 
     @Test
-    public void noAnr() {
+    void noAnr() {
         Handler handler = mock(Handler.class);
         Thread mainThread = mock(Thread.class);
         SplunkRum splunkRum = mock(SplunkRum.class);
@@ -64,7 +64,7 @@ public class AnrWatcherTest {
     }
 
     @Test
-    public void noAnr_temporaryPause() {
+    void noAnr_temporaryPause() {
         Handler handler = mock(Handler.class);
         Thread mainThread = mock(Thread.class);
         SplunkRum splunkRum = mock(SplunkRum.class);
@@ -88,7 +88,7 @@ public class AnrWatcherTest {
     }
 
     @Test
-    public void anr_detected() {
+    void anr_detected() {
         Handler handler = mock(Handler.class);
         Thread mainThread = mock(Thread.class);
         SplunkRum splunkRum = mock(SplunkRum.class);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/AppStartupTimerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/AppStartupTimerTest.java
@@ -16,30 +16,30 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class AppStartupTimerTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class AppStartupTimerTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void start_end() {
+    void start_end() {
         AppStartupTimer appStartupTimer = new AppStartupTimer();
         Span startSpan = appStartupTimer.start(tracer);
         assertNotNull(startSpan);
@@ -57,7 +57,7 @@ public class AppStartupTimerTest {
     }
 
     @Test
-    public void multi_end() {
+    void multi_end() {
         AppStartupTimer appStartupTimer = new AppStartupTimer();
         appStartupTimer.start(tracer);
         appStartupTimer.end();
@@ -67,7 +67,7 @@ public class AppStartupTimerTest {
     }
 
     @Test
-    public void multi_start() {
+    void multi_start() {
         AppStartupTimer appStartupTimer = new AppStartupTimer();
         appStartupTimer.start(tracer);
         assertSame(appStartupTimer.start(tracer), appStartupTimer.start(tracer));

--- a/splunk-otel-android/src/test/java/com/splunk/rum/BandwidthTrackerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/BandwidthTrackerTest.java
@@ -16,23 +16,23 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 import java.time.Clock;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class BandwidthTrackerTest {
+class BandwidthTrackerTest {
 
     private Clock clock;
     private AtomicLong time;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         clock = mock(Clock.class);
         time = new AtomicLong(System.currentTimeMillis());
         // Clock moves 5s each time its queried
@@ -40,13 +40,13 @@ public class BandwidthTrackerTest {
     }
 
     @Test
-    public void testSustainedRateNoData() {
+    void testSustainedRateNoData() {
         BandwidthTracker tracker = new BandwidthTracker(clock);
         assertEquals(0.0, tracker.totalSustainedRate(), 0.0);
     }
 
     @Test
-    public void testSustainedRate() {
+    void testSustainedRate() {
         BandwidthTracker tracker = new BandwidthTracker(clock);
         tracker.tick(Collections.singletonList(new byte[270000]));
         tracker.tick(Collections.singletonList(new byte[200]));

--- a/splunk-otel-android/src/test/java/com/splunk/rum/CarrierFinderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/CarrierFinderTest.java
@@ -21,12 +21,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.telephony.TelephonyManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CarrierFinderTest {
+class CarrierFinderTest {
 
     @Test
-    public void testSimpleGet() {
+    void testSimpleGet() {
         Carrier expected =
                 Carrier.builder()
                         .id(206)
@@ -49,7 +49,7 @@ public class CarrierFinderTest {
     }
 
     @Test
-    public void testMostlyInvalid() {
+    void testMostlyInvalid() {
         Carrier expected = Carrier.builder().build();
 
         TelephonyManager manager = mock(TelephonyManager.class);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ConnectionUtilTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ConnectionUtilTest.java
@@ -17,8 +17,8 @@
 package com.splunk.rum;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/CrashReporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/CrashReporterTest.java
@@ -18,8 +18,8 @@ package com.splunk.rum;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 import androidx.annotation.NonNull;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -36,19 +36,19 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CrashReporterTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class CrashReporterTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
     private SdkTracerProvider sdkTracerProvider;
     private CompletableResultCode flushResult;
     private RuntimeDetails runtimeDetails;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
         sdkTracerProvider = mock(SdkTracerProvider.class);
         flushResult = mock(CompletableResultCode.class);
@@ -61,7 +61,7 @@ public class CrashReporterTest {
     }
 
     @Test
-    public void crashReportingSpan() {
+    void crashReportingSpan() {
         TestDelegateHandler existingHandler = new TestDelegateHandler();
         CrashReporter.CrashReportingExceptionHandler crashReporter =
                 new CrashReporter.CrashReportingExceptionHandler(
@@ -94,7 +94,7 @@ public class CrashReporterTest {
     }
 
     @Test
-    public void multipleErrorsDuringACrash() {
+    void multipleErrorsDuringACrash() {
         CrashReporter.CrashReportingExceptionHandler crashReporter =
                 new CrashReporter.CrashReportingExceptionHandler(
                         tracer, sdkTracerProvider, null, runtimeDetails);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/CustomZipkinEncoderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/CustomZipkinEncoderTest.java
@@ -16,17 +16,17 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zipkin2.Span;
 
-public class CustomZipkinEncoderTest {
+class CustomZipkinEncoderTest {
 
     @Test
-    public void nameReplacement() {
+    void nameReplacement() {
         CustomZipkinEncoder encoder = new CustomZipkinEncoder();
         Span span =
                 Span.newBuilder()

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
@@ -16,8 +16,8 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -26,14 +26,14 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.stream.Stream;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DeviceSpanStorageLimiterTest {
+@ExtendWith(MockitoExtension.class)
+class DeviceSpanStorageLimiterTest {
 
     private static final int MAX_STORAGE_USE_MB = 3;
     private static final long MAX_STORAGE_USE_BYTES = MAX_STORAGE_USE_MB * 1024 * 1024;
@@ -41,8 +41,8 @@ public class DeviceSpanStorageLimiterTest {
     @Mock private File path;
     private DeviceSpanStorageLimiter limiter;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         limiter =
                 DeviceSpanStorageLimiter.builder()
                         .fileUtils(fileUtils)
@@ -52,7 +52,7 @@ public class DeviceSpanStorageLimiterTest {
     }
 
     @Test
-    public void ensureFreeSpace_littleUsageEnoughFreeSpace() {
+    void ensureFreeSpace_littleUsageEnoughFreeSpace() {
         when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(10 * 1024L);
         when(path.getFreeSpace()).thenReturn(99L); // Disk is very full
         assertFalse(limiter.ensureFreeSpace());
@@ -60,7 +60,7 @@ public class DeviceSpanStorageLimiterTest {
     }
 
     @Test
-    public void ensureFreeSpace_littleUsageButNotEnoughFreeSpace() {
+    void ensureFreeSpace_littleUsageButNotEnoughFreeSpace() {
         when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(10 * 1024L);
         when(path.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES * 99); // lots of room
         assertTrue(limiter.ensureFreeSpace());
@@ -68,7 +68,7 @@ public class DeviceSpanStorageLimiterTest {
     }
 
     @Test
-    public void ensureFreeSpace_underLimit() {
+    void ensureFreeSpace_underLimit() {
         when(fileUtils.getTotalFileSizeInBytes(path)).thenReturn(MAX_STORAGE_USE_BYTES - 1);
         when(path.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES + 1);
         boolean result = limiter.ensureFreeSpace();
@@ -77,7 +77,7 @@ public class DeviceSpanStorageLimiterTest {
     }
 
     @Test
-    public void ensureFreeSpace_overLimitHappyDeletion() {
+    void ensureFreeSpace_overLimitHappyDeletion() {
         File file1 = new File("oldest");
         File file2 = new File("younger");
         File file3 = new File("newest");

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
@@ -25,14 +25,15 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.stream.Stream;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DiskToZipkinExporterTest {
+@ExtendWith(MockitoExtension.class)
+class DiskToZipkinExporterTest {
 
     static final int BANDWIDTH_LIMIT = 20 * 1024;
     static final File spanFilesPath = new File("/path/to/thing");
@@ -49,8 +50,8 @@ public class DiskToZipkinExporterTest {
     @Mock FileSender sender;
     @Mock private BandwidthTracker bandwidthTracker;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         when(connectionUtil.refreshNetworkStatus()).thenReturn(currentNetwork);
         when(currentNetwork.isOnline()).thenReturn(true);
         Stream<File> files = Stream.of(file1, imposter, file2);
@@ -58,7 +59,7 @@ public class DiskToZipkinExporterTest {
     }
 
     @Test
-    public void testHappyPathExport() throws Exception {
+    void testHappyPathExport() {
         when(sender.handleFileOnDisk(file1)).thenReturn(true);
         when(sender.handleFileOnDisk(file2)).thenReturn(true);
 
@@ -71,7 +72,7 @@ public class DiskToZipkinExporterTest {
     }
 
     @Test
-    public void fileFailureSkipsSubsequentFiles() throws Exception {
+    void fileFailureSkipsSubsequentFiles() {
 
         when(sender.handleFileOnDisk(file1)).thenReturn(false);
 
@@ -84,7 +85,8 @@ public class DiskToZipkinExporterTest {
     }
 
     @Test
-    public void testSkipsWhenOffline() {
+    void testSkipsWhenOffline() {
+        Mockito.reset(fileUtils);
         when(currentNetwork.isOnline()).thenReturn(false);
 
         DiskToZipkinExporter exporter = buildExporter();
@@ -96,7 +98,7 @@ public class DiskToZipkinExporterTest {
     }
 
     @Test
-    public void testSkipsWhenOverBandwidth() throws Exception {
+    void testSkipsWhenOverBandwidth() {
         when(bandwidthTracker.totalSustainedRate()).thenReturn(BANDWIDTH_LIMIT + 1.0);
 
         DiskToZipkinExporter exporter = buildExporter();
@@ -107,7 +109,7 @@ public class DiskToZipkinExporterTest {
     }
 
     @Test
-    public void testOtherExceptionsHandled() throws Exception {
+    void testOtherExceptionsHandled() {
         when(fileUtils.listSpanFiles(spanFilesPath)).thenThrow(new RuntimeException("unexpected!"));
         DiskToZipkinExporter exporter = buildExporter();
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
@@ -17,8 +17,8 @@
 package com.splunk.rum;
 
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,16 +31,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import zipkin2.Call;
 import zipkin2.reporter.Sender;
 
-@RunWith(MockitoJUnitRunner.class)
-public class FileSenderTest {
+@ExtendWith(MockitoExtension.class)
+class FileSenderTest {
 
     private final byte[] span1 = "span1".getBytes(StandardCharsets.UTF_8);
     private final byte[] span2 = "span2".getBytes(StandardCharsets.UTF_8);
@@ -54,14 +55,16 @@ public class FileSenderTest {
     @Mock private Call<Void> httpCall;
     @Mock private Consumer<Integer> backoff;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         when(fileUtils.readFileCompletely(file)).thenReturn(fileSpans);
         when(delegate.sendSpans(fileSpans)).thenReturn(httpCall);
     }
 
     @Test
-    public void testEmptyFile() throws Exception {
+    void testEmptyFile() throws Exception {
+        Mockito.reset(fileUtils);
+        Mockito.reset(delegate);
         File file = new File("/asdflkajsdfoij");
         when(fileUtils.readFileCompletely(file)).thenReturn(emptyList());
         FileSender sender = buildSender();
@@ -70,7 +73,7 @@ public class FileSenderTest {
     }
 
     @Test
-    public void testHappyPathSendSpans() {
+    void testHappyPathSendSpans() {
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);
         assertTrue(result);
@@ -78,7 +81,7 @@ public class FileSenderTest {
     }
 
     @Test
-    public void testSendFailsButNotExceeded() throws Exception {
+    void testSendFailsButNotExceeded() throws Exception {
         when(httpCall.execute()).thenThrow(new IOException("boom"));
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);
@@ -88,7 +91,7 @@ public class FileSenderTest {
     }
 
     @Test
-    public void testSenderFailureRetriesExhausted() throws Exception {
+    void testSenderFailureRetriesExhausted() throws Exception {
         when(httpCall.execute()).thenThrow(new IOException("boom"));
         FileSender sender = buildSender(3);
         boolean result = sender.handleFileOnDisk(file);
@@ -106,7 +109,9 @@ public class FileSenderTest {
     }
 
     @Test
-    public void testReadFileFails() throws IOException {
+    void testReadFileFails() throws IOException {
+        Mockito.reset(fileUtils);
+        Mockito.reset(delegate);
         when(fileUtils.readFileCompletely(file)).thenThrow(new IOException("boom"));
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/FragmentTracerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/FragmentTracerTest.java
@@ -16,32 +16,32 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import androidx.fragment.app.Fragment;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class FragmentTracerTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class FragmentTracerTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
     private final VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void create() {
+    void create() {
         FragmentTracer trackableTracer =
                 new FragmentTracer(mock(Fragment.class), tracer, visibleScreenTracker);
         trackableTracer.startFragmentCreation();
@@ -51,7 +51,7 @@ public class FragmentTracerTest {
     }
 
     @Test
-    public void addPreviousScreen_noPrevious() {
+    void addPreviousScreen_noPrevious() {
         VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
 
         FragmentTracer trackableTracer =
@@ -66,7 +66,7 @@ public class FragmentTracerTest {
     }
 
     @Test
-    public void addPreviousScreen_currentSameAsPrevious() {
+    void addPreviousScreen_currentSameAsPrevious() {
         VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("Fragment");
 
@@ -82,7 +82,7 @@ public class FragmentTracerTest {
     }
 
     @Test
-    public void addPreviousScreen() {
+    void addPreviousScreen() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
 
         FragmentTracer fragmentTracer =
@@ -97,7 +97,7 @@ public class FragmentTracerTest {
     }
 
     @Test
-    public void testAnnotatedScreenName() {
+    void testAnnotatedScreenName() {
         Fragment fragment = new AnnotatedFragment();
         FragmentTracer fragmentTracer = new FragmentTracer(fragment, tracer, visibleScreenTracker);
         fragmentTracer.startFragmentCreation();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/MemoryBufferingExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/MemoryBufferingExporterTest.java
@@ -16,9 +16,9 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -34,21 +34,21 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-public class MemoryBufferingExporterTest {
+class MemoryBufferingExporterTest {
     private final ConnectionUtil connectionUtil = mock(ConnectionUtil.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(connectionUtil.refreshNetworkStatus())
                 .thenReturn(CurrentNetwork.builder(NetworkState.TRANSPORT_CELLULAR).build());
     }
 
     @Test
-    public void happyPath() {
+    void happyPath() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);
@@ -61,7 +61,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void offlinePath() {
+    void offlinePath() {
         when(connectionUtil.refreshNetworkStatus())
                 .thenReturn(CurrentNetwork.builder(NetworkState.NO_NETWORK_AVAILABLE).build())
                 .thenReturn(CurrentNetwork.builder(NetworkState.TRANSPORT_UNKNOWN).build());
@@ -89,7 +89,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void retryPath() {
+    void retryPath() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);
@@ -111,7 +111,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void flush_withBacklog() {
+    void flush_withBacklog() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);
@@ -133,7 +133,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void flush() {
+    void flush() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);
@@ -145,7 +145,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void maxBacklog() {
+    void maxBacklog() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);
@@ -177,7 +177,7 @@ public class MemoryBufferingExporterTest {
     }
 
     @Test
-    public void shutdown() {
+    void shutdown() {
         SpanExporter delegate = mock(SpanExporter.class);
         MemoryBufferingExporter bufferingExporter =
                 new MemoryBufferingExporter(connectionUtil, delegate);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ModifiedSpanDataTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ModifiedSpanDataTest.java
@@ -18,7 +18,7 @@ package com.splunk.rum;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
@@ -32,14 +32,14 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ModifiedSpanDataTest {
+class ModifiedSpanDataTest {
     private static final String TRACE_ID = TraceId.fromLongs(0, 42);
     private static final String SPAN_ID = SpanId.fromLong(123);
 
     @Test
-    public void shouldForwardAllCallsExceptAttributesToTheOriginal() {
+    void shouldForwardAllCallsExceptAttributesToTheOriginal() {
         SpanData original =
                 TestSpanData.builder()
                         .setName("test")

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NativeRumSessionIdTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NativeRumSessionIdTest.java
@@ -16,16 +16,16 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NativeRumSessionIdTest {
+class NativeRumSessionIdTest {
 
     @Test
-    public void getNativeSessionId() {
+    void getNativeSessionId() {
         SplunkRum splunkRum = mock(SplunkRum.class);
         when(splunkRum.getRumSessionId()).thenReturn("123456");
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NetworkMonitorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NetworkMonitorTest.java
@@ -18,31 +18,31 @@ package com.splunk.rum;
 
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class NetworkMonitorTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class NetworkMonitorTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void networkAvailable_wifi() {
+    void networkAvailable_wifi() {
         NetworkMonitor.TracingConnectionStateListener listener =
                 new NetworkMonitor.TracingConnectionStateListener(tracer, new AtomicBoolean(true));
 
@@ -59,7 +59,7 @@ public class NetworkMonitorTest {
     }
 
     @Test
-    public void networkAvailable_cellular() {
+    void networkAvailable_cellular() {
         NetworkMonitor.TracingConnectionStateListener listener =
                 new NetworkMonitor.TracingConnectionStateListener(tracer, new AtomicBoolean(true));
 
@@ -78,7 +78,7 @@ public class NetworkMonitorTest {
     }
 
     @Test
-    public void networkLost() {
+    void networkLost() {
         NetworkMonitor.TracingConnectionStateListener listener =
                 new NetworkMonitor.TracingConnectionStateListener(tracer, new AtomicBoolean(true));
 
@@ -96,7 +96,7 @@ public class NetworkMonitorTest {
     }
 
     @Test
-    public void noEventsPlease() {
+    void noEventsPlease() {
         AtomicBoolean shouldEmitChangeEvents = new AtomicBoolean(false);
 
         NetworkMonitor.TracingConnectionStateListener listener =

--- a/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/NoOpSplunkRumTest.java
@@ -16,8 +16,8 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
 import android.location.Location;
@@ -25,12 +25,12 @@ import android.webkit.WebView;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import okhttp3.OkHttpClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NoOpSplunkRumTest {
+class NoOpSplunkRumTest {
 
     @Test
-    public void doesNotThrow() {
+    void doesNotThrow() {
         NoOpSplunkRum instance = NoOpSplunkRum.INSTANCE;
         instance.addRumEvent("foo", Attributes.empty());
         instance.addRumException(new RuntimeException(), Attributes.empty());

--- a/splunk-otel-android/src/test/java/com/splunk/rum/Pre29ActivityLifecycleCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/Pre29ActivityLifecycleCallbacksTest.java
@@ -16,37 +16,37 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class Pre29ActivityLifecycleCallbacksTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class Pre29ActivityLifecycleCallbacksTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
     private VisibleScreenTracker visibleScreenTracker;
     private final AppStartupTimer appStartupTimer = new AppStartupTimer();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
         visibleScreenTracker = mock(VisibleScreenTracker.class);
     }
 
     @Test
-    public void appStartup() {
+    void appStartup() {
         appStartupTimer.start(tracer);
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
@@ -86,7 +86,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityCreation() {
+    void activityCreation() {
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
         Pre29ActivityCallbackTestHarness testHarness =
@@ -127,7 +127,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityRestart() {
+    void activityRestart() {
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
         Pre29ActivityCallbackTestHarness testHarness =
@@ -163,7 +163,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityResumed() {
+    void activityResumed() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
 
         Pre29ActivityCallbacks rumLifecycleCallbacks =
@@ -198,7 +198,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityDestroyedFromStopped() {
+    void activityDestroyedFromStopped() {
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
         Pre29ActivityCallbackTestHarness testHarness =
@@ -231,7 +231,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityDestroyedFromPaused() {
+    void activityDestroyedFromPaused() {
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
         Pre29ActivityCallbackTestHarness testHarness =
@@ -282,7 +282,7 @@ public class Pre29ActivityLifecycleCallbacksTest {
     }
 
     @Test
-    public void activityStoppedFromRunning() {
+    void activityStoppedFromRunning() {
         Pre29ActivityCallbacks rumLifecycleCallbacks =
                 new Pre29ActivityCallbacks(tracer, visibleScreenTracker, appStartupTimer);
         Pre29ActivityCallbackTestHarness testHarness =
@@ -335,6 +335,6 @@ public class Pre29ActivityLifecycleCallbacksTest {
     private void checkEventExists(List<EventData> events, String eventName) {
         Optional<EventData> event =
                 events.stream().filter(e -> e.getName().equals(eventName)).findAny();
-        assertTrue("Event with name " + eventName + " not found", event.isPresent());
+        assertTrue(event.isPresent(), "Event with name " + eventName + " not found");
     }
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumAttributeAppenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumAttributeAppenderTest.java
@@ -16,8 +16,8 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -28,16 +28,16 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RumAttributeAppenderTest {
 
     private VisibleScreenTracker visibleScreenTracker;
     private final ConnectionUtil connectionUtil = mock(ConnectionUtil.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         visibleScreenTracker = mock(VisibleScreenTracker.class);
         when(connectionUtil.getActiveNetwork())
                 .thenReturn(
@@ -47,7 +47,7 @@ public class RumAttributeAppenderTest {
     }
 
     @Test
-    public void interfaceMethods() {
+    void interfaceMethods() {
         RumAttributeAppender rumAttributeAppender =
                 new RumAttributeAppender(
                         mock(SessionId.class), visibleScreenTracker, connectionUtil);
@@ -57,7 +57,7 @@ public class RumAttributeAppenderTest {
     }
 
     @Test
-    public void appendAttributesOnStart() {
+    void appendAttributesOnStart() {
         SessionId sessionId = mock(SessionId.class);
         when(sessionId.getSessionId()).thenReturn("rumSessionId");
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("ScreenOne");
@@ -75,7 +75,7 @@ public class RumAttributeAppenderTest {
     }
 
     @Test
-    public void appendAttributes_noCurrentScreens() {
+    void appendAttributes_noCurrentScreens() {
         SessionId sessionId = mock(SessionId.class);
         when(sessionId.getSessionId()).thenReturn("rumSessionId");
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("unknown");

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumFragmentLifecycleCallbacksTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumFragmentLifecycleCallbacksTest.java
@@ -16,36 +16,36 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import androidx.fragment.app.Fragment;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class RumFragmentLifecycleCallbacksTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class RumFragmentLifecycleCallbacksTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
     private final VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void fragmentCreation() {
+    void fragmentCreation() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -80,7 +80,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentRestored() {
+    void fragmentRestored() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("previousScreen");
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
@@ -113,7 +113,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentResumed() {
+    void fragmentResumed() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -139,7 +139,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentPaused() {
+    void fragmentPaused() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -169,7 +169,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentDetachedFromActive() {
+    void fragmentDetachedFromActive() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -231,7 +231,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentDestroyedFromStopped() {
+    void fragmentDestroyedFromStopped() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -260,7 +260,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentDetachedFromStopped() {
+    void fragmentDetachedFromStopped() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -306,7 +306,7 @@ public class RumFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    public void fragmentDetached() {
+    void fragmentDetached() {
         FragmentCallbackTestHarness testHarness =
                 new FragmentCallbackTestHarness(
                         new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker));
@@ -338,6 +338,6 @@ public class RumFragmentLifecycleCallbacksTest {
     private void checkEventExists(List<EventData> events, String eventName) {
         Optional<EventData> event =
                 events.stream().filter(e -> e.getName().equals(eventName)).findAny();
-        assertTrue("Event with name " + eventName + " not found", event.isPresent());
+        assertTrue(event.isPresent(), "Event with name " + eventName + " not found");
     }
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -21,8 +21,8 @@ import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,11 +44,12 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RumInitializerTest {
+class RumInitializerTest {
+
     @Test
-    public void initializationSpan() {
+    void initializationSpan() {
         SplunkRumBuilder splunkRumBuilder =
                 new SplunkRumBuilder()
                         .setRealm("dev")
@@ -101,12 +102,12 @@ public class RumInitializerTest {
 
     private void checkEventExists(List<EventData> events, String eventName) {
         assertTrue(
-                "Event with name " + eventName + " not found",
-                events.stream().map(EventData::getName).anyMatch(name -> name.equals(eventName)));
+                events.stream().map(EventData::getName).anyMatch(name -> name.equals(eventName)),
+                "Event with name " + eventName + " not found");
     }
 
     @Test
-    public void spanLimitsAreConfigured() {
+    void spanLimitsAreConfigured() {
         SplunkRumBuilder splunkRumBuilder =
                 new SplunkRumBuilder()
                         .setRealm("dev")
@@ -152,7 +153,7 @@ public class RumInitializerTest {
 
     /** Verify that we have buffering in place in our exporter implementation. */
     @Test
-    public void verifyExporterBuffering() {
+    void verifyExporterBuffering() {
         SplunkRumBuilder splunkRumBuilder =
                 new SplunkRumBuilder()
                         .setRealm("dev")
@@ -208,7 +209,7 @@ public class RumInitializerTest {
     }
 
     @Test
-    public void shouldTranslateExceptionEventsToSpanAttributes() {
+    void shouldTranslateExceptionEventsToSpanAttributes() {
         InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
         SplunkRumBuilder splunkRumBuilder =

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
@@ -27,12 +27,12 @@ import io.opentelemetry.context.Context;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RumResponseAttributesExtractorTest {
+class RumResponseAttributesExtractorTest {
 
     @Test
-    public void spanDecoration() {
+    void spanDecoration() {
         ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
         when(headerParser.parse("headerValue"))
                 .thenReturn(new String[] {"9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86"});
@@ -62,7 +62,7 @@ public class RumResponseAttributesExtractorTest {
     }
 
     @Test
-    public void spanDecoration_noLinkingHeader() {
+    void spanDecoration_noLinkingHeader() {
         ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
         when(headerParser.parse(null)).thenReturn(new String[0]);
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RuntimeDetailsTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RuntimeDetailsTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,20 +24,20 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.BatteryManager;
 import java.io.File;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class RuntimeDetailsTest {
+class RuntimeDetailsTest {
 
     private Context context;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         context = mock(Context.class);
     }
 
     @Test
-    public void testBattery() {
+    void testBattery() {
         Intent intent = mock(Intent.class);
 
         Integer level = 690;
@@ -52,7 +52,7 @@ public class RuntimeDetailsTest {
     }
 
     @Test
-    public void testFreeSpace() {
+    void testFreeSpace() {
         File filesDir = mock(File.class);
 
         when(context.getFilesDir()).thenReturn(filesDir);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ServerTimingHeaderParserTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ServerTimingHeaderParserTest.java
@@ -16,15 +16,15 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // the header looks like: traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-01"
-public class ServerTimingHeaderParserTest {
+class ServerTimingHeaderParserTest {
 
     @Test
-    public void badHeader() {
+    void badHeader() {
         ServerTimingHeaderParser parser = new ServerTimingHeaderParser();
         assertArrayEquals(new String[0], parser.parse(null));
         assertArrayEquals(new String[0], parser.parse("foo"));
@@ -37,7 +37,7 @@ public class ServerTimingHeaderParserTest {
     }
 
     @Test
-    public void parsableHeader() {
+    void parsableHeader() {
         ServerTimingHeaderParser parser = new ServerTimingHeaderParser();
         String traceId = "9499195c502eb217c448a68bfe0f967c";
         String spanId = "fe16eca542cd5d86";
@@ -47,7 +47,7 @@ public class ServerTimingHeaderParserTest {
     }
 
     @Test
-    public void parsableHeader_singleQuotes() {
+    void parsableHeader_singleQuotes() {
         ServerTimingHeaderParser parser = new ServerTimingHeaderParser();
         String traceId = "9499195c502eb217c448a68bfe0f967c";
         String spanId = "fe16eca542cd5d86";

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdChangeTracerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdChangeTracerTest.java
@@ -16,30 +16,30 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class SessionIdChangeTracerTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class SessionIdChangeTracerTest {
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
     private SessionIdChangeListener underTest;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         Tracer tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
         underTest = new SessionIdChangeTracer(tracer);
     }
 
     @Test
-    public void shouldEmitSessionIdChangeSpan() {
+    void shouldEmitSessionIdChangeSpan() {
         underTest.onChange("123", "456");
 
         List<SpanData> spans = otelTesting.getSpans();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdRatioBasedSamplerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdRatioBasedSamplerTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,12 +32,12 @@ import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SessionIdRatioBasedSamplerTest {
+@ExtendWith(MockitoExtension.class)
+class SessionIdRatioBasedSamplerTest {
     private static final String HIGH_ID = "00000000000000008fffffffffffffff";
     private static final String LOW_ID = "00000000000000000000000000000000";
     private static final IdGenerator idsGenerator = IdGenerator.random();
@@ -48,7 +48,7 @@ public class SessionIdRatioBasedSamplerTest {
             Collections.singletonList(LinkData.create(SpanContext.getInvalid()));
 
     @Test
-    public void samplerUsesSessionId() {
+    void samplerUsesSessionId() {
         SessionId sessionId = mock(SessionId.class);
         SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, sessionId);
 
@@ -62,7 +62,7 @@ public class SessionIdRatioBasedSamplerTest {
     }
 
     @Test
-    public void zeroRatioDropsAll() {
+    void zeroRatioDropsAll() {
         SessionId sessionId = mock(SessionId.class);
         SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.0, sessionId);
 
@@ -73,7 +73,7 @@ public class SessionIdRatioBasedSamplerTest {
     }
 
     @Test
-    public void oneRatioAcceptsAll() {
+    void oneRatioAcceptsAll() {
         SessionId sessionId = mock(SessionId.class);
         SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(1.0, sessionId);
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdTest.java
@@ -16,10 +16,10 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -31,19 +31,19 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.sdk.testing.time.TestClock;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SessionIdTest {
+@ExtendWith(MockitoExtension.class)
+class SessionIdTest {
 
     @Mock SessionIdTimeoutHandler timeoutHandler;
 
     @Test
-    public void valueValid() {
+    void valueValid() {
         String sessionId = new SessionId(TestClock.create(), timeoutHandler).getSessionId();
         assertNotNull(sessionId);
         assertEquals(32, sessionId.length());
@@ -51,7 +51,7 @@ public class SessionIdTest {
     }
 
     @Test
-    public void valueSameUntil4Hours() {
+    void valueSameUntil4Hours() {
         TestClock clock = TestClock.create();
         SessionId sessionId = new SessionId(clock, timeoutHandler);
         String value = sessionId.getSessionId();
@@ -71,7 +71,7 @@ public class SessionIdTest {
     }
 
     @Test
-    public void shouldCallSessionIdChangeListener() {
+    void shouldCallSessionIdChangeListener() {
         TestClock clock = TestClock.create();
         SessionIdChangeListener listener = mock(SessionIdChangeListener.class);
         SessionId sessionId = new SessionId(clock, timeoutHandler);
@@ -92,7 +92,7 @@ public class SessionIdTest {
     }
 
     @Test
-    public void shouldCreateNewSessionIdAfterTimeout() {
+    void shouldCreateNewSessionIdAfterTimeout() {
         SessionId sessionId = new SessionId(timeoutHandler);
 
         String value = sessionId.getSessionId();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdTimeoutHandlerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SessionIdTimeoutHandlerTest.java
@@ -16,17 +16,18 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SessionIdTimeoutHandlerTest {
+class SessionIdTimeoutHandlerTest {
 
     @Test
-    public void shouldNeverTimeOutInForeground() {
+    void shouldNeverTimeOutInForeground() {
         TestClock clock = TestClock.create();
         SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler(clock);
 
@@ -39,7 +40,7 @@ public class SessionIdTimeoutHandlerTest {
     }
 
     @Test
-    public void shouldApply15MinutesTimeoutToAppsInBackground() {
+    void shouldApply15MinutesTimeoutToAppsInBackground() {
         TestClock clock = TestClock.create();
         SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler(clock);
 
@@ -70,7 +71,7 @@ public class SessionIdTimeoutHandlerTest {
     }
 
     @Test
-    public void shouldApplyTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
+    void shouldApplyTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
         TestClock clock = TestClock.create();
         SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler(clock);
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SpanDataModifierTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SpanDataModifierTest.java
@@ -21,8 +21,8 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,15 +37,15 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SpanDataModifierTest {
+@ExtendWith(MockitoExtension.class)
+class SpanDataModifierTest {
     static final AttributeKey<String> ATTRIBUTE = stringKey("attribute");
     static final AttributeKey<String> OTHER_ATTRIBUTE = stringKey("other_attribute");
     static final AttributeKey<Long> LONG_ATTRIBUTE = longKey("long_attribute");
@@ -55,7 +55,7 @@ public class SpanDataModifierTest {
     @Captor ArgumentCaptor<Collection<SpanData>> spansCaptor;
 
     @Test
-    public void shouldRejectSpansByName() {
+    void shouldRejectSpansByName() {
         // given
         SpanExporter underTest =
                 new SpanFilterBuilder()
@@ -85,7 +85,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void shouldRejectSpansByAttributeValue() {
+    void shouldRejectSpansByAttributeValue() {
         // given
         SpanExporter underTest =
                 new SpanFilterBuilder()
@@ -132,7 +132,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void shouldRemoveSpanAttributes() {
+    void shouldRemoveSpanAttributes() {
         // given
         SpanExporter underTest =
                 new SpanFilterBuilder()
@@ -166,7 +166,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void shouldReplaceSpanAttributes() {
+    void shouldReplaceSpanAttributes() {
         // given
         SpanExporter underTest =
                 new SpanFilterBuilder()
@@ -201,7 +201,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void shouldReplaceSpanAttributes_removeAttributeByReturningNull() {
+    void shouldReplaceSpanAttributes_removeAttributeByReturningNull() {
         // given
         SpanExporter underTest =
                 new SpanFilterBuilder()
@@ -227,7 +227,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void builderChangesShouldNotApplyToAlreadyDecoratedExporter() {
+    void builderChangesShouldNotApplyToAlreadyDecoratedExporter() {
         // given
         SpanFilterBuilder builder = new SpanFilterBuilder();
         SpanExporter underTest = builder.build().apply(delegate);
@@ -257,7 +257,7 @@ public class SpanDataModifierTest {
     }
 
     @Test
-    public void shouldDelegateCalls() {
+    void shouldDelegateCalls() {
         SpanExporter underTest = new SpanFilterBuilder().build().apply(delegate);
 
         underTest.flush();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
@@ -16,21 +16,21 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import android.app.Application;
 import io.opentelemetry.api.common.Attributes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SplunkRumBuilderTest {
+class SplunkRumBuilderTest {
 
     @Test
-    public void buildingRequiredFields() {
+    void buildingRequiredFields() {
         Application app = mock(Application.class);
 
         assertThrows(IllegalStateException.class, () -> SplunkRum.builder().build(app));
@@ -58,7 +58,7 @@ public class SplunkRumBuilderTest {
     }
 
     @Test
-    public void defaultValues() {
+    void defaultValues() {
         SplunkRumBuilder builder = SplunkRum.builder();
 
         assertFalse(builder.debugEnabled);
@@ -73,19 +73,19 @@ public class SplunkRumBuilderTest {
     }
 
     @Test
-    public void handleNullAttributes() {
+    void handleNullAttributes() {
         SplunkRumBuilder builder = SplunkRum.builder().setGlobalAttributes(null);
         assertEquals(Attributes.empty(), builder.globalAttributes);
     }
 
     @Test
-    public void setBeaconFromRealm() {
+    void setBeaconFromRealm() {
         SplunkRumBuilder builder = SplunkRum.builder().setRealm("us0");
         assertEquals("https://rum-ingest.us0.signalfx.com/v1/rum", builder.beaconEndpoint);
     }
 
     @Test
-    public void beaconOverridesRealm() {
+    void beaconOverridesRealm() {
         SplunkRumBuilder builder =
                 SplunkRum.builder().setRealm("us0").setBeaconEndpoint("http://beacon");
         assertEquals("http://beacon", builder.beaconEndpoint);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
@@ -16,9 +16,9 @@
 
 package com.splunk.rum;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -19,10 +19,10 @@ package com.splunk.rum;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -45,7 +45,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.rum.internal.GlobalAttributesSpanAppender;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -55,30 +55,30 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SplunkRumTest {
 
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
     private Tracer tracer;
 
     @Mock private GlobalAttributesSpanAppender globalAttributes;
 
-    @Before
+    @BeforeEach
     public void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
         SplunkRum.resetSingletonForTest();
     }
 
     @Test
-    public void initialization_onlyOnce() {
+    void initialization_onlyOnce() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
         ConnectionUtil.Factory connectionUtilFactory =
                 mock(ConnectionUtil.Factory.class, RETURNS_DEEP_STUBS);
@@ -102,13 +102,13 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void getInstance_preConfig() {
+    void getInstance_preConfig() {
         SplunkRum instance = SplunkRum.getInstance();
         assertTrue(instance instanceof NoOpSplunkRum);
     }
 
     @Test
-    public void getInstance() {
+    void getInstance() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
         ConnectionUtil.Factory connectionUtilFactory =
                 mock(ConnectionUtil.Factory.class, RETURNS_DEEP_STUBS);
@@ -130,12 +130,12 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void newBuilder() {
+    void newBuilder() {
         assertNotNull(SplunkRum.builder());
     }
 
     @Test
-    public void nonNullMethods() {
+    void nonNullMethods() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
         ConnectionUtil.Factory connectionUtilFactory =
                 mock(ConnectionUtil.Factory.class, RETURNS_DEEP_STUBS);
@@ -158,7 +158,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void addEvent() {
+    void addEvent() {
         SplunkRum splunkRum =
                 new SplunkRum(
                         (OpenTelemetrySdk) otelTesting.getOpenTelemetry(),
@@ -175,7 +175,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void recordAnr() {
+    void recordAnr() {
         StackTraceElement[] stackTrace = new Exception().getStackTrace();
         StringBuilder stringBuilder = new StringBuilder();
         for (StackTraceElement stackTraceElement : stackTrace) {
@@ -206,7 +206,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void addException() {
+    void addException() {
         InMemorySpanExporter testExporter = InMemorySpanExporter.create();
         OpenTelemetrySdk testSdk = buildTestSdk(testExporter);
 
@@ -240,7 +240,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void createAndEnd() {
+    void createAndEnd() {
         SplunkRum splunkRum =
                 new SplunkRum(
                         (OpenTelemetrySdk) otelTesting.getOpenTelemetry(),
@@ -266,7 +266,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void integrateWithBrowserRum() {
+    void integrateWithBrowserRum() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
         ConnectionUtil.Factory connectionUtilFactory =
                 mock(ConnectionUtil.Factory.class, RETURNS_DEEP_STUBS);
@@ -292,7 +292,7 @@ public class SplunkRumTest {
     }
 
     @Test
-    public void updateLocation() {
+    void updateLocation() {
         AtomicReference<Attributes> updatedAttributes = new AtomicReference<>();
         GlobalAttributesSpanAppender globalAttributes = mock(GlobalAttributesSpanAppender.class);
         doAnswer(

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ThrottlingExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ThrottlingExporterTest.java
@@ -30,17 +30,17 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ThrottlingExporterTest {
+@ExtendWith(MockitoExtension.class)
+class ThrottlingExporterTest {
     @Mock private SpanExporter delegate;
 
     @Test
-    public void shouldExportAllSpansBelowLimit() {
+    void shouldExportAllSpansBelowLimit() {
         // given
         SpanExporter underTest =
                 ThrottlingExporter.newBuilder(delegate)
@@ -66,7 +66,7 @@ public class ThrottlingExporterTest {
     }
 
     @Test
-    public void shouldThrottleSpansOverLimit() {
+    void shouldThrottleSpansOverLimit() {
         // given
         SpanExporter underTest =
                 ThrottlingExporter.newBuilder(delegate)
@@ -104,7 +104,7 @@ public class ThrottlingExporterTest {
     }
 
     @Test
-    public void shouldCountDifferentComponentsSeparately() {
+    void shouldCountDifferentComponentsSeparately() {
         // given
         SpanExporter underTest =
                 ThrottlingExporter.newBuilder(delegate)
@@ -151,7 +151,7 @@ public class ThrottlingExporterTest {
     }
 
     @Test
-    public void shouldKeepStateBetweenExportCalls() {
+    void shouldKeepStateBetweenExportCalls() {
         // given
         SpanExporter underTest =
                 ThrottlingExporter.newBuilder(delegate)
@@ -196,7 +196,7 @@ public class ThrottlingExporterTest {
     }
 
     @Test
-    public void shouldDelegateFlushCall() {
+    void shouldDelegateFlushCall() {
         // given
         SpanExporter underTest = ThrottlingExporter.newBuilder(delegate).build();
 
@@ -208,7 +208,7 @@ public class ThrottlingExporterTest {
     }
 
     @Test
-    public void shouldDelegateShutdownCall() {
+    void shouldDelegateShutdownCall() {
         // given
         SpanExporter underTest = ThrottlingExporter.newBuilder(delegate).build();
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/VisibleScreenTrackerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/VisibleScreenTrackerTest.java
@@ -16,20 +16,20 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 import android.app.Activity;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class VisibleScreenTrackerTest {
+class VisibleScreenTrackerTest {
 
     @Test
-    public void activityLifecycle() {
+    void activityLifecycle() {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
         Activity activity = mock(Activity.class);
 
@@ -49,7 +49,7 @@ public class VisibleScreenTrackerTest {
     }
 
     @Test
-    public void fragmentLifecycle() {
+    void fragmentLifecycle() {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
         Fragment fragment = mock(Fragment.class);
 
@@ -69,7 +69,7 @@ public class VisibleScreenTrackerTest {
     }
 
     @Test
-    public void fragmentLifecycle_navHostIgnored() {
+    void fragmentLifecycle_navHostIgnored() {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
         Fragment fragment = mock(Fragment.class);
         NavHostFragment navHostFragment = mock(NavHostFragment.class);
@@ -92,7 +92,7 @@ public class VisibleScreenTrackerTest {
     }
 
     @Test
-    public void fragmentLifecycle_dialogFragment() {
+    void fragmentLifecycle_dialogFragment() {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
         Fragment fragment = mock(Fragment.class);
         DialogFragment dialogFragment = mock(DialogFragment.class);
@@ -118,7 +118,7 @@ public class VisibleScreenTrackerTest {
     }
 
     @Test
-    public void fragmentWinsOverActivityLifecycle() {
+    void fragmentWinsOverActivityLifecycle() {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
         Activity activity = mock(Activity.class);
         Fragment fragment = mock(Fragment.class);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/WorkflowTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/WorkflowTest.java
@@ -16,30 +16,31 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WorkflowTest {
-    @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();
+class WorkflowTest {
+
+    @RegisterExtension final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
     private Tracer tracer;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
     }
 
     @Test
-    public void createAndEnd() {
+    void createAndEnd() {
         Span workflowTimer =
                 tracer.spanBuilder("workflow")
                         .setAttribute(SplunkRum.WORKFLOW_NAME_KEY, "workflow")

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -27,14 +27,15 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ZipkinToDiskSenderTest {
+@ExtendWith(MockitoExtension.class)
+class ZipkinToDiskSenderTest {
 
     private final long now = System.currentTimeMillis();
     private final File path = new File("/my/great/storage/location");
@@ -48,14 +49,14 @@ public class ZipkinToDiskSenderTest {
     @Mock private Clock clock;
     @Mock private DeviceSpanStorageLimiter limiter;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         when(clock.now()).thenReturn(now);
         when(limiter.ensureFreeSpace()).thenReturn(true);
     }
 
     @Test
-    public void testHappyPath() throws Exception {
+    void testHappyPath() throws Exception {
 
         ZipkinToDiskSender sender =
                 ZipkinToDiskSender.builder()
@@ -70,7 +71,7 @@ public class ZipkinToDiskSenderTest {
     }
 
     @Test
-    public void testWriteFails() throws Exception {
+    void testWriteFails() throws Exception {
         doThrow(new IOException("boom")).when(fileUtils).writeAsLines(finalPath, spans);
 
         ZipkinToDiskSender sender =
@@ -86,8 +87,8 @@ public class ZipkinToDiskSenderTest {
     }
 
     @Test
-    public void testLimitExceeded() throws Exception {
-
+    void testLimitExceeded() {
+        Mockito.reset(clock);
         when(limiter.ensureFreeSpace()).thenReturn(false);
 
         ZipkinToDiskSender sender =

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/GlobalAttributesSpanAppenderTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/GlobalAttributesSpanAppenderTest.java
@@ -26,12 +26,12 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class GlobalAttributesSpanAppenderTest {
+@ExtendWith(MockitoExtension.class)
+class GlobalAttributesSpanAppenderTest {
 
     @Mock private ReadWriteSpan span;
 
@@ -39,7 +39,7 @@ public class GlobalAttributesSpanAppenderTest {
             GlobalAttributesSpanAppender.create(Attributes.of(stringKey("key"), "value"));
 
     @Test
-    public void shouldAppendGlobalAttributes() {
+    void shouldAppendGlobalAttributes() {
         globalAttributes.update(attributesBuilder -> attributesBuilder.put("key", "value2"));
         globalAttributes.update(
                 attributesBuilder -> attributesBuilder.put(longKey("otherKey"), 1234L));


### PR DESCRIPTION
We have to keep junit4 (vintage) around because we (still) rely on RoboElectric and there is a long history of continued incompatibility there. Maybe one day.... 🤞🏻 