### PR TITLE
Extract unified lifecycle instrumentation to new class 

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -23,7 +23,6 @@ import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
 import static com.splunk.rum.SplunkRum.RUM_VERSION_KEY;
-import static java.util.Objects.requireNonNull;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.rum.internal.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
@@ -33,28 +32,15 @@ import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Build;
 import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.splunk.android.rum.R;
-
-import java.io.File;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.logging.Level;
-
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
@@ -80,6 +66,15 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
@@ -206,16 +201,23 @@ class RumInitializer {
 
         otelRumBuilder.addInstrumentation(
                 instrumentedApp -> {
-                    Function<Tracer, Tracer> tracerCustomizer = tracer -> (Tracer) spanName -> {
-                        String component = spanName.equals(APP_START_SPAN_NAME) ? COMPONENT_APPSTART : COMPONENT_UI;
-                        return tracer.spanBuilder(spanName)
-                                .setAttribute(COMPONENT_KEY, component);
-                    };
-                    AndroidLifecycleInstrumentation instrumentation = AndroidLifecycleInstrumentation.builder()
-                            .setVisibleScreenTracker(visibleScreenTracker)
-                            .setStartupTimer(startupTimer)
-                            .setTracerCustomizer(tracerCustomizer)
-                            .build();
+                    Function<Tracer, Tracer> tracerCustomizer =
+                            tracer ->
+                                    (Tracer)
+                                            spanName -> {
+                                                String component =
+                                                        spanName.equals(APP_START_SPAN_NAME)
+                                                                ? COMPONENT_APPSTART
+                                                                : COMPONENT_UI;
+                                                return tracer.spanBuilder(spanName)
+                                                        .setAttribute(COMPONENT_KEY, component);
+                                            };
+                    AndroidLifecycleInstrumentation instrumentation =
+                            AndroidLifecycleInstrumentation.builder()
+                                    .setVisibleScreenTracker(visibleScreenTracker)
+                                    .setStartupTimer(startupTimer)
+                                    .setTracerCustomizer(tracerCustomizer)
+                                    .build();
                     instrumentation.installOn(instrumentedApp);
                     initializationEvents.add(
                             new InitializationEvent(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -204,19 +204,18 @@ class RumInitializer {
     private void installLifecycleInstrumentations(
             OpenTelemetryRumBuilder otelRumBuilder, VisibleScreenTracker visibleScreenTracker) {
 
-        Function<Tracer, Tracer> tracerCustomizer = tracer -> (Tracer) spanName -> {
-            String component = spanName.equals(APP_START_SPAN_NAME) ? COMPONENT_APPSTART : COMPONENT_UI;
-            return tracer.spanBuilder(spanName)
-                    .setAttribute(COMPONENT_KEY, component);
-        };
-        AndroidLifecycleInstrumentation instrumentation = AndroidLifecycleInstrumentation.builder()
-                .setVisibleScreenTracker(visibleScreenTracker)
-                .setStartupTimer(startupTimer)
-                .setTracerCustomizer(tracerCustomizer)
-                .build();
-
         otelRumBuilder.addInstrumentation(
                 instrumentedApp -> {
+                    Function<Tracer, Tracer> tracerCustomizer = tracer -> (Tracer) spanName -> {
+                        String component = spanName.equals(APP_START_SPAN_NAME) ? COMPONENT_APPSTART : COMPONENT_UI;
+                        return tracer.spanBuilder(spanName)
+                                .setAttribute(COMPONENT_KEY, component);
+                    };
+                    AndroidLifecycleInstrumentation instrumentation = AndroidLifecycleInstrumentation.builder()
+                            .setVisibleScreenTracker(visibleScreenTracker)
+                            .setStartupTimer(startupTimer)
+                            .setTracerCustomizer(tracerCustomizer)
+                            .build();
                     instrumentation.installOn(instrumentedApp);
                     initializationEvents.add(
                             new InitializationEvent(

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
@@ -1,0 +1,132 @@
+package io.opentelemetry.rum.internal.instrumentation.lifecycle;
+
+import android.app.Application;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import java.util.function.Function;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
+import io.opentelemetry.rum.internal.instrumentation.activity.ActivityCallbacks;
+import io.opentelemetry.rum.internal.instrumentation.activity.ActivityTracerCache;
+import io.opentelemetry.rum.internal.instrumentation.activity.Pre29ActivityCallbacks;
+import io.opentelemetry.rum.internal.instrumentation.activity.Pre29VisibleScreenLifecycleBinding;
+import io.opentelemetry.rum.internal.instrumentation.activity.RumFragmentActivityRegisterer;
+import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenLifecycleBinding;
+import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
+import io.opentelemetry.rum.internal.instrumentation.fragment.RumFragmentLifecycleCallbacks;
+import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
+
+public class AndroidLifecycleInstrumentation {
+
+    private static final String INSTRUMENTATION_SCOPE = "io.opentelemetry.lifecycle";
+    private final AppStartupTimer startupTimer;
+    private final VisibleScreenTracker visibleScreenTracker;
+
+    private final Function<Tracer,Tracer> tracerCustomizer;
+
+    private AndroidLifecycleInstrumentation(Builder builder) {
+        this.startupTimer = builder.startupTimer;
+        this.visibleScreenTracker = builder.visibleScreenTracker;
+        this.tracerCustomizer = builder.tracerCustomizer;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void installOn(InstrumentedApplication app){
+        installStartupTimerInstrumentation(app);
+        installActivityLifecycleEventsInstrumentation(app);
+        installFragmentLifecycleInstrumentation(app);
+        installScreenTrackingInstrumentation(app);
+    }
+
+    private void installStartupTimerInstrumentation(InstrumentedApplication app) {
+        app.getApplication()
+                .registerActivityLifecycleCallbacks(
+                        startupTimer.createLifecycleCallback());
+    }
+
+    private void installActivityLifecycleEventsInstrumentation(InstrumentedApplication app){
+            Application.ActivityLifecycleCallbacks activityCallbacks =
+                    buildActivityEventsCallback(app);
+            app.getApplication().registerActivityLifecycleCallbacks(activityCallbacks);
+    }
+
+    @NonNull
+    private Application.ActivityLifecycleCallbacks buildActivityEventsCallback(InstrumentedApplication instrumentedApp) {
+        Tracer delegateTracer = instrumentedApp.getOpenTelemetrySdk().getTracer(INSTRUMENTATION_SCOPE);
+        Tracer tracer = tracerCustomizer.apply(delegateTracer);
+
+        ActivityTracerCache tracers =
+                new ActivityTracerCache(tracer, visibleScreenTracker, startupTimer);
+        if (Build.VERSION.SDK_INT < 29) {
+            return new Pre29ActivityCallbacks(tracers);
+        }
+        return new ActivityCallbacks(tracers);
+    }
+
+    private void installFragmentLifecycleInstrumentation(InstrumentedApplication app) {
+        Application.ActivityLifecycleCallbacks fragmentRegisterer = buildFragmentRegisterer(app);
+        app.getApplication()
+                .registerActivityLifecycleCallbacks(fragmentRegisterer);
+    }
+
+    @NonNull
+    private Application.ActivityLifecycleCallbacks buildFragmentRegisterer(InstrumentedApplication app) {
+
+        Tracer delegateTracer = app.getOpenTelemetrySdk().getTracer(INSTRUMENTATION_SCOPE);
+        Tracer tracer = tracerCustomizer.apply(delegateTracer);
+        RumFragmentLifecycleCallbacks fragmentLifecycle =
+                new RumFragmentLifecycleCallbacks(tracer, visibleScreenTracker);
+        if (Build.VERSION.SDK_INT < 29) {
+            return RumFragmentActivityRegisterer.createPre29(fragmentLifecycle);
+        }
+        return RumFragmentActivityRegisterer.create(fragmentLifecycle);
+    }
+
+    private void installScreenTrackingInstrumentation(InstrumentedApplication app) {
+        Application.ActivityLifecycleCallbacks screenTrackingBinding =
+                buildScreenTrackingBinding(visibleScreenTracker);
+        app.getApplication()
+                .registerActivityLifecycleCallbacks(screenTrackingBinding);
+    }
+
+    @NonNull
+    private Application.ActivityLifecycleCallbacks buildScreenTrackingBinding(
+            VisibleScreenTracker visibleScreenTracker) {
+        if (Build.VERSION.SDK_INT < 29) {
+            return new Pre29VisibleScreenLifecycleBinding(visibleScreenTracker);
+        }
+        return new VisibleScreenLifecycleBinding(visibleScreenTracker);
+    }
+
+    public static class Builder {
+        private AppStartupTimer startupTimer;
+        private VisibleScreenTracker visibleScreenTracker;
+        private Function<Tracer, Tracer> tracerCustomizer = Function.identity();
+
+        public Builder setStartupTimer(AppStartupTimer timer) {
+            this.startupTimer = timer;
+            return this;
+        }
+
+        public Builder setVisibleScreenTracker(VisibleScreenTracker tracker) {
+            this.visibleScreenTracker = tracker;
+            return this;
+        }
+
+        public Builder setTracerCustomizer(Function<Tracer, Tracer> customizer) {
+            this.tracerCustomizer = customizer;
+            return this;
+        }
+
+        public AndroidLifecycleInstrumentation build() {
+            return new AndroidLifecycleInstrumentation(this);
+        }
+    }
+
+}

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
@@ -1,12 +1,24 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.rum.internal.instrumentation.lifecycle;
 
 import android.app.Application;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
-
-import java.util.function.Function;
-
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
 import io.opentelemetry.rum.internal.instrumentation.activity.ActivityCallbacks;
@@ -18,13 +30,14 @@ import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenLifec
 import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.rum.internal.instrumentation.fragment.RumFragmentLifecycleCallbacks;
 import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
+import java.util.function.Function;
 
 /**
- * This is an umbrella instrumentation that covers several things:
- * * startup timer callback is registered so that UI startup time can be measured
- * - activity lifecycle callbacks are registered so that lifecycle events can be generated
- * - activity lifecycle callback listener is registered to that will register a FragmentLifecycleCallbacks when appropriate
- * - activity lifecycle callback listener is registered to dispatch events to the VisibleScreenTracker
+ * This is an umbrella instrumentation that covers several things: * startup timer callback is
+ * registered so that UI startup time can be measured - activity lifecycle callbacks are registered
+ * so that lifecycle events can be generated - activity lifecycle callback listener is registered to
+ * that will register a FragmentLifecycleCallbacks when appropriate - activity lifecycle callback
+ * listener is registered to dispatch events to the VisibleScreenTracker
  */
 public class AndroidLifecycleInstrumentation {
 
@@ -32,7 +45,7 @@ public class AndroidLifecycleInstrumentation {
     private final AppStartupTimer startupTimer;
     private final VisibleScreenTracker visibleScreenTracker;
 
-    private final Function<Tracer,Tracer> tracerCustomizer;
+    private final Function<Tracer, Tracer> tracerCustomizer;
 
     private AndroidLifecycleInstrumentation(Builder builder) {
         this.startupTimer = builder.startupTimer;
@@ -44,7 +57,7 @@ public class AndroidLifecycleInstrumentation {
         return new Builder();
     }
 
-    public void installOn(InstrumentedApplication app){
+    public void installOn(InstrumentedApplication app) {
         installStartupTimerInstrumentation(app);
         installActivityLifecycleEventsInstrumentation(app);
         installFragmentLifecycleInstrumentation(app);
@@ -53,19 +66,19 @@ public class AndroidLifecycleInstrumentation {
 
     private void installStartupTimerInstrumentation(InstrumentedApplication app) {
         app.getApplication()
-                .registerActivityLifecycleCallbacks(
-                        startupTimer.createLifecycleCallback());
+                .registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback());
     }
 
-    private void installActivityLifecycleEventsInstrumentation(InstrumentedApplication app){
-            Application.ActivityLifecycleCallbacks activityCallbacks =
-                    buildActivityEventsCallback(app);
-            app.getApplication().registerActivityLifecycleCallbacks(activityCallbacks);
+    private void installActivityLifecycleEventsInstrumentation(InstrumentedApplication app) {
+        Application.ActivityLifecycleCallbacks activityCallbacks = buildActivityEventsCallback(app);
+        app.getApplication().registerActivityLifecycleCallbacks(activityCallbacks);
     }
 
     @NonNull
-    private Application.ActivityLifecycleCallbacks buildActivityEventsCallback(InstrumentedApplication instrumentedApp) {
-        Tracer delegateTracer = instrumentedApp.getOpenTelemetrySdk().getTracer(INSTRUMENTATION_SCOPE);
+    private Application.ActivityLifecycleCallbacks buildActivityEventsCallback(
+            InstrumentedApplication instrumentedApp) {
+        Tracer delegateTracer =
+                instrumentedApp.getOpenTelemetrySdk().getTracer(INSTRUMENTATION_SCOPE);
         Tracer tracer = tracerCustomizer.apply(delegateTracer);
 
         ActivityTracerCache tracers =
@@ -78,12 +91,12 @@ public class AndroidLifecycleInstrumentation {
 
     private void installFragmentLifecycleInstrumentation(InstrumentedApplication app) {
         Application.ActivityLifecycleCallbacks fragmentRegisterer = buildFragmentRegisterer(app);
-        app.getApplication()
-                .registerActivityLifecycleCallbacks(fragmentRegisterer);
+        app.getApplication().registerActivityLifecycleCallbacks(fragmentRegisterer);
     }
 
     @NonNull
-    private Application.ActivityLifecycleCallbacks buildFragmentRegisterer(InstrumentedApplication app) {
+    private Application.ActivityLifecycleCallbacks buildFragmentRegisterer(
+            InstrumentedApplication app) {
 
         Tracer delegateTracer = app.getOpenTelemetrySdk().getTracer(INSTRUMENTATION_SCOPE);
         Tracer tracer = tracerCustomizer.apply(delegateTracer);
@@ -98,8 +111,7 @@ public class AndroidLifecycleInstrumentation {
     private void installScreenTrackingInstrumentation(InstrumentedApplication app) {
         Application.ActivityLifecycleCallbacks screenTrackingBinding =
                 buildScreenTrackingBinding(visibleScreenTracker);
-        app.getApplication()
-                .registerActivityLifecycleCallbacks(screenTrackingBinding);
+        app.getApplication().registerActivityLifecycleCallbacks(screenTrackingBinding);
     }
 
     @NonNull
@@ -135,5 +147,4 @@ public class AndroidLifecycleInstrumentation {
             return new AndroidLifecycleInstrumentation(this);
         }
     }
-
 }

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
@@ -19,6 +19,13 @@ import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTrack
 import io.opentelemetry.rum.internal.instrumentation.fragment.RumFragmentLifecycleCallbacks;
 import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
 
+/**
+ * This is an umbrella instrumentation that covers several things:
+ * * startup timer callback is registered so that UI startup time can be measured
+ * - activity lifecycle callbacks are registered so that lifecycle events can be generated
+ * - activity lifecycle callback listener is registered to that will register a FragmentLifecycleCallbacks when appropriate
+ * - activity lifecycle callback listener is registered to dispatch events to the VisibleScreenTracker
+ */
 public class AndroidLifecycleInstrumentation {
 
     private static final String INSTRUMENTATION_SCOPE = "io.opentelemetry.lifecycle";

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
@@ -122,5 +122,4 @@ public class AndroidLifecycleInstrumentation {
         }
         return new VisibleScreenLifecycleBinding(visibleScreenTracker);
     }
-
 }

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentation.java
@@ -47,14 +47,14 @@ public class AndroidLifecycleInstrumentation {
 
     private final Function<Tracer, Tracer> tracerCustomizer;
 
-    private AndroidLifecycleInstrumentation(Builder builder) {
+    AndroidLifecycleInstrumentation(AndroidLifecycleInstrumentationBuilder builder) {
         this.startupTimer = builder.startupTimer;
         this.visibleScreenTracker = builder.visibleScreenTracker;
         this.tracerCustomizer = builder.tracerCustomizer;
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static AndroidLifecycleInstrumentationBuilder builder() {
+        return new AndroidLifecycleInstrumentationBuilder();
     }
 
     public void installOn(InstrumentedApplication app) {
@@ -123,28 +123,4 @@ public class AndroidLifecycleInstrumentation {
         return new VisibleScreenLifecycleBinding(visibleScreenTracker);
     }
 
-    public static class Builder {
-        private AppStartupTimer startupTimer;
-        private VisibleScreenTracker visibleScreenTracker;
-        private Function<Tracer, Tracer> tracerCustomizer = Function.identity();
-
-        public Builder setStartupTimer(AppStartupTimer timer) {
-            this.startupTimer = timer;
-            return this;
-        }
-
-        public Builder setVisibleScreenTracker(VisibleScreenTracker tracker) {
-            this.visibleScreenTracker = tracker;
-            return this;
-        }
-
-        public Builder setTracerCustomizer(Function<Tracer, Tracer> customizer) {
-            this.tracerCustomizer = customizer;
-            return this;
-        }
-
-        public AndroidLifecycleInstrumentation build() {
-            return new AndroidLifecycleInstrumentation(this);
-        }
-    }
 }

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentationBuilder.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentationBuilder.java
@@ -1,10 +1,25 @@
-package io.opentelemetry.rum.internal.instrumentation.lifecycle;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.function.Function;
+package io.opentelemetry.rum.internal.instrumentation.lifecycle;
 
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
+import java.util.function.Function;
 
 public class AndroidLifecycleInstrumentationBuilder {
     AppStartupTimer startupTimer;
@@ -16,12 +31,14 @@ public class AndroidLifecycleInstrumentationBuilder {
         return this;
     }
 
-    public AndroidLifecycleInstrumentationBuilder setVisibleScreenTracker(VisibleScreenTracker tracker) {
+    public AndroidLifecycleInstrumentationBuilder setVisibleScreenTracker(
+            VisibleScreenTracker tracker) {
         this.visibleScreenTracker = tracker;
         return this;
     }
 
-    public AndroidLifecycleInstrumentationBuilder setTracerCustomizer(Function<Tracer, Tracer> customizer) {
+    public AndroidLifecycleInstrumentationBuilder setTracerCustomizer(
+            Function<Tracer, Tracer> customizer) {
         this.tracerCustomizer = customizer;
         return this;
     }

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentationBuilder.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/instrumentation/lifecycle/AndroidLifecycleInstrumentationBuilder.java
@@ -1,0 +1,32 @@
+package io.opentelemetry.rum.internal.instrumentation.lifecycle;
+
+import java.util.function.Function;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
+import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
+
+public class AndroidLifecycleInstrumentationBuilder {
+    AppStartupTimer startupTimer;
+    VisibleScreenTracker visibleScreenTracker;
+    Function<Tracer, Tracer> tracerCustomizer = Function.identity();
+
+    public AndroidLifecycleInstrumentationBuilder setStartupTimer(AppStartupTimer timer) {
+        this.startupTimer = timer;
+        return this;
+    }
+
+    public AndroidLifecycleInstrumentationBuilder setVisibleScreenTracker(VisibleScreenTracker tracker) {
+        this.visibleScreenTracker = tracker;
+        return this;
+    }
+
+    public AndroidLifecycleInstrumentationBuilder setTracerCustomizer(Function<Tracer, Tracer> customizer) {
+        this.tracerCustomizer = customizer;
+        return this;
+    }
+
+    public AndroidLifecycleInstrumentation build() {
+        return new AndroidLifecycleInstrumentation(this);
+    }
+}


### PR DESCRIPTION
This builds on https://github.com/signalfx/splunk-otel-android/pull/478.
It primarily takes the 4 bundled pieces of "lifecycle" instrumentation (startup, activity, fragment, and screen tracking glue) and moves them out of the RumInitializer and into a new package lifecycle with a new class called AndroidLifecycleInstrumentation. This then uses the installOn(InstrumentedApp) approach used in several other instrumentations.

I like that it removes a lot of reusable boilerplate and shrinks the size of the RumInstrumentation class.

What I'm not stoked on is that the lifecycle package only has one class, and the AppStartupTimer still has tendrils all over the place. It would also be nice to figure out what to do with RumInitializer.recordInitializationSpans() eventually.