### PR TITLE
Don't include first frame in draw duration histogram for slow renders.

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import static android.view.FrameMetrics.DRAW_DURATION;
+import static android.view.FrameMetrics.FIRST_DRAW_FRAME;
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 
 import android.app.Activity;
@@ -156,7 +158,13 @@ class SlowRenderingDetectorImpl
         @Override
         public void onFrameMetricsAvailable(
                 Window window, FrameMetrics frameMetrics, int dropCountSinceLastInvocation) {
-            long drawDurationsNs = frameMetrics.getMetric(FrameMetrics.DRAW_DURATION);
+
+            long firstDrawFrame = frameMetrics.getMetric(FIRST_DRAW_FRAME);
+            if(firstDrawFrame == 1){
+                return;
+            }
+
+            long drawDurationsNs = frameMetrics.getMetric(DRAW_DURATION);
             // ignore values < 0; something must have gone wrong
             if (drawDurationsNs >= 0) {
                 synchronized (lock) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SlowRenderingDetectorImpl.java
@@ -160,7 +160,7 @@ class SlowRenderingDetectorImpl
                 Window window, FrameMetrics frameMetrics, int dropCountSinceLastInvocation) {
 
             long firstDrawFrame = frameMetrics.getMetric(FIRST_DRAW_FRAME);
-            if(firstDrawFrame == 1){
+            if (firstDrawFrame == 1) {
                 return;
             }
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
@@ -16,14 +16,18 @@
 
 package com.splunk.rum;
 
+import static android.view.FrameMetrics.DRAW_DURATION;
+import static android.view.FrameMetrics.FIRST_DRAW_FRAME;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -134,7 +138,7 @@ public class SlowRenderingDetectorImplTest {
                 .addOnFrameMetricsAvailableListener(activityListenerCaptor.capture(), any());
         SlowRenderingDetectorImpl.PerActivityListener listener = activityListenerCaptor.getValue();
         for (long duration : makeSomeDurations()) {
-            when(frameMetrics.getMetric(FrameMetrics.DRAW_DURATION)).thenReturn(duration);
+            when(frameMetrics.getMetric(DRAW_DURATION)).thenReturn(duration);
             listener.onFrameMetricsAvailable(null, frameMetrics, 0);
         }
 
@@ -167,7 +171,7 @@ public class SlowRenderingDetectorImplTest {
                 .addOnFrameMetricsAvailableListener(activityListenerCaptor.capture(), any());
         SlowRenderingDetectorImpl.PerActivityListener listener = activityListenerCaptor.getValue();
         for (long duration : makeSomeDurations()) {
-            when(frameMetrics.getMetric(FrameMetrics.DRAW_DURATION)).thenReturn(duration);
+            when(frameMetrics.getMetric(DRAW_DURATION)).thenReturn(duration);
             listener.onFrameMetricsAvailable(null, frameMetrics, 0);
         }
 
@@ -176,6 +180,14 @@ public class SlowRenderingDetectorImplTest {
 
         List<SpanData> spans = otelTesting.getSpans();
         assertSpanContent(spans);
+    }
+
+    @Test
+    public void activityListenerSkipsFirstFrame() {
+        SlowRenderingDetectorImpl.PerActivityListener listener = new SlowRenderingDetectorImpl.PerActivityListener(null);
+        when(frameMetrics.getMetric(FIRST_DRAW_FRAME)).thenReturn(1L);
+        listener.onFrameMetricsAvailable(null, frameMetrics, 99);
+        verify(frameMetrics, never()).getMetric(DRAW_DURATION);
     }
 
     private static void assertSpanContent(List<SpanData> spans) {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SlowRenderingDetectorImplTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -184,7 +183,8 @@ public class SlowRenderingDetectorImplTest {
 
     @Test
     public void activityListenerSkipsFirstFrame() {
-        SlowRenderingDetectorImpl.PerActivityListener listener = new SlowRenderingDetectorImpl.PerActivityListener(null);
+        SlowRenderingDetectorImpl.PerActivityListener listener =
+                new SlowRenderingDetectorImpl.PerActivityListener(null);
         when(frameMetrics.getMetric(FIRST_DRAW_FRAME)).thenReturn(1L);
         listener.onFrameMetricsAvailable(null, frameMetrics, 99);
         verify(frameMetrics, never()).getMetric(DRAW_DURATION);


### PR DESCRIPTION
The javadoc in `FrameMetrics` says:
```
     * First draw frames are expected to be slow and should usually be exempt
     * from display jank calculations as they do not cause skips in animations
     * and are usually hidden by window animations or other tricks.
```