### PR TITLE
Allow building RUM with preconfigured SDK.

### DIFF
--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
@@ -19,6 +19,9 @@ package io.opentelemetry.rum.internal;
 import android.app.Application;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 
 /**
  * Entrypoint for the OpenTelemetry Real User Monitoring library for Android.

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
@@ -29,10 +29,10 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 public interface OpenTelemetryRum {
 
     /**
-     * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum}.
-     * Use this version if you would like to configure individual aspects of the OpenTelemetry
-     * SDK but would still prefer to allow OpenTelemetry RUM to create the SDK for you. If you
-     * would like to "bring your own" SDK, call the two-argument version.
+     * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum}. Use this version
+     * if you would like to configure individual aspects of the OpenTelemetry SDK but would still
+     * prefer to allow OpenTelemetry RUM to create the SDK for you. If you would like to "bring your
+     * own" SDK, call the two-argument version.
      *
      * @param application The {@link Application} that is being instrumented.
      */
@@ -44,16 +44,17 @@ public interface OpenTelemetryRum {
      * Returns a new {@link SdkPreconfiguredRumBuilder} for {@link OpenTelemetryRum}. This version
      * requires the user to preconfigure and create their own OpenTelemetrySdk instance. If you
      * prefer to use the builder to configure individual aspects of the OpenTelemetry SDK and to
-     * create and manage it for you, call the two-argument version.
+     * create and manage it for you, call the one-argument version.
      *
-     * Specific consideration should be given to the creation of your provided SDK to ensure
-     * that the {@link SdkTracerProvider}, {@link SdkMeterProvider}, and {@link SdkLoggerProvider} are configured
-     * correctly for your target RUM provider.
+     * <p>Specific consideration should be given to the creation of your provided SDK to ensure that
+     * the {@link SdkTracerProvider}, {@link SdkMeterProvider}, and {@link SdkLoggerProvider} are
+     * configured correctly for your target RUM provider.
      *
      * @param application The {@link Application} that is being instrumented.
      * @param openTelemetrySdk The {@link OpenTelemetrySdk} that the user has already created.
      */
-    static SdkPreconfiguredRumBuilder builder(Application application, OpenTelemetrySdk openTelemetrySdk){
+    static SdkPreconfiguredRumBuilder builder(
+            Application application, OpenTelemetrySdk openTelemetrySdk) {
         return new SdkPreconfiguredRumBuilder(application, openTelemetrySdk);
     }
 

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
@@ -47,7 +47,7 @@ public interface OpenTelemetryRum {
      * create and manage it for you, call the two-argument version.
      *
      * Specific consideration should be given to the creation of your provided SDK to ensure
-     * that the SdkTracerProvider, SdkMeterProvider, and SdkLoggerProvider are configured
+     * that the {@link SdkTracerProvider}, {@link SdkMeterProvider}, and {@link SdkLoggerProvider} are configured
      * correctly for your target RUM provider.
      *
      * @param application The {@link Application} that is being instrumented.

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRum.java
@@ -18,6 +18,7 @@ package io.opentelemetry.rum.internal;
 
 import android.app.Application;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 /**
  * Entrypoint for the OpenTelemetry Real User Monitoring library for Android.
@@ -29,11 +30,31 @@ public interface OpenTelemetryRum {
 
     /**
      * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum}.
+     * Use this version if you would like to configure individual aspects of the OpenTelemetry
+     * SDK but would still prefer to allow OpenTelemetry RUM to create the SDK for you. If you
+     * would like to "bring your own" SDK, call the two-argument version.
      *
      * @param application The {@link Application} that is being instrumented.
      */
     static OpenTelemetryRumBuilder builder(Application application) {
         return new OpenTelemetryRumBuilder(application);
+    }
+
+    /**
+     * Returns a new {@link SdkPreconfiguredRumBuilder} for {@link OpenTelemetryRum}. This version
+     * requires the user to preconfigure and create their own OpenTelemetrySdk instance. If you
+     * prefer to use the builder to configure individual aspects of the OpenTelemetry SDK and to
+     * create and manage it for you, call the two-argument version.
+     *
+     * Specific consideration should be given to the creation of your provided SDK to ensure
+     * that the SdkTracerProvider, SdkMeterProvider, and SdkLoggerProvider are configured
+     * correctly for your target RUM provider.
+     *
+     * @param application The {@link Application} that is being instrumented.
+     * @param openTelemetrySdk The {@link OpenTelemetrySdk} that the user has already created.
+     */
+    static SdkPreconfiguredRumBuilder builder(Application application, OpenTelemetrySdk openTelemetrySdk){
+        return new SdkPreconfiguredRumBuilder(application, openTelemetrySdk);
     }
 
     /** Returns a no-op implementation of {@link OpenTelemetryRum}. */

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.rum.internal;
 
 import android.app.Application;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -175,7 +174,8 @@ public final class OpenTelemetryRumBuilder {
                         .setLoggerProvider(buildLoggerProvider(application))
                         .build();
 
-        SdkPreconfiguredRumBuilder delegate = new SdkPreconfiguredRumBuilder(application, sdk, sessionId);
+        SdkPreconfiguredRumBuilder delegate =
+                new SdkPreconfiguredRumBuilder(application, sdk, sessionId);
         instrumentationInstallers.forEach(delegate::addInstrumentation);
         return delegate.build();
     }

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilder.java
@@ -54,8 +54,8 @@ public final class OpenTelemetryRumBuilder {
     private Resource resource;
 
     OpenTelemetryRumBuilder(Application application) {
-        SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
         this.application = application;
+        SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
         this.sessionId = new SessionId(timeoutHandler);
         this.resource = AndroidResource.createDefault(application);
     }
@@ -168,31 +168,16 @@ public final class OpenTelemetryRumBuilder {
      * @return A new {@link OpenTelemetryRum} instance.
      */
     public OpenTelemetryRum build() {
-        // the app state listeners need to be run in the first ActivityLifecycleCallbacks since they
-        // might turn off/on additional telemetry depending on whether the app is active or not
-        ApplicationStateWatcher applicationStateWatcher = new ApplicationStateWatcher();
-        application.registerActivityLifecycleCallbacks(applicationStateWatcher);
-
-        applicationStateWatcher.registerListener(sessionId.getTimeoutHandler());
-
-        OpenTelemetrySdk openTelemetrySdk =
+        OpenTelemetrySdk sdk =
                 OpenTelemetrySdk.builder()
                         .setTracerProvider(buildTracerProvider(sessionId, application))
                         .setMeterProvider(buildMeterProvider(application))
                         .setLoggerProvider(buildLoggerProvider(application))
                         .build();
 
-        Tracer tracer = openTelemetrySdk.getTracer(OpenTelemetryRum.class.getSimpleName());
-        sessionId.setSessionIdChangeListener(new SessionIdChangeTracer(tracer));
-
-        InstrumentedApplication instrumentedApplication =
-                new InstrumentedApplicationImpl(
-                        application, openTelemetrySdk, applicationStateWatcher);
-        for (Consumer<InstrumentedApplication> installer : instrumentationInstallers) {
-            installer.accept(instrumentedApplication);
-        }
-
-        return new OpenTelemetryRumImpl(openTelemetrySdk, sessionId);
+        SdkPreconfiguredRumBuilder delegate = new SdkPreconfiguredRumBuilder(application, sdk, sessionId);
+        instrumentationInstallers.forEach(delegate::addInstrumentation);
+        return delegate.build();
     }
 
     private SdkTracerProvider buildTracerProvider(SessionId sessionId, Application application) {

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SdkPreconfiguredRumBuilder.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SdkPreconfiguredRumBuilder.java
@@ -1,0 +1,72 @@
+package io.opentelemetry.rum.internal;
+
+import android.app.Application;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+public class SdkPreconfiguredRumBuilder {
+    private final Application application;
+    private final OpenTelemetrySdk sdk;
+    private final SessionId sessionId;
+
+    private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
+            new ArrayList<>();
+
+
+    SdkPreconfiguredRumBuilder(Application application, OpenTelemetrySdk openTelemetrySdk) {
+        this(application, openTelemetrySdk, new SessionId(new SessionIdTimeoutHandler()));
+    }
+
+    SdkPreconfiguredRumBuilder(Application application, OpenTelemetrySdk openTelemetrySdk, SessionId sessionId) {
+        this.application = application;
+        this.sdk = openTelemetrySdk;
+        this.sessionId = sessionId;
+    }
+
+    /**
+     * Adds an instrumentation installer function that will be run on an {@link
+     * InstrumentedApplication} instance as a part of the {@link #build()} method call.
+     *
+     * @return {@code this}
+     */
+    public SdkPreconfiguredRumBuilder addInstrumentation(
+            Consumer<InstrumentedApplication> instrumentationInstaller) {
+        instrumentationInstallers.add(instrumentationInstaller);
+        return this;
+    }
+
+    /**
+     * Creates a new instance of {@link OpenTelemetryRum} with the settings of this {@link
+     * OpenTelemetryRumBuilder}.
+     *
+     * <p>This method uses a preconfigured OpenTelemetry SDK and install built-in system
+     * instrumentations in the passed Android {@link Application}.
+     *
+     * @return A new {@link OpenTelemetryRum} instance.
+     */
+    public OpenTelemetryRum build() {
+        // the app state listeners need to be run in the first ActivityLifecycleCallbacks since they
+        // might turn off/on additional telemetry depending on whether the app is active or not
+        ApplicationStateWatcher applicationStateWatcher = new ApplicationStateWatcher();
+        application.registerActivityLifecycleCallbacks(applicationStateWatcher);
+        applicationStateWatcher.registerListener(sessionId.getTimeoutHandler());
+
+        Tracer tracer = sdk.getTracer(OpenTelemetryRum.class.getSimpleName());
+        sessionId.setSessionIdChangeListener(new SessionIdChangeTracer(tracer));
+
+        InstrumentedApplication instrumentedApplication =
+                new InstrumentedApplicationImpl(
+                        application, sdk, applicationStateWatcher);
+        for (Consumer<InstrumentedApplication> installer : instrumentationInstallers) {
+            installer.accept(instrumentedApplication);
+        }
+
+        return new OpenTelemetryRumImpl(sdk, sessionId);
+    }
+}

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SdkPreconfiguredRumBuilder.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SdkPreconfiguredRumBuilder.java
@@ -1,16 +1,30 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opentelemetry.rum.internal;
 
 import android.app.Application;
-
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.rum.internal.instrumentation.InstrumentedApplication;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
-
-public class SdkPreconfiguredRumBuilder {
+public final class SdkPreconfiguredRumBuilder {
     private final Application application;
     private final OpenTelemetrySdk sdk;
     private final SessionId sessionId;
@@ -18,12 +32,12 @@ public class SdkPreconfiguredRumBuilder {
     private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
             new ArrayList<>();
 
-
     SdkPreconfiguredRumBuilder(Application application, OpenTelemetrySdk openTelemetrySdk) {
         this(application, openTelemetrySdk, new SessionId(new SessionIdTimeoutHandler()));
     }
 
-    SdkPreconfiguredRumBuilder(Application application, OpenTelemetrySdk openTelemetrySdk, SessionId sessionId) {
+    SdkPreconfiguredRumBuilder(
+            Application application, OpenTelemetrySdk openTelemetrySdk, SessionId sessionId) {
         this.application = application;
         this.sdk = openTelemetrySdk;
         this.sessionId = sessionId;
@@ -61,8 +75,7 @@ public class SdkPreconfiguredRumBuilder {
         sessionId.setSessionIdChangeListener(new SessionIdChangeTracer(tracer));
 
         InstrumentedApplication instrumentedApplication =
-                new InstrumentedApplicationImpl(
-                        application, sdk, applicationStateWatcher);
+                new InstrumentedApplicationImpl(application, sdk, applicationStateWatcher);
         for (Consumer<InstrumentedApplication> installer : instrumentationInstallers) {
             installer.accept(instrumentedApplication);
         }


### PR DESCRIPTION
As part of [#1400](https://github.com/open-telemetry/community/issues/1400) there was [this conversation](https://github.com/open-telemetry/community/issues/1400#issuecomment-1494825874) about "bring your own" sdk. While this has not been historically important with one vendor (Splunk), this will need to be relaxed when going into upstream. 

So this provides a peer of `OpenTelemetryRumBuilder` called `SdkPreconfiguredRumBuilder`. This class does not provide a means to customize any of the various `*ProviderCustomizer` and assumes the user has already done all the hard work. For a single-vendor solution this is a bit of a foot gun, but we expect that opinionated distros can help fill in the important parts for their users.