### PR TITLE
Version the otel submodule as "-alpha"

### DIFF
--- a/opentelemetry-android-instrumentation/build.gradle.kts
+++ b/opentelemetry-android-instrumentation/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     id("splunk.errorprone-conventions")
 }
 
+// This submodule is alpha and is not yet intended to be used by itself
+version = "${project.version}-alpha"
+
 android {
     namespace = "opentelemetry.rum.instrumentation"
 


### PR DESCRIPTION
Based on this [thread here](https://github.com/signalfx/splunk-otel-android/pull/526#discussion_r1172469953) in #526, we discussed doing a shadow of the dependent otel module into the splunk module. Unfortunately, the johnrengelman shadow plugin doesn't really support android aar merging. Also unfortunate is that [fat-aar-android](https://github.com/kezong/fat-aar-android) is no longer supported.

The [android docs](https://developer.android.com/studio/projects/android-library#psd-add-library-dependency) also suggest that publishing and consuming via declared dependencies is the way to go.

So I suppose it will be a slight bit odd that during this transitional phase with will have a package with the name opentelemetry in it, but scoped within com.splunk namespace. This PR adds `-alpha` to the version to clearly indicate that this submodule is not "stable".