### PR TITLE
Added session.id as key along with rum.session.id for span

### DIFF
--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/RumConstants.java
@@ -26,7 +26,9 @@ public class RumConstants {
 
     public static final String OTEL_RUM_LOG_TAG = "OpenTelemetryRum";
 
-    public static final AttributeKey<String> SESSION_ID_KEY = stringKey("rum.session.id");
+    public static final AttributeKey<String> SESSION_ID_KEY = stringKey("session.id");
+
+    public static final AttributeKey<String> RUM_SESSION_ID_KEY = stringKey("rum.session.id");
 
     public static final AttributeKey<String> LAST_SCREEN_NAME_KEY =
             AttributeKey.stringKey("last.screen.name");

--- a/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
+++ b/opentelemetry-android-instrumentation/src/main/java/io/opentelemetry/rum/internal/SessionIdSpanAppender.java
@@ -32,6 +32,7 @@ final class SessionIdSpanAppender implements SpanProcessor {
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
         span.setAttribute(RumConstants.SESSION_ID_KEY, sessionId.getSessionId());
+        span.setAttribute(RumConstants.RUM_SESSION_ID_KEY, sessionId.getSessionId());
     }
 
     @Override

--- a/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
+++ b/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
@@ -83,8 +83,7 @@ class OpenTelemetryRumBuilderTest {
                 .hasName("test span")
                 .hasResource(resource)
                 .hasAttributesSatisfyingExactly(
-                    equalTo(SESSION_ID_KEY, sessionId),
-                    equalTo(RUM_SESSION_ID_KEY, sessionId));
+                        equalTo(SESSION_ID_KEY, sessionId), equalTo(RUM_SESSION_ID_KEY, sessionId));
     }
 
     @Test

--- a/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
+++ b/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/OpenTelemetryRumBuilderTest.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.rum.internal;
 
+import static io.opentelemetry.rum.internal.RumConstants.RUM_SESSION_ID_KEY;
 import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -81,7 +82,9 @@ class OpenTelemetryRumBuilderTest {
         assertThat(spans.get(0))
                 .hasName("test span")
                 .hasResource(resource)
-                .hasAttributesSatisfyingExactly(equalTo(SESSION_ID_KEY, sessionId));
+                .hasAttributesSatisfyingExactly(
+                    equalTo(SESSION_ID_KEY, sessionId),
+                    equalTo(RUM_SESSION_ID_KEY, sessionId));
     }
 
     @Test

--- a/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
+++ b/opentelemetry-android-instrumentation/src/test/java/io/opentelemetry/rum/internal/SessionIdSpanAppenderTest.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.rum.internal;
 
+import static io.opentelemetry.rum.internal.RumConstants.RUM_SESSION_ID_KEY;
 import static io.opentelemetry.rum.internal.RumConstants.SESSION_ID_KEY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +46,7 @@ class SessionIdSpanAppenderTest {
         underTest.onStart(Context.root(), span);
 
         verify(span).setAttribute(SESSION_ID_KEY, "42");
-
+        verify(span).setAttribute(RUM_SESSION_ID_KEY, "42");
         assertFalse(underTest.isEndRequired());
     }
 }


### PR DESCRIPTION
As per semantic convention added the replaced the `rum.session.id` to `session.id`. Adding both of them to the attribute in order to make this backward compatible.

Resolves https://github.com/signalfx/splunk-otel-android/issues/606