### PR TITLE
Fix the build: Revert version of setup-java

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11


### PR DESCRIPTION
Apparently that release got pulled? It's no longer available anyway.