### PR TITLE
Fix flaky crash reporter test

### DIFF
--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/instrumentation/crash/CrashReporterTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/instrumentation/crash/CrashReporterTest.java
@@ -57,7 +57,7 @@ class CrashReporterTest {
     }
 
     @Test
-    void integrationTest() {
+    void integrationTest() throws InterruptedException {
         InstrumentedApplication instrumentedApplication = mock(InstrumentedApplication.class);
         when(instrumentedApplication.getOpenTelemetrySdk())
                 .thenReturn((OpenTelemetrySdk) testing.getOpenTelemetry());
@@ -75,6 +75,7 @@ class CrashReporterTest {
                         });
         crashingThread.setDaemon(true);
         crashingThread.start();
+        crashingThread.join();
 
         Attributes expectedAttributes =
                 Attributes.builder()


### PR DESCRIPTION
Awaitility also installs an uncaught exception hander. Test fails when background thread is thrown after `assertTrace` has called `await`. Adding sleep to background thread before throwing exception makes the test fail reliably.