### PR TITLE
Migrate sampler to otel package (take 2)

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -46,6 +46,7 @@ import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.rum.internal.GlobalAttributesSpanAppender;
 import io.opentelemetry.rum.internal.OpenTelemetryRum;
 import io.opentelemetry.rum.internal.OpenTelemetryRumBuilder;
+import io.opentelemetry.rum.internal.SessionIdRatioBasedSampler;
 import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.rum.internal.instrumentation.anr.AnrDetector;
 import io.opentelemetry.rum.internal.instrumentation.crash.CrashReporter;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -159,11 +159,11 @@ class RumInitializer {
         if (builder.sessionBasedSamplerEnabled) {
             otelRumBuilder.addTracerProviderCustomizer(
                     (tracerProviderBuilder, app) -> {
-                        // TODO: this is hacky behavior that utilizes a mutable variable, fix this!
-                        return tracerProviderBuilder.setSampler(
+                        SessionIdRatioBasedSampler sampler =
                                 new SessionIdRatioBasedSampler(
                                         builder.sessionBasedSamplerRatio,
-                                        () -> SplunkRum.getInstance().getRumSessionId()));
+                                        otelRumBuilder.getSessionId());
+                        return tracerProviderBuilder.setSampler(sampler);
                     });
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SessionIdRatioBasedSampler.java
@@ -19,11 +19,11 @@ package com.splunk.rum;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.rum.internal.SessionId;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Session ID ratio based sampler. Uses {@link Sampler#traceIdRatioBased(double)} sampler
@@ -34,10 +34,10 @@ import java.util.function.Supplier;
  */
 class SessionIdRatioBasedSampler implements Sampler {
     private final Sampler ratioBasedSampler;
-    private final Supplier<String> sessionIdSupplier;
+    private final SessionId sessionid;
 
-    SessionIdRatioBasedSampler(double ratio, Supplier<String> splunkRumSupplier) {
-        this.sessionIdSupplier = splunkRumSupplier;
+    SessionIdRatioBasedSampler(double ratio, SessionId sessionId) {
+        this.sessionid = sessionId;
         // SessionId uses the same format as TraceId, so we can reuse trace ID ratio sampler.
         this.ratioBasedSampler = Sampler.traceIdRatioBased(ratio);
     }
@@ -52,7 +52,7 @@ class SessionIdRatioBasedSampler implements Sampler {
             List<LinkData> parentLinks) {
         // Replace traceId with sessionId
         return ratioBasedSampler.shouldSample(
-                parentContext, sessionIdSupplier.get(), name, spanKind, attributes, parentLinks);
+                parentContext, sessionid.getSessionId(), name, spanKind, attributes, parentLinks);
     }
 
     @Override

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
@@ -28,7 +28,9 @@ public interface OpenTelemetryRum {
 
     /** Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum}. */
     static OpenTelemetryRumBuilder builder() {
-        return new OpenTelemetryRumBuilder();
+        SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
+        SessionId sessionId = new SessionId(timeoutHandler);
+        return new OpenTelemetryRumBuilder(sessionId);
     }
 
     /** Returns a no-op implementation of {@link OpenTelemetryRum}. */

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
  */
 public final class OpenTelemetryRumBuilder {
 
+    private final SessionId sessionId;
     private Resource resource = Resource.getDefault();
     private final List<BiFunction<SdkTracerProviderBuilder, Application, SdkTracerProviderBuilder>>
             tracerProviderCustomizers = new ArrayList<>();
@@ -51,7 +52,9 @@ public final class OpenTelemetryRumBuilder {
     private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
             new ArrayList<>();
 
-    OpenTelemetryRumBuilder() {}
+    OpenTelemetryRumBuilder(SessionId sessionId) {
+        this.sessionId = sessionId;
+    }
 
     /**
      * Assign a {@link Resource} to be attached to all telemetry emitted by the {@link
@@ -135,6 +138,10 @@ public final class OpenTelemetryRumBuilder {
         return this;
     }
 
+    public SessionId getSessionId() {
+        return sessionId;
+    }
+
     /**
      * Creates a new instance of {@link OpenTelemetryRum} with the settings of this {@link
      * OpenTelemetryRumBuilder}.
@@ -151,9 +158,7 @@ public final class OpenTelemetryRumBuilder {
         ApplicationStateWatcher applicationStateWatcher = new ApplicationStateWatcher();
         application.registerActivityLifecycleCallbacks(applicationStateWatcher);
 
-        SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
-        SessionId sessionId = new SessionId(timeoutHandler);
-        applicationStateWatcher.registerListener(timeoutHandler);
+        applicationStateWatcher.registerListener(sessionId.getTimeoutHandler());
 
         OpenTelemetrySdk openTelemetrySdk =
                 OpenTelemetrySdk.builder()

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionId.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionId.java
@@ -25,7 +25,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-class SessionId {
+public class SessionId {
 
     private static final long SESSION_LIFETIME_NANOS = TimeUnit.HOURS.toNanos(4);
 
@@ -54,7 +54,11 @@ class SessionId {
         return TraceId.fromLongs(random.nextLong(), random.nextLong());
     }
 
-    String getSessionId() {
+    SessionIdTimeoutHandler getTimeoutHandler() {
+        return timeoutHandler;
+    }
+
+    public String getSessionId() {
         // value will never be null
         String oldValue = requireNonNull(value.get());
         String currentValue = oldValue;

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionId.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionId.java
@@ -25,7 +25,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class SessionId {
+class SessionId {
 
     private static final long SESSION_LIFETIME_NANOS = TimeUnit.HOURS.toNanos(4);
 
@@ -58,7 +58,7 @@ public class SessionId {
         return timeoutHandler;
     }
 
-    public String getSessionId() {
+    String getSessionId() {
         // value will never be null
         String oldValue = requireNonNull(value.get());
         String currentValue = oldValue;

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdRatioBasedSampler.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdRatioBasedSampler.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package com.splunk.rum;
+package io.opentelemetry.rum.internal;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.rum.internal.SessionId;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
@@ -32,11 +31,11 @@ import java.util.List;
  * io.opentelemetry.api.trace.TraceId#fromLongs(long, long)} internally to generate random session
  * IDs.
  */
-class SessionIdRatioBasedSampler implements Sampler {
+public class SessionIdRatioBasedSampler implements Sampler {
     private final Sampler ratioBasedSampler;
     private final SessionId sessionid;
 
-    SessionIdRatioBasedSampler(double ratio, SessionId sessionId) {
+    public SessionIdRatioBasedSampler(double ratio, SessionId sessionId) {
         this.sessionid = sessionId;
         // SessionId uses the same format as TraceId, so we can reuse trace ID ratio sampler.
         this.ratioBasedSampler = Sampler.traceIdRatioBased(ratio);

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdRatioBasedSamplerTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdRatioBasedSamplerTest.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.splunk.rum;
+package io.opentelemetry.rum.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -29,17 +30,16 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SessionIdRatioBasedSamplerTest {
+    @Mock SessionId sessionId;
     private static final String HIGH_ID = "00000000000000008fffffffffffffff";
-    private static final Supplier<String> HIGH_ID_SUPPLIER = () -> HIGH_ID;
     private static final String LOW_ID = "00000000000000000000000000000000";
-    private static final Supplier<String> LOW_ID_SAMPLER = () -> LOW_ID;
     private static final IdGenerator idsGenerator = IdGenerator.random();
 
     private final String traceId = idsGenerator.generateTraceId();
@@ -49,7 +49,9 @@ class SessionIdRatioBasedSamplerTest {
 
     @Test
     void samplerDropsHigh() {
-        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, HIGH_ID_SUPPLIER);
+        when(sessionId.getSessionId()).thenReturn(HIGH_ID);
+
+        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, sessionId);
 
         // Sampler drops if TraceIdRatioBasedSampler would drop this sessionId
         assertEquals(shouldSample(sampler), SamplingDecision.DROP);
@@ -58,25 +60,35 @@ class SessionIdRatioBasedSamplerTest {
     @Test
     void samplerKeepsLowestId() {
         // Sampler accepts if TraceIdRatioBasedSampler would accept this sessionId
-        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, LOW_ID_SAMPLER);
+        when(sessionId.getSessionId()).thenReturn(LOW_ID);
+
+        SessionIdRatioBasedSampler sampler = new SessionIdRatioBasedSampler(0.5, sessionId);
         assertEquals(shouldSample(sampler), SamplingDecision.RECORD_AND_SAMPLE);
     }
 
     @Test
     void zeroRatioDropsAll() {
-        SessionIdRatioBasedSampler samplerHigh =
-                new SessionIdRatioBasedSampler(0.0, HIGH_ID_SUPPLIER);
+        when(sessionId.getSessionId()).thenReturn(HIGH_ID);
+
+        SessionIdRatioBasedSampler samplerHigh = new SessionIdRatioBasedSampler(0.0, sessionId);
         assertEquals(shouldSample(samplerHigh), SamplingDecision.DROP);
-        SessionIdRatioBasedSampler samplerLow = new SessionIdRatioBasedSampler(0.0, LOW_ID_SAMPLER);
+
+        when(sessionId.getSessionId()).thenReturn(LOW_ID);
+
+        SessionIdRatioBasedSampler samplerLow = new SessionIdRatioBasedSampler(0.0, sessionId);
         assertEquals(shouldSample(samplerLow), SamplingDecision.DROP);
     }
 
     @Test
     void oneRatioAcceptsAll() {
-        SessionIdRatioBasedSampler samplerHigh =
-                new SessionIdRatioBasedSampler(1.0, HIGH_ID_SUPPLIER);
+        when(sessionId.getSessionId()).thenReturn(HIGH_ID);
+
+        SessionIdRatioBasedSampler samplerHigh = new SessionIdRatioBasedSampler(1.0, sessionId);
         assertEquals(shouldSample(samplerHigh), SamplingDecision.RECORD_AND_SAMPLE);
-        SessionIdRatioBasedSampler samplerLow = new SessionIdRatioBasedSampler(1.0, LOW_ID_SAMPLER);
+
+        when(sessionId.getSessionId()).thenReturn(LOW_ID);
+
+        SessionIdRatioBasedSampler samplerLow = new SessionIdRatioBasedSampler(1.0, sessionId);
         assertEquals(shouldSample(samplerLow), SamplingDecision.RECORD_AND_SAMPLE);
     }
 


### PR DESCRIPTION
The `SessionId` is now created much earlier in the startup/init lifecycle. This allows us to pass the instance to the sampler and not rely on lazy `Supplier` action. The sampler is now moved into the otel package.