### PR TITLE
Migrate RuntimeDetailsExtractor to otel package

### DIFF
--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.rum.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -33,6 +35,10 @@ public class RumConstants {
     public static final AttributeKey<String> START_TYPE_KEY = stringKey("start.type");
 
     public static final AttributeKey<String> RUM_SDK_VERSION = stringKey("rum.sdk.version");
+
+    public static final AttributeKey<Long> STORAGE_SPACE_FREE_KEY = longKey("storage.free");
+    public static final AttributeKey<Long> HEAP_FREE_KEY = longKey("heap.free");
+    public static final AttributeKey<Double> BATTERY_PERCENT_KEY = doubleKey("battery.percent");
 
     public static final AttributeKey<String> PREVIOUS_SESSION_ID_KEY =
             stringKey("rum.session.previous_id");

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RuntimeDetailsExtractor.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RuntimeDetailsExtractor.java
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-package com.splunk.rum;
+package io.opentelemetry.rum.internal;
+
+import static io.opentelemetry.rum.internal.RumConstants.BATTERY_PERCENT_KEY;
+import static io.opentelemetry.rum.internal.RumConstants.HEAP_FREE_KEY;
+import static io.opentelemetry.rum.internal.RumConstants.STORAGE_SPACE_FREE_KEY;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -27,13 +31,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.io.File;
 
 /** Represents details about the runtime environment at a time */
-final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
+public final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
         implements AttributesExtractor<RQ, RS> {
 
     private @Nullable volatile Double batteryPercent = null;
     private final File filesDir;
 
-    static <RQ, RS> RuntimeDetailsExtractor<RQ, RS> create(Context context) {
+    public static <RQ, RS> RuntimeDetailsExtractor<RQ, RS> create(Context context) {
         IntentFilter batteryChangedFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
         File filesDir = context.getFilesDir();
         RuntimeDetailsExtractor<RQ, RS> runtimeDetails = new RuntimeDetailsExtractor<>(filesDir);
@@ -57,12 +61,12 @@ final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
             AttributesBuilder attributes,
             io.opentelemetry.context.Context parentContext,
             RQ request) {
-        attributes.put(SplunkRum.STORAGE_SPACE_FREE_KEY, getCurrentStorageFreeSpaceInBytes());
-        attributes.put(SplunkRum.HEAP_FREE_KEY, getCurrentFreeHeapInBytes());
+        attributes.put(STORAGE_SPACE_FREE_KEY, getCurrentStorageFreeSpaceInBytes());
+        attributes.put(HEAP_FREE_KEY, getCurrentFreeHeapInBytes());
 
         Double currentBatteryPercent = getCurrentBatteryPercent();
         if (currentBatteryPercent != null) {
-            attributes.put(SplunkRum.BATTERY_PERCENT_KEY, currentBatteryPercent);
+            attributes.put(BATTERY_PERCENT_KEY, currentBatteryPercent);
         }
     }
 

--- a/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/RuntimeDetailsExtractorTest.java
+++ b/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/RuntimeDetailsExtractorTest.java
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package com.splunk.rum;
+package io.opentelemetry.rum.internal;
 
 import static io.opentelemetry.context.Context.root;
+import static io.opentelemetry.rum.internal.RumConstants.BATTERY_PERCENT_KEY;
+import static io.opentelemetry.rum.internal.RumConstants.HEAP_FREE_KEY;
+import static io.opentelemetry.rum.internal.RumConstants.STORAGE_SPACE_FREE_KEY;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -54,8 +57,8 @@ class RuntimeDetailsExtractorTest {
         details.onStart(attributes, root(), null);
         assertThat(attributes.build())
                 .hasSize(3)
-                .containsEntry(SplunkRum.STORAGE_SPACE_FREE_KEY, 4200L)
-                .containsKey(SplunkRum.HEAP_FREE_KEY)
-                .containsEntry(SplunkRum.BATTERY_PERCENT_KEY, 69.0);
+                .containsEntry(STORAGE_SPACE_FREE_KEY, 4200L)
+                .containsKey(HEAP_FREE_KEY)
+                .containsEntry(BATTERY_PERCENT_KEY, 69.0);
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -39,6 +39,7 @@ import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.rum.internal.GlobalAttributesSpanAppender;
 import io.opentelemetry.rum.internal.OpenTelemetryRum;
 import io.opentelemetry.rum.internal.OpenTelemetryRumBuilder;
+import io.opentelemetry.rum.internal.RuntimeDetailsExtractor;
 import io.opentelemetry.rum.internal.SessionIdRatioBasedSampler;
 import io.opentelemetry.rum.internal.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.rum.internal.instrumentation.anr.AnrDetector;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -17,7 +17,6 @@
 package com.splunk.rum;
 
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import android.app.Application;
@@ -57,10 +56,6 @@ public class SplunkRum {
     static final AttributeKey<String> WORKFLOW_NAME_KEY = stringKey("workflow.name");
     static final AttributeKey<Double> LOCATION_LATITUDE_KEY = doubleKey("location.lat");
     static final AttributeKey<Double> LOCATION_LONGITUDE_KEY = doubleKey("location.long");
-
-    static final AttributeKey<Long> STORAGE_SPACE_FREE_KEY = longKey("storage.free");
-    static final AttributeKey<Long> HEAP_FREE_KEY = longKey("heap.free");
-    static final AttributeKey<Double> BATTERY_PERCENT_KEY = doubleKey("battery.percent");
 
     static final String COMPONENT_APPSTART = "appstart";
     static final String COMPONENT_UI = "ui";


### PR DESCRIPTION
Nothing vendor specific in this, so migrate to upstream package.