### PR TITLE
More RumInitializer refactoring

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+public class ConfigFlags {
+    private boolean debugEnabled = false;
+    private boolean diskBufferingEnabled = false;
+    private boolean reactNativeSupportEnabled = false;
+    private boolean crashReportingEnabled = true;
+    private boolean networkMonitorEnabled = true;
+    private boolean anrDetectionEnabled = true;
+    private boolean slowRenderingDetectionEnabled = true;
+
+    public void enableDebug() {
+        debugEnabled = true;
+    }
+
+    public void enableDiskBuffering() {
+        diskBufferingEnabled = true;
+    }
+
+    public void enableReactNativeSupport() {
+        reactNativeSupportEnabled = true;
+    }
+
+    public void disableCrashReporting() {
+        crashReportingEnabled = false;
+    }
+
+    public void disableNetworkMonitor() {
+        networkMonitorEnabled = false;
+    }
+
+    public void disableAnrDetection() {
+        anrDetectionEnabled = false;
+    }
+
+    public void disableSlowRenderingDetection() {
+        slowRenderingDetectionEnabled = false;
+    }
+
+    public boolean isDebugEnabled() {
+        return debugEnabled;
+    }
+
+    public boolean isAnrDetectionEnabled() {
+        return anrDetectionEnabled;
+    }
+
+    public boolean isNetworkMonitorEnabled() {
+        return networkMonitorEnabled;
+    }
+
+    public boolean isSlowRenderingDetectionEnabled() {
+        return slowRenderingDetectionEnabled;
+    }
+
+    public boolean isCrashReportingEnabled() {
+        return crashReportingEnabled;
+    }
+
+    public boolean isDiskBufferingEnabled() {
+        return diskBufferingEnabled;
+    }
+
+    public boolean isReactNativeSupportEnabled() {
+        return reactNativeSupportEnabled;
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
@@ -16,7 +16,7 @@
 
 package com.splunk.rum;
 
-public class ConfigFlags {
+class ConfigFlags {
     private boolean debugEnabled = false;
     private boolean diskBufferingEnabled = false;
     private boolean reactNativeSupportEnabled = false;
@@ -25,59 +25,59 @@ public class ConfigFlags {
     private boolean anrDetectionEnabled = true;
     private boolean slowRenderingDetectionEnabled = true;
 
-    public void enableDebug() {
+    void enableDebug() {
         debugEnabled = true;
     }
 
-    public void enableDiskBuffering() {
+    void enableDiskBuffering() {
         diskBufferingEnabled = true;
     }
 
-    public void enableReactNativeSupport() {
+    void enableReactNativeSupport() {
         reactNativeSupportEnabled = true;
     }
 
-    public void disableCrashReporting() {
+    void disableCrashReporting() {
         crashReportingEnabled = false;
     }
 
-    public void disableNetworkMonitor() {
+    void disableNetworkMonitor() {
         networkMonitorEnabled = false;
     }
 
-    public void disableAnrDetection() {
+    void disableAnrDetection() {
         anrDetectionEnabled = false;
     }
 
-    public void disableSlowRenderingDetection() {
+    void disableSlowRenderingDetection() {
         slowRenderingDetectionEnabled = false;
     }
 
-    public boolean isDebugEnabled() {
+    boolean isDebugEnabled() {
         return debugEnabled;
     }
 
-    public boolean isAnrDetectionEnabled() {
+    boolean isAnrDetectionEnabled() {
         return anrDetectionEnabled;
     }
 
-    public boolean isNetworkMonitorEnabled() {
+    boolean isNetworkMonitorEnabled() {
         return networkMonitorEnabled;
     }
 
-    public boolean isSlowRenderingDetectionEnabled() {
+    boolean isSlowRenderingDetectionEnabled() {
         return slowRenderingDetectionEnabled;
     }
 
-    public boolean isCrashReportingEnabled() {
+    boolean isCrashReportingEnabled() {
         return crashReportingEnabled;
     }
 
-    public boolean isDiskBufferingEnabled() {
+    boolean isDiskBufferingEnabled() {
         return diskBufferingEnabled;
     }
 
-    public boolean isReactNativeSupportEnabled() {
+    boolean isReactNativeSupportEnabled() {
         return reactNativeSupportEnabled;
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import androidx.annotation.NonNull;
+
 class ConfigFlags {
     private boolean debugEnabled = false;
     private boolean diskBufferingEnabled = false;
@@ -79,5 +81,25 @@ class ConfigFlags {
 
     boolean isReactNativeSupportEnabled() {
         return reactNativeSupportEnabled;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "[debug:"
+                + debugEnabled
+                + ","
+                + "crashReporting:"
+                + crashReportingEnabled
+                + ","
+                + "anrReporting:"
+                + anrDetectionEnabled
+                + ","
+                + "slowRenderingDetector:"
+                + slowRenderingDetectionEnabled
+                + ","
+                + "networkMonitor:"
+                + networkMonitorEnabled
+                + "]";
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static com.splunk.rum.SplunkRum.COMPONENT_APPSTART;
+import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
+
+import androidx.annotation.NonNull;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.rum.internal.instrumentation.startup.AppStartupTimer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+class InitializationEvents {
+    private final AppStartupTimer startupTimer;
+    private final List<Event> events = new ArrayList<>();
+
+    InitializationEvents(AppStartupTimer startupTimer) {
+        this.startupTimer = startupTimer;
+    }
+
+    void emit(String eventName) {
+        events.add(new Event(eventName, startupTimer.clockNow()));
+    }
+
+    void recordInitializationSpans(long startTimeNanos, ConfigFlags flags, Tracer delegateTracer) {
+        Tracer tracer =
+                spanName ->
+                        delegateTracer
+                                .spanBuilder(spanName)
+                                .setAttribute(COMPONENT_KEY, COMPONENT_APPSTART);
+
+        Span overallAppStart = startupTimer.start(tracer);
+        Span span =
+                tracer.spanBuilder("SplunkRum.initialize")
+                        .setParent(Context.current().with(overallAppStart))
+                        .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+                        .setAttribute(COMPONENT_KEY, COMPONENT_APPSTART)
+                        .startSpan();
+
+        String configSettings = buildConfigSettings(flags);
+        span.setAttribute("config_settings", configSettings);
+
+        for (Event initializationEvent : events) {
+            span.addEvent(initializationEvent.name, initializationEvent.time, TimeUnit.NANOSECONDS);
+        }
+        long spanEndTime = startupTimer.clockNow();
+        // we only want to create SplunkRum.initialize span when there is a AppStart span so we
+        // register a callback that is called right before AppStart span is ended
+        startupTimer.setCompletionCallback(() -> span.end(spanEndTime, TimeUnit.NANOSECONDS));
+    }
+
+    @NonNull
+    private String buildConfigSettings(ConfigFlags flags) {
+        return "[debug:"
+                + flags.isDebugEnabled()
+                + ","
+                + "crashReporting:"
+                + flags.isCrashReportingEnabled()
+                + ","
+                + "anrReporting:"
+                + flags.isAnrDetectionEnabled()
+                + ","
+                + "slowRenderingDetector:"
+                + flags.isSlowRenderingDetectionEnabled()
+                + ","
+                + "networkMonitor:"
+                + flags.isNetworkMonitorEnabled()
+                + "]";
+    }
+
+    private static class Event {
+        private final String name;
+        private final long time;
+
+        private Event(String name, long time) {
+            this.name = name;
+            this.time = time;
+        }
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
@@ -31,16 +31,21 @@ import java.util.concurrent.TimeUnit;
 class InitializationEvents {
     private final AppStartupTimer startupTimer;
     private final List<Event> events = new ArrayList<>();
+    private long startTimeNanos = -1;
 
     InitializationEvents(AppStartupTimer startupTimer) {
         this.startupTimer = startupTimer;
+    }
+
+    void begin() {
+        startTimeNanos = startupTimer.clockNow();
     }
 
     void emit(String eventName) {
         events.add(new Event(eventName, startupTimer.clockNow()));
     }
 
-    void recordInitializationSpans(long startTimeNanos, ConfigFlags flags, Tracer delegateTracer) {
+    void recordInitializationSpans(ConfigFlags flags, Tracer delegateTracer) {
         Tracer tracer =
                 spanName ->
                         delegateTracer

--- a/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
@@ -52,7 +52,6 @@ class InitializationEvents {
                 tracer.spanBuilder("SplunkRum.initialize")
                         .setParent(Context.current().with(overallAppStart))
                         .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
-                        .setAttribute(COMPONENT_KEY, COMPONENT_APPSTART)
                         .startSpan();
 
         String configSettings = buildConfigSettings(flags);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
@@ -19,7 +19,6 @@ package com.splunk.rum;
 import static com.splunk.rum.SplunkRum.COMPONENT_APPSTART;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 
-import androidx.annotation.NonNull;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/InitializationEvents.java
@@ -54,8 +54,7 @@ class InitializationEvents {
                         .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
                         .startSpan();
 
-        String configSettings = buildConfigSettings(flags);
-        span.setAttribute("config_settings", configSettings);
+        span.setAttribute("config_settings", flags.toString());
 
         for (Event initializationEvent : events) {
             span.addEvent(initializationEvent.name, initializationEvent.time, TimeUnit.NANOSECONDS);
@@ -64,25 +63,6 @@ class InitializationEvents {
         // we only want to create SplunkRum.initialize span when there is a AppStart span so we
         // register a callback that is called right before AppStart span is ended
         startupTimer.setCompletionCallback(() -> span.end(spanEndTime, TimeUnit.NANOSECONDS));
-    }
-
-    @NonNull
-    private String buildConfigSettings(ConfigFlags flags) {
-        return "[debug:"
-                + flags.isDebugEnabled()
-                + ","
-                + "crashReporting:"
-                + flags.isCrashReportingEnabled()
-                + ","
-                + "anrReporting:"
-                + flags.isAnrDetectionEnabled()
-                + ","
-                + "slowRenderingDetector:"
-                + flags.isSlowRenderingDetectionEnabled()
-                + ","
-                + "networkMonitor:"
-                + flags.isNetworkMonitorEnabled()
-                + "]";
     }
 
     private static class Event {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -97,7 +97,7 @@ class RumInitializer {
             Looper mainLooper) {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
 
-        long startTimeNanos = startupTimer.clockNow();
+        initializationEvents.begin();
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder();
 
         otelRumBuilder.setResource(createResource());
@@ -206,7 +206,6 @@ class RumInitializer {
         OpenTelemetryRum openTelemetryRum = otelRumBuilder.build(application);
 
         initializationEvents.recordInitializationSpans(
-                startTimeNanos,
                 builder.getConfigFlags(),
                 openTelemetryRum.getOpenTelemetry().getTracer(RUM_TRACER_NAME));
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -40,9 +40,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.android.rum.R;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.rum.internal.GlobalAttributesSpanAppender;
@@ -68,10 +66,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.File;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -87,13 +82,14 @@ class RumInitializer {
     private final SplunkRumBuilder builder;
     private final Application application;
     private final AppStartupTimer startupTimer;
-    private final List<RumInitializer.InitializationEvent> initializationEvents = new ArrayList<>();
+    private final InitializationEvents initializationEvents;
 
     RumInitializer(
             SplunkRumBuilder builder, Application application, AppStartupTimer startupTimer) {
         this.builder = builder;
         this.application = application;
         this.startupTimer = startupTimer;
+        this.initializationEvents = new InitializationEvents(startupTimer);
     }
 
     SplunkRum initialize(
@@ -105,14 +101,11 @@ class RumInitializer {
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder();
 
         otelRumBuilder.setResource(createResource());
-        initializationEvents.add(
-                new RumInitializer.InitializationEvent(
-                        "resourceInitialized", startupTimer.clockNow()));
+        initializationEvents.emit("resourceInitialized");
 
         CurrentNetworkProvider currentNetworkProvider =
                 currentNetworkProviderFactory.apply(application);
-        initializationEvents.add(
-                new InitializationEvent("connectionUtilInitialized", startupTimer.clockNow()));
+        initializationEvents.emit("connectionUtilInitialized");
 
         // TODO: How truly important is the order of these span processors? The location of event
         // generation should probably not be altered...
@@ -121,90 +114,89 @@ class RumInitializer {
                 GlobalAttributesSpanAppender.create(builder.globalAttributes);
 
         // Add span processor that appends global attributes.
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) ->
-                tracerProviderBuilder.addSpanProcessor(globalAttributesSpanAppender));
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) ->
+                        tracerProviderBuilder.addSpanProcessor(globalAttributesSpanAppender));
 
         // Add span processor that appends network attributes.
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-            SpanProcessor networkAttributesSpanAppender =
-                    NetworkAttributesSpanAppender.create(currentNetworkProvider);
-            return tracerProviderBuilder.addSpanProcessor(networkAttributesSpanAppender);
-        });
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) -> {
+                    SpanProcessor networkAttributesSpanAppender =
+                            NetworkAttributesSpanAppender.create(currentNetworkProvider);
+                    return tracerProviderBuilder.addSpanProcessor(networkAttributesSpanAppender);
+                });
 
         // Add span processor that appends screen attributes and generate init event.
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-            ScreenAttributesAppender screenAttributesAppender =
-                    new ScreenAttributesAppender(visibleScreenTracker);
-            initializationEvents.add(
-                    new RumInitializer.InitializationEvent(
-                            "attributeAppenderInitialized", startupTimer.clockNow()));
-            return tracerProviderBuilder.addSpanProcessor(screenAttributesAppender);
-        });
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) -> {
+                    ScreenAttributesAppender screenAttributesAppender =
+                            new ScreenAttributesAppender(visibleScreenTracker);
+                    initializationEvents.emit("attributeAppenderInitialized");
+                    return tracerProviderBuilder.addSpanProcessor(screenAttributesAppender);
+                });
 
         // Add batch span processor
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-            SpanExporter zipkinExporter = buildFilteringExporter(currentNetworkProvider);
-            initializationEvents.add(
-                    new RumInitializer.InitializationEvent(
-                            "exporterInitialized", startupTimer.clockNow()));
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) -> {
+                    SpanExporter zipkinExporter = buildFilteringExporter(currentNetworkProvider);
+                    initializationEvents.emit("exporterInitialized");
 
-            BatchSpanProcessor batchSpanProcessor =
-                    BatchSpanProcessor.builder(zipkinExporter).build();
-            initializationEvents.add(
-                    new RumInitializer.InitializationEvent(
-                            "batchSpanProcessorInitialized", startupTimer.clockNow()));
-            return tracerProviderBuilder.addSpanProcessor(batchSpanProcessor);
-        });
+                    BatchSpanProcessor batchSpanProcessor =
+                            BatchSpanProcessor.builder(zipkinExporter).build();
+                    initializationEvents.emit("batchSpanProcessorInitialized");
+                    return tracerProviderBuilder.addSpanProcessor(batchSpanProcessor);
+                });
 
         // Set span limits
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) ->
-                tracerProviderBuilder.setSpanLimits(
-                        SpanLimits.builder()
-                                .setMaxAttributeValueLength(MAX_ATTRIBUTE_LENGTH)
-                                .build()));
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) ->
+                        tracerProviderBuilder.setSpanLimits(
+                                SpanLimits.builder()
+                                        .setMaxAttributeValueLength(MAX_ATTRIBUTE_LENGTH)
+                                        .build()));
 
         // Set up the sampler, if enabled
         if (builder.sessionBasedSamplerEnabled) {
-            otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-                // TODO: this is hacky behavior that utilizes a mutable variable, fix this!
-                return tracerProviderBuilder.setSampler(
-                        new SessionIdRatioBasedSampler(
-                                builder.sessionBasedSamplerRatio, () -> SplunkRum.getInstance().getRumSessionId()));
-            });
+            otelRumBuilder.addTracerProviderCustomizer(
+                    (tracerProviderBuilder, app) -> {
+                        // TODO: this is hacky behavior that utilizes a mutable variable, fix this!
+                        return tracerProviderBuilder.setSampler(
+                                new SessionIdRatioBasedSampler(
+                                        builder.sessionBasedSamplerRatio,
+                                        () -> SplunkRum.getInstance().getRumSessionId()));
+                    });
         }
 
         // Wire up the logging exporter, if enabled.
-        if (builder.debugEnabled) {
-            otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-                tracerProviderBuilder.addSpanProcessor(
-                        SimpleSpanProcessor.create(
-                                builder.decorateWithSpanFilter(
-                                        LoggingSpanExporter.create())));
-                initializationEvents.add(
-                        new RumInitializer.InitializationEvent(
-                                "debugSpanExporterInitialized", startupTimer.clockNow()));
-                return tracerProviderBuilder;
-            });
+        if (builder.isDebugEnabled()) {
+            otelRumBuilder.addTracerProviderCustomizer(
+                    (tracerProviderBuilder, app) -> {
+                        tracerProviderBuilder.addSpanProcessor(
+                                SimpleSpanProcessor.create(
+                                        builder.decorateWithSpanFilter(
+                                                LoggingSpanExporter.create())));
+                        initializationEvents.emit("debugSpanExporterInitialized");
+                        return tracerProviderBuilder;
+                    });
         }
 
-        //Add final event showing tracer provider init finished
-        otelRumBuilder.addTracerProviderCustomizer((tracerProviderBuilder, app) -> {
-            initializationEvents.add(
-                    new RumInitializer.InitializationEvent(
-                            "tracerProviderInitialized", startupTimer.clockNow()));
-            return tracerProviderBuilder;
-        });
+        // Add final event showing tracer provider init finished
+        otelRumBuilder.addTracerProviderCustomizer(
+                (tracerProviderBuilder, app) -> {
+                    initializationEvents.emit("tracerProviderInitialized");
+                    return tracerProviderBuilder;
+                });
 
-        if (builder.anrDetectionEnabled) {
+        if (builder.isAnrDetectionEnabled()) {
             installAnrDetector(otelRumBuilder, mainLooper);
         }
-        if (builder.networkMonitorEnabled) {
+        if (builder.isNetworkMonitorEnabled()) {
             installNetworkMonitor(otelRumBuilder, currentNetworkProvider);
         }
-        if (builder.slowRenderingDetectionEnabled) {
+        if (builder.isSlowRenderingDetectionEnabled()) {
             installSlowRenderingDetector(otelRumBuilder);
         }
-        if (builder.crashReportingEnabled) {
+        if (builder.isCrashReportingEnabled()) {
             installCrashReporter(otelRumBuilder);
         }
 
@@ -213,9 +205,9 @@ class RumInitializer {
 
         OpenTelemetryRum openTelemetryRum = otelRumBuilder.build(application);
 
-        recordInitializationSpans(
+        initializationEvents.recordInitializationSpans(
                 startTimeNanos,
-                initializationEvents,
+                builder.getConfigFlags(),
                 openTelemetryRum.getOpenTelemetry().getTracer(RUM_TRACER_NAME));
 
         return new SplunkRum(openTelemetryRum, globalAttributesSpanAppender);
@@ -244,10 +236,7 @@ class RumInitializer {
                                     .setTracerCustomizer(tracerCustomizer)
                                     .build();
                     instrumentation.installOn(instrumentedApp);
-                    initializationEvents.add(
-                            new InitializationEvent(
-                                    "activityLifecycleCallbacksInitialized",
-                                    startupTimer.clockNow()));
+                    initializationEvents.emit("activityLifecycleCallbacksInitialized");
                 });
     }
 
@@ -294,9 +283,7 @@ class RumInitializer {
                             .build()
                             .installOn(instrumentedApplication);
 
-                    initializationEvents.add(
-                            new InitializationEvent(
-                                    "anrMonitorInitialized", startupTimer.clockNow()));
+                    initializationEvents.emit("anrMonitorInitialized");
                 });
     }
 
@@ -306,9 +293,7 @@ class RumInitializer {
                 instrumentedApplication -> {
                     NetworkChangeMonitor.create(currentNetworkProvider)
                             .installOn(instrumentedApplication);
-                    initializationEvents.add(
-                            new InitializationEvent(
-                                    "networkMonitorInitialized", startupTimer.clockNow()));
+                    initializationEvents.emit("networkMonitorInitialized");
                 });
     }
 
@@ -320,9 +305,7 @@ class RumInitializer {
                                     builder.slowRenderingDetectionPollInterval)
                             .build()
                             .installOn(instrumentedApplication);
-                    initializationEvents.add(
-                            new InitializationEvent(
-                                    "slowRenderingDetectorInitialized", startupTimer.clockNow()));
+                    initializationEvents.emit("slowRenderingDetectorInitialized");
                 });
     }
 
@@ -339,79 +322,29 @@ class RumInitializer {
                             .build()
                             .installOn(instrumentedApplication);
 
-                    initializationEvents.add(
-                            new InitializationEvent(
-                                    "crashReportingInitialized", startupTimer.clockNow()));
+                    initializationEvents.emit("crashReportingInitialized");
                 });
-    }
-
-    private void recordInitializationSpans(
-            long startTimeNanos,
-            List<InitializationEvent> initializationEvents,
-            Tracer delegateTracer) {
-
-        Tracer tracer =
-                spanName ->
-                        delegateTracer
-                                .spanBuilder(spanName)
-                                .setAttribute(COMPONENT_KEY, COMPONENT_APPSTART);
-
-        Span overallAppStart = startupTimer.start(tracer);
-        Span span =
-                tracer.spanBuilder("SplunkRum.initialize")
-                        .setParent(Context.current().with(overallAppStart))
-                        .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
-                        .setAttribute(COMPONENT_KEY, COMPONENT_APPSTART)
-                        .startSpan();
-
-        String configSettings =
-                "[debug:"
-                        + builder.debugEnabled
-                        + ","
-                        + "crashReporting:"
-                        + builder.crashReportingEnabled
-                        + ","
-                        + "anrReporting:"
-                        + builder.anrDetectionEnabled
-                        + ","
-                        + "slowRenderingDetector:"
-                        + builder.slowRenderingDetectionEnabled
-                        + ","
-                        + "networkMonitor:"
-                        + builder.networkMonitorEnabled
-                        + "]";
-        span.setAttribute("config_settings", configSettings);
-
-        for (RumInitializer.InitializationEvent initializationEvent : initializationEvents) {
-            span.addEvent(initializationEvent.name, initializationEvent.time, TimeUnit.NANOSECONDS);
-        }
-        long spanEndTime = startupTimer.clockNow();
-        // we only want to create SplunkRum.initialize span when there is a AppStart span so we
-        // register a callback that is called right before AppStart span is ended
-        startupTimer.setCompletionCallback(() -> span.end(spanEndTime, TimeUnit.NANOSECONDS));
     }
 
     // visible for testing
     SpanExporter buildFilteringExporter(CurrentNetworkProvider currentNetworkProvider) {
         SpanExporter exporter = buildExporter(currentNetworkProvider);
         SpanExporter splunkTranslatedExporter =
-                new SplunkSpanDataModifier(exporter, builder.reactNativeSupportEnabled);
+                new SplunkSpanDataModifier(exporter, builder.isReactNativeSupportEnabled());
         SpanExporter filteredExporter = builder.decorateWithSpanFilter(splunkTranslatedExporter);
-        initializationEvents.add(
-                new InitializationEvent("zipkin exporter initialized", startupTimer.clockNow()));
+        initializationEvents.emit("zipkin exporter initialized");
         return filteredExporter;
     }
 
     private SpanExporter buildExporter(CurrentNetworkProvider currentNetworkProvider) {
-        if (builder.debugEnabled) {
+        if (builder.isDebugEnabled()) {
             // tell the Zipkin exporter to shut up already. We're on mobile, network stuff happens.
             // we'll do our best to hang on to the spans with the wrapping BufferingExporter.
             ZipkinSpanExporter.baseLogger.setLevel(Level.SEVERE);
-            initializationEvents.add(
-                    new InitializationEvent("logger setup complete", startupTimer.clockNow()));
+            initializationEvents.emit("logger setup complete");
         }
 
-        if (builder.diskBufferingEnabled) {
+        if (builder.isDiskBufferingEnabled()) {
             return buildStorageBufferingExporter(currentNetworkProvider);
         }
 
@@ -473,16 +406,6 @@ class RumInitializer {
                                 // remove the local IP address
                                 .setLocalIpAddressSupplier(() -> null)
                                 .build());
-    }
-
-    static class InitializationEvent {
-        private final String name;
-        private final long time;
-
-        private InitializationEvent(String name, long time) {
-            this.name = name;
-            this.time = time;
-        }
     }
 
     private static class LazyInitSpanExporter implements SpanExporter {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
@@ -52,12 +52,7 @@ class SessionIdRatioBasedSampler implements Sampler {
             List<LinkData> parentLinks) {
         // Replace traceId with sessionId
         return ratioBasedSampler.shouldSample(
-                parentContext,
-                sessionIdSupplier.get(),
-                name,
-                spanKind,
-                attributes,
-                parentLinks);
+                parentContext, sessionIdSupplier.get(), name, spanKind, attributes, parentLinks);
     }
 
     @Override

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
@@ -34,10 +34,10 @@ import java.util.function.Supplier;
  */
 class SessionIdRatioBasedSampler implements Sampler {
     private final Sampler ratioBasedSampler;
-    private final Supplier<SplunkRum> splunkRumSupplier;
+    private final Supplier<String> sessionIdSupplier;
 
-    SessionIdRatioBasedSampler(double ratio, Supplier<SplunkRum> splunkRumSupplier) {
-        this.splunkRumSupplier = splunkRumSupplier;
+    SessionIdRatioBasedSampler(double ratio, Supplier<String> splunkRumSupplier) {
+        this.sessionIdSupplier = splunkRumSupplier;
         // SessionId uses the same format as TraceId, so we can reuse trace ID ratio sampler.
         this.ratioBasedSampler = Sampler.traceIdRatioBased(ratio);
     }
@@ -53,7 +53,7 @@ class SessionIdRatioBasedSampler implements Sampler {
         // Replace traceId with sessionId
         return ratioBasedSampler.shouldSample(
                 parentContext,
-                splunkRumSupplier.get().getRumSessionId(),
+                sessionIdSupplier.get(),
                 name,
                 spanKind,
                 attributes,

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -109,7 +109,7 @@ public class SplunkRum {
                 new RumInitializer(builder, application, startupTimer)
                         .initialize(currentNetworkProviderFactory, Looper.getMainLooper());
 
-        if (builder.debugEnabled) {
+        if (builder.isDebugEnabled()) {
             Log.i(
                     LOG_TAG,
                     "Splunk RUM monitoring initialized with session ID: "

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -37,13 +37,9 @@ public final class SplunkRumBuilder {
     @Nullable String beaconEndpoint;
     @Nullable String rumAccessToken;
     @Nullable private String realm;
-    boolean debugEnabled = false;
-    boolean diskBufferingEnabled = false;
-    boolean reactNativeSupportEnabled = false;
-    boolean crashReportingEnabled = true;
-    boolean networkMonitorEnabled = true;
-    boolean anrDetectionEnabled = true;
-    boolean slowRenderingDetectionEnabled = true;
+
+    private final ConfigFlags configFlags = new ConfigFlags();
+
     Duration slowRenderingDetectionPollInterval = DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
     Attributes globalAttributes = Attributes.empty();
     @Nullable String deploymentEnvironment;
@@ -119,7 +115,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder enableDebug() {
-        this.debugEnabled = true;
+        configFlags.enableDebug();
         return this;
     }
 
@@ -133,7 +129,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder enableDiskBuffering() {
-        this.diskBufferingEnabled = true;
+        configFlags.enableDiskBuffering();
         return this;
     }
 
@@ -145,7 +141,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder enableReactNativeSupport() {
-        this.reactNativeSupportEnabled = true;
+        configFlags.enableReactNativeSupport();
         return this;
     }
 
@@ -157,7 +153,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder disableCrashReporting() {
-        this.crashReportingEnabled = false;
+        configFlags.disableCrashReporting();
         return this;
     }
 
@@ -169,7 +165,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder disableNetworkMonitor() {
-        this.networkMonitorEnabled = false;
+        configFlags.disableNetworkMonitor();
         return this;
     }
 
@@ -183,7 +179,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder disableAnrDetection() {
-        this.anrDetectionEnabled = false;
+        configFlags.disableAnrDetection();
         return this;
     }
 
@@ -195,7 +191,7 @@ public final class SplunkRumBuilder {
      * @return {@code this}
      */
     public SplunkRumBuilder disableSlowRenderingDetection() {
-        slowRenderingDetectionEnabled = false;
+        configFlags.disableSlowRenderingDetection();
         return this;
     }
 
@@ -318,7 +314,40 @@ public final class SplunkRumBuilder {
         return SplunkRum.initialize(this, application, CurrentNetworkProvider::createAndStart);
     }
 
+    // one day maybe these can use kotlin delegation
+    ConfigFlags getConfigFlags() {
+        return configFlags;
+    }
+
     SpanExporter decorateWithSpanFilter(SpanExporter exporter) {
         return spanFilterBuilder.build().apply(exporter);
+    }
+
+    boolean isDebugEnabled() {
+        return configFlags.isDebugEnabled();
+    }
+
+    boolean isAnrDetectionEnabled() {
+        return configFlags.isAnrDetectionEnabled();
+    }
+
+    boolean isNetworkMonitorEnabled() {
+        return configFlags.isNetworkMonitorEnabled();
+    }
+
+    boolean isSlowRenderingDetectionEnabled() {
+        return configFlags.isSlowRenderingDetectionEnabled();
+    }
+
+    boolean isCrashReportingEnabled() {
+        return configFlags.isCrashReportingEnabled();
+    }
+
+    boolean isDiskBufferingEnabled() {
+        return configFlags.isDiskBufferingEnabled();
+    }
+
+    boolean isReactNativeSupportEnabled() {
+        return configFlags.isReactNativeSupportEnabled();
     }
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
@@ -16,9 +16,9 @@
 
 package com.splunk.rum;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -61,12 +61,12 @@ class SplunkRumBuilderTest {
     void defaultValues() {
         SplunkRumBuilder builder = SplunkRum.builder();
 
-        assertFalse(builder.debugEnabled);
-        assertFalse(builder.diskBufferingEnabled);
-        assertTrue(builder.crashReportingEnabled);
-        assertTrue(builder.networkMonitorEnabled);
-        assertTrue(builder.anrDetectionEnabled);
-        assertTrue(builder.slowRenderingDetectionEnabled);
+        assertFalse(builder.isDebugEnabled());
+        assertFalse(builder.isDiskBufferingEnabled());
+        assertTrue(builder.isCrashReportingEnabled());
+        assertTrue(builder.isNetworkMonitorEnabled());
+        assertTrue(builder.isAnrDetectionEnabled());
+        assertTrue(builder.isSlowRenderingDetectionEnabled());
         assertEquals(Attributes.empty(), builder.globalAttributes);
         assertNull(builder.deploymentEnvironment);
         assertFalse(builder.sessionBasedSamplerEnabled);


### PR DESCRIPTION
The main points:

* Split and flatten large anonymous `TracerProviderCustomizer` lambda in the `RumInitializer`. Instead, add as a series of sequential steps.
* Encapsulate the init events into a new `InitializationEvents` class.
* Factor out block of boolean config items from builder to own `ConfigFlags` class.
* Change `SessionIdRatioBasedSampler` to take a `Supplier<String>` for the session id (instead of `Supplier<SplunkRum>`