### PR TITLE
Remove Guava dep

### DIFF
--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -75,7 +75,6 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.10.3")
     testImplementation("androidx.test:core:1.5.0")
     testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("com.google.guava:guava:32.0.1-jre")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.content.Context;
 import android.os.Looper;
-import com.google.common.base.Strings;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -47,6 +46,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -145,7 +145,7 @@ class RumInitializerTest {
                 "testEvent",
                 Attributes.of(
                         longAttributeKey,
-                        Strings.repeat("a", RumInitializer.MAX_ATTRIBUTE_LENGTH + 1)));
+                        makeString('a', RumInitializer.MAX_ATTRIBUTE_LENGTH + 1)));
 
         splunkRum.flushSpans();
         List<SpanData> spans = testExporter.getFinishedSpanItems();
@@ -154,7 +154,7 @@ class RumInitializerTest {
         SpanData eventSpan = spans.get(0);
         assertEquals("testEvent", eventSpan.getName());
         String truncatedValue = eventSpan.getAttributes().get(longAttributeKey);
-        assertEquals(Strings.repeat("a", RumInitializer.MAX_ATTRIBUTE_LENGTH), truncatedValue);
+        assertEquals(makeString('a', RumInitializer.MAX_ATTRIBUTE_LENGTH), truncatedValue);
     }
 
     /** Verify that we have buffering in place in our exporter implementation. */
@@ -282,5 +282,11 @@ class RumInitializerTest {
                                                                         SemanticAttributes
                                                                                 .EXCEPTION_STACKTRACE))
                                         .hasEvents(emptyList()));
+    }
+
+    private String makeString(char c, int count) {
+        char[] buf = new char[count];
+        Arrays.fill(buf, c);
+        return new String(buf);
     }
 }


### PR DESCRIPTION
Supersedes #586

Turns out it was only used in one place, and just one trivial method. Let's just remove it instead of solving hellish dependency resolution issues.