### PR TITLE
Guard against empty files.

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -55,7 +55,6 @@ public class SampleApplication extends Application {
                                 spanFilter
                                         .removeSpanAttribute(stringKey("http.user_agent"))
                                         .rejectSpansByName(spanName -> spanName.contains("ignored"))
-                                        .rejectSpansByName(name -> !name.equals("nope"))
                                         // sensitive data in the login http.url attribute
                                         // will be redacted before it hits the exporter
                                         .replaceSpanAttribute(

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -55,6 +55,7 @@ public class SampleApplication extends Application {
                                 spanFilter
                                         .removeSpanAttribute(stringKey("http.user_agent"))
                                         .rejectSpansByName(spanName -> spanName.contains("ignored"))
+                                        .rejectSpansByName(name -> !name.equals("nope"))
                                         // sensitive data in the login http.url attribute
                                         // will be redacted before it hits the exporter
                                         .replaceSpanAttribute(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -60,6 +60,7 @@ class FileSender {
         Log.d(LOG_TAG, "Reading file content for ingest: " + file);
         List<byte[]> encodedSpans = readFileCompletely(file);
         if (encodedSpans.isEmpty()) {
+            fileUtils.safeDelete(file);
             return false;
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
@@ -59,7 +59,7 @@ class ZipkinToDiskSender extends Sender {
 
     @Override
     public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-        if(encodedSpans.isEmpty()){
+        if (encodedSpans.isEmpty()) {
             return Call.create(null);
         }
         if (!storageLimiter.ensureFreeSpace()) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
@@ -59,6 +59,9 @@ class ZipkinToDiskSender extends Sender {
 
     @Override
     public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+        if(encodedSpans.isEmpty()){
+            return Call.create(null);
+        }
         if (!storageLimiter.ensureFreeSpace()) {
             Log.e(
                     SplunkRum.LOG_TAG,

--- a/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/FileSenderTest.java
@@ -62,7 +62,7 @@ class FileSenderTest {
     }
 
     @Test
-    void testEmptyFile() throws Exception {
+    void sendEmptyFile() throws Exception {
         Mockito.reset(fileUtils);
         Mockito.reset(delegate);
         File file = new File("/asdflkajsdfoij");
@@ -70,10 +70,11 @@ class FileSenderTest {
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);
         assertFalse(result);
+        verify(fileUtils).safeDelete(file);
     }
 
     @Test
-    void testHappyPathSendSpans() {
+    void happyPathSendSpans() {
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);
         assertTrue(result);
@@ -81,7 +82,7 @@ class FileSenderTest {
     }
 
     @Test
-    void testSendFailsButNotExceeded() throws Exception {
+    void sendFailsButNotExceeded() throws Exception {
         when(httpCall.execute()).thenThrow(new IOException("boom"));
         FileSender sender = buildSender();
         boolean result = sender.handleFileOnDisk(file);
@@ -91,7 +92,7 @@ class FileSenderTest {
     }
 
     @Test
-    void testSenderFailureRetriesExhausted() throws Exception {
+    void senderFailureRetriesExhausted() throws Exception {
         when(httpCall.execute()).thenThrow(new IOException("boom"));
         FileSender sender = buildSender(3);
         boolean result = sender.handleFileOnDisk(file);
@@ -109,7 +110,7 @@ class FileSenderTest {
     }
 
     @Test
-    void testReadFileFails() throws IOException {
+    void readFileFails() throws IOException {
         Mockito.reset(fileUtils);
         Mockito.reset(delegate);
         when(fileUtils.readFileCompletely(file)).thenThrow(new IOException("boom"));

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -16,6 +16,7 @@
 
 package com.splunk.rum;
 
+import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -23,14 +24,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import static java.util.Collections.emptyList;
-
 import io.opentelemetry.sdk.common.Clock;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -17,15 +17,20 @@
 package com.splunk.rum;
 
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import static java.util.Collections.emptyList;
 
 import io.opentelemetry.sdk.common.Clock;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,8 +56,8 @@ class ZipkinToDiskSenderTest {
 
     @BeforeEach
     void setup() {
-        when(clock.now()).thenReturn(now);
-        when(limiter.ensureFreeSpace()).thenReturn(true);
+        lenient().when(clock.now()).thenReturn(now);
+        lenient().when(limiter.ensureFreeSpace()).thenReturn(true);
     }
 
     @Test
@@ -68,6 +73,18 @@ class ZipkinToDiskSenderTest {
         sender.sendSpans(spans);
 
         verify(fileUtils).writeAsLines(finalPath, spans);
+    }
+
+    @Test
+    void testEmptyListDoesNotWriteFile() {
+        ZipkinToDiskSender sender =
+                ZipkinToDiskSender.builder()
+                        .path(path)
+                        .fileUtils(fileUtils)
+                        .storageLimiter(limiter)
+                        .build();
+        sender.sendSpans(emptyList());
+        verifyNoInteractions(fileUtils);
     }
 
     @Test


### PR DESCRIPTION
This allows empty (zero-byte) span files to be deleted when encountered, but also prevents creating them in the first place when the span batch is empty.