### PR TITLE
Decouple session id name

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkSpanDataModifier.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkSpanDataModifier.java
@@ -85,7 +85,6 @@ final class SplunkSpanDataModifier implements SpanExporter {
         // Copy the native session id name into the splunk name
         String sessionId = original.getAttributes().get(RumConstants.SESSION_ID_KEY);
         modifiedAttributes.put(StandardAttributes.SESSION_ID_KEY, sessionId);
-        modifiedAttributes.remove(RumConstants.SESSION_ID_KEY);
 
         SpanContext spanContext;
         if (reactNativeEnabled) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkSpanDataModifier.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkSpanDataModifier.java
@@ -29,6 +29,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.rum.internal.RumConstants;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
 import io.opentelemetry.sdk.trace.data.EventData;
@@ -80,6 +81,11 @@ final class SplunkSpanDataModifier implements SpanExporter {
     private SpanData modify(SpanData original) {
         List<EventData> modifiedEvents = new ArrayList<>(original.getEvents().size());
         AttributesBuilder modifiedAttributes = original.getAttributes().toBuilder();
+
+        // Copy the native session id name into the splunk name
+        String sessionId = original.getAttributes().get(RumConstants.SESSION_ID_KEY);
+        modifiedAttributes.put(StandardAttributes.SESSION_ID_KEY, sessionId);
+        modifiedAttributes.remove(RumConstants.SESSION_ID_KEY);
 
         SpanContext spanContext;
         if (reactNativeEnabled) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
@@ -16,6 +16,8 @@
 
 package com.splunk.rum;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.rum.internal.SpanFilterBuilder;
@@ -31,7 +33,7 @@ public final class StandardAttributes {
      *
      * @see SplunkRumBuilder#setGlobalAttributes(Attributes)
      */
-    public static final AttributeKey<String> APP_VERSION = AttributeKey.stringKey("app.version");
+    public static final AttributeKey<String> APP_VERSION = stringKey("app.version");
 
     /**
      * The build type of your app (typically one of debug or release). Useful for adding to global
@@ -40,7 +42,7 @@ public final class StandardAttributes {
      * @see SplunkRumBuilder#setGlobalAttributes(Attributes)
      */
     public static final AttributeKey<String> APP_BUILD_TYPE =
-            AttributeKey.stringKey("app.build.type");
+            stringKey("app.build.type");
 
     /**
      * Full HTTP client request URL in the form {@code scheme://host[:port]/path?query[#fragment]}.
@@ -49,6 +51,7 @@ public final class StandardAttributes {
      * @see SemanticAttributes#HTTP_URL
      */
     public static final AttributeKey<String> HTTP_URL = SemanticAttributes.HTTP_URL;
+    public static final AttributeKey<? super String> SESSION_ID_KEY = stringKey("splunk.rumSessionId");
 
     private StandardAttributes() {}
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StandardAttributes.java
@@ -41,8 +41,7 @@ public final class StandardAttributes {
      *
      * @see SplunkRumBuilder#setGlobalAttributes(Attributes)
      */
-    public static final AttributeKey<String> APP_BUILD_TYPE =
-            stringKey("app.build.type");
+    public static final AttributeKey<String> APP_BUILD_TYPE = stringKey("app.build.type");
 
     /**
      * Full HTTP client request URL in the form {@code scheme://host[:port]/path?query[#fragment]}.
@@ -51,7 +50,9 @@ public final class StandardAttributes {
      * @see SemanticAttributes#HTTP_URL
      */
     public static final AttributeKey<String> HTTP_URL = SemanticAttributes.HTTP_URL;
-    public static final AttributeKey<? super String> SESSION_ID_KEY = stringKey("splunk.rumSessionId");
+
+    public static final AttributeKey<? super String> SESSION_ID_KEY =
+            stringKey("splunk.rumSessionId");
 
     private StandardAttributes() {}
 }

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
@@ -24,6 +24,8 @@ public class RumConstants {
 
     public static final String OTEL_RUM_LOG_TAG = "OpenTelemetryRum";
 
+    public static final AttributeKey<String> SESSION_ID_KEY = stringKey("rum.session.id");
+
     public static final AttributeKey<String> LAST_SCREEN_NAME_KEY =
             AttributeKey.stringKey("last.screen.name");
     public static final AttributeKey<String> SCREEN_NAME_KEY =

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
@@ -16,9 +16,8 @@
 
 package io.opentelemetry.rum.internal;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -26,8 +25,6 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 
 final class SessionIdSpanAppender implements SpanProcessor {
 
-    // TODO: rename to something that is not splunk specific
-    static final AttributeKey<String> SESSION_ID_KEY = stringKey("splunk.rumSessionId");
 
     private final SessionId sessionId;
 

--- a/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
+++ b/splunk-otel-android/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
@@ -25,7 +25,6 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 
 final class SessionIdSpanAppender implements SpanProcessor {
 
-
     private final SessionId sessionId;
 
     public SessionIdSpanAppender(SessionId sessionId) {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkSpanDataModifierTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkSpanDataModifierTest.java
@@ -41,10 +41,8 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -55,18 +53,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SplunkSpanDataModifierTest {
 
-    @Mock
-    private SpanExporter delegate;
-    @Captor
-    private ArgumentCaptor<Collection<SpanData>> exportedSpansCaptor;
+    @Mock private SpanExporter delegate;
+    @Captor private ArgumentCaptor<Collection<SpanData>> exportedSpansCaptor;
 
     @Test
     void changesSpanIdAttrName() {
         String sessionId = "abc123fonzie";
         Attributes attrs = Attributes.of(RumConstants.SESSION_ID_KEY, sessionId);
-        SpanData original = startBuilder()
-                        .setAttributes(attrs)
-                        .build();
+        SpanData original = startBuilder().setAttributes(attrs).build();
 
         CompletableResultCode exportResult = CompletableResultCode.ofSuccess();
         when(delegate.export(exportedSpansCaptor.capture())).thenReturn(exportResult);
@@ -77,7 +71,8 @@ class SplunkSpanDataModifierTest {
         Collection<SpanData> exported = exportedSpansCaptor.getValue();
         assertThat(exported).hasSize(1);
         SpanData first = exported.iterator().next();
-        assertThat(first.getAttributes().get(StandardAttributes.SESSION_ID_KEY)).isEqualTo(sessionId);
+        assertThat(first.getAttributes().get(StandardAttributes.SESSION_ID_KEY))
+                .isEqualTo(sessionId);
         assertThat(first.getAttributes().get(RumConstants.SESSION_ID_KEY)).isEqualTo(sessionId);
     }
 
@@ -218,7 +213,8 @@ class SplunkSpanDataModifierTest {
                         TraceFlags.getSampled(),
                         TraceState.getDefault());
 
-        SpanData original = startBuilder("SplunkRumSpan")
+        SpanData original =
+                startBuilder("SplunkRumSpan")
                         .setSpanContext(spanContext)
                         .setAttributes(
                                 Attributes.builder()

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkSpanDataModifierTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkSpanDataModifierTest.java
@@ -23,6 +23,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.Attributes;
@@ -30,6 +31,7 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.rum.internal.RumConstants;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
@@ -39,8 +41,10 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -51,19 +55,36 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SplunkSpanDataModifierTest {
 
-    @Mock private SpanExporter delegate;
-    @Captor private ArgumentCaptor<Collection<SpanData>> exportedSpansCaptor;
+    @Mock
+    private SpanExporter delegate;
+    @Captor
+    private ArgumentCaptor<Collection<SpanData>> exportedSpansCaptor;
+
+    @Test
+    void changesSpanIdAttrName() {
+        String sessionId = "abc123fonzie";
+        Attributes attrs = Attributes.of(RumConstants.SESSION_ID_KEY, sessionId);
+        SpanData original = startBuilder()
+                        .setAttributes(attrs)
+                        .build();
+
+        CompletableResultCode exportResult = CompletableResultCode.ofSuccess();
+        when(delegate.export(exportedSpansCaptor.capture())).thenReturn(exportResult);
+
+        SplunkSpanDataModifier underTest = new SplunkSpanDataModifier(delegate, false);
+        underTest.export(singletonList(original));
+
+        Collection<SpanData> exported = exportedSpansCaptor.getValue();
+        assertThat(exported).hasSize(1);
+        SpanData first = exported.iterator().next();
+        assertThat(first.getAttributes().get(StandardAttributes.SESSION_ID_KEY)).isEqualTo(sessionId);
+        assertThat(first.getAttributes().get(RumConstants.SESSION_ID_KEY)).isEqualTo(sessionId);
+    }
 
     @Test
     void shouldConvertExceptionEventsToSpanAttributes() {
         SpanData original =
-                TestSpanData.builder()
-                        .setName("test")
-                        .setKind(SpanKind.CLIENT)
-                        .setStatus(StatusData.unset())
-                        .setStartEpochNanos(12345)
-                        .setEndEpochNanos(67890)
-                        .setHasEnded(true)
+                startBuilder()
                         .setEvents(
                                 Arrays.asList(
                                         EventData.create(
@@ -119,15 +140,7 @@ class SplunkSpanDataModifierTest {
 
     @Test
     void shouldSetCaseSensitiveSpanNameToAttribute() {
-        SpanData original =
-                TestSpanData.builder()
-                        .setName("SplunkRumSpan")
-                        .setKind(SpanKind.CLIENT)
-                        .setStatus(StatusData.unset())
-                        .setStartEpochNanos(12345)
-                        .setEndEpochNanos(67890)
-                        .setHasEnded(true)
-                        .build();
+        SpanData original = startBuilder("SplunkRumSpan").build();
 
         CompletableResultCode exportResult = CompletableResultCode.ofSuccess();
         when(delegate.export(exportedSpansCaptor.capture())).thenReturn(exportResult);
@@ -205,15 +218,8 @@ class SplunkSpanDataModifierTest {
                         TraceFlags.getSampled(),
                         TraceState.getDefault());
 
-        SpanData original =
-                TestSpanData.builder()
+        SpanData original = startBuilder("SplunkRumSpan")
                         .setSpanContext(spanContext)
-                        .setName("SplunkRumSpan")
-                        .setKind(SpanKind.CLIENT)
-                        .setStatus(StatusData.unset())
-                        .setStartEpochNanos(12345)
-                        .setEndEpochNanos(67890)
-                        .setHasEnded(true)
                         .setAttributes(
                                 Attributes.builder()
                                         .put(
@@ -285,5 +291,19 @@ class SplunkSpanDataModifierTest {
                 .hasTraceId("99999999999999999999999999999999")
                 .hasSpanId("8888888888888888")
                 .hasAttributesSatisfyingExactly(equalTo(SPLUNK_OPERATION_KEY, "SplunkRumSpan"));
+    }
+
+    private TestSpanData.Builder startBuilder() {
+        return startBuilder("test");
+    }
+
+    private TestSpanData.Builder startBuilder(String name) {
+        return TestSpanData.builder()
+                .setName(name)
+                .setKind(SpanKind.CLIENT)
+                .setStatus(StatusData.unset())
+                .setStartEpochNanos(12345)
+                .setEndEpochNanos(67890)
+                .setHasEnded(true);
     }
 }

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
@@ -81,8 +81,7 @@ class OpenTelemetryRumBuilderTest {
         assertThat(spans.get(0))
                 .hasName("test span")
                 .hasResource(resource)
-                .hasAttributesSatisfyingExactly(
-                        equalTo(SESSION_ID_KEY, sessionId));
+                .hasAttributesSatisfyingExactly(equalTo(SESSION_ID_KEY, sessionId));
     }
 
     @Test

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.rum.internal;
 
+import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.mockito.ArgumentMatchers.isA;
@@ -81,7 +82,7 @@ class OpenTelemetryRumBuilderTest {
                 .hasName("test span")
                 .hasResource(resource)
                 .hasAttributesSatisfyingExactly(
-                        equalTo(SessionIdSpanAppender.SESSION_ID_KEY, sessionId));
+                        equalTo(SESSION_ID_KEY, sessionId));
     }
 
     @Test

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
@@ -16,12 +16,11 @@
 
 package io.opentelemetry.rum.internal;
 
+import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;

--- a/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
+++ b/splunk-otel-android/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import org.junit.jupiter.api.Test;
@@ -43,7 +45,7 @@ class SessionIdSpanAppenderTest {
         assertTrue(underTest.isStartRequired());
         underTest.onStart(Context.root(), span);
 
-        verify(span).setAttribute(SessionIdSpanAppender.SESSION_ID_KEY, "42");
+        verify(span).setAttribute(SESSION_ID_KEY, "42");
 
         assertFalse(underTest.isEndRequired());
     }


### PR DESCRIPTION
We don't want the otel package making spans with the name `splunk.rumSessionId`, so I moved it into the constants class and changed the spelling to `rum.session.id`. 

I updated the `SplunkSpanDataModifier` to copy the `rum.session.id` attribute into the `splunk.rumSessionId` attribute while leaving the original one intact for transition purposes.