### PR TITLE
Disable Background Task Instrumentation

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -42,6 +42,7 @@ public class SampleApplication extends Application {
                 .setRumAccessToken(getResources().getString(R.string.rum_access_token))
                 .enableDebug()
                 .enableDiskBuffering()
+                .disableBackgroundTaskReporting(BuildConfig.APPLICATION_ID)
                 .setSlowRenderingDetectionPollInterval(Duration.ofMillis(1000))
                 .setDeploymentEnvironment("demo")
                 .limitDiskUsageMegabytes(1)

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum;
 
 import android.annotation.SuppressLint;
@@ -8,14 +24,14 @@ import java.lang.reflect.Method;
 public class BackgroundProcessDetector {
     public static Boolean isBackgroundProcess(String applicationId) {
         String applicationProcessName = "";
-        if (Build.VERSION.SDK_INT >= 28)
-            applicationProcessName = Application.getProcessName();
+        if (Build.VERSION.SDK_INT >= 28) applicationProcessName = Application.getProcessName();
         else {
             try {
                 @SuppressLint("PrivateApi")
                 Class<?> activityThread = Class.forName("android.app.ActivityThread");
                 String methodName = "currentProcessName";
-                @SuppressLint("PrivateApi") Method getProcessName = activityThread.getDeclaredMethod(methodName);
+                @SuppressLint("PrivateApi")
+                Method getProcessName = activityThread.getDeclaredMethod(methodName);
                 applicationProcessName = (String) getProcessName.invoke(null);
             } catch (Exception e) {
             }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
@@ -1,0 +1,26 @@
+package com.splunk.rum;
+
+import android.annotation.SuppressLint;
+import android.app.Application;
+import android.os.Build;
+import java.lang.reflect.Method;
+
+public class BackgroundProcessDetector {
+    public static Boolean isBackgroundProcess(String applicationId) {
+        String applicationProcessName = "";
+        if (Build.VERSION.SDK_INT >= 28)
+            applicationProcessName = Application.getProcessName();
+        else {
+            try {
+                @SuppressLint("PrivateApi")
+                Class<?> activityThread = Class.forName("android.app.ActivityThread");
+                String methodName = "currentProcessName";
+                @SuppressLint("PrivateApi") Method getProcessName = activityThread.getDeclaredMethod(methodName);
+                applicationProcessName = (String) getProcessName.invoke(null);
+            } catch (Exception e) {
+            }
+        }
+
+        return applicationProcessName != null && applicationProcessName.equals(applicationId);
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
@@ -23,6 +23,9 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 
 public final class BackgroundProcessDetector {
+
+    BackgroundProcessDetector() {}
+
     public static Boolean isBackgroundProcess(String applicationId) {
         String applicationProcessName = getApplicationProcessName();
         return Objects.equals(applicationProcessName, applicationId);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 public final class BackgroundProcessDetector {
 
-    BackgroundProcessDetector() {}
+    private BackgroundProcessDetector() {}
 
     public static Boolean isBackgroundProcess(String applicationId) {
         String applicationProcessName = getApplicationProcessName();

--- a/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/BackgroundProcessDetector.java
@@ -20,23 +20,28 @@ import android.annotation.SuppressLint;
 import android.app.Application;
 import android.os.Build;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
-public class BackgroundProcessDetector {
+public final class BackgroundProcessDetector {
     public static Boolean isBackgroundProcess(String applicationId) {
-        String applicationProcessName = "";
-        if (Build.VERSION.SDK_INT >= 28) applicationProcessName = Application.getProcessName();
-        else {
+        String applicationProcessName = getApplicationProcessName();
+        return Objects.equals(applicationProcessName, applicationId);
+    }
+
+    private static String getApplicationProcessName() {
+        if (Build.VERSION.SDK_INT >= 28) {
+            return Application.getProcessName();
+        } else {
             try {
                 @SuppressLint("PrivateApi")
                 Class<?> activityThread = Class.forName("android.app.ActivityThread");
                 String methodName = "currentProcessName";
                 @SuppressLint("PrivateApi")
                 Method getProcessName = activityThread.getDeclaredMethod(methodName);
-                applicationProcessName = (String) getProcessName.invoke(null);
+                return (String) getProcessName.invoke(null);
             } catch (Exception e) {
+                return null;
             }
         }
-
-        return applicationProcessName != null && applicationProcessName.equals(applicationId);
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ConfigFlags.java
@@ -26,6 +26,7 @@ class ConfigFlags {
     private boolean networkMonitorEnabled = true;
     private boolean anrDetectionEnabled = true;
     private boolean slowRenderingDetectionEnabled = true;
+    private boolean backgroundTaskInstrumentationEnabled = true;
 
     void enableDebug() {
         debugEnabled = true;
@@ -55,8 +56,16 @@ class ConfigFlags {
         slowRenderingDetectionEnabled = false;
     }
 
+    public void disableBackgroundTaskDetection() {
+        backgroundTaskInstrumentationEnabled = false;
+    }
+
     boolean isDebugEnabled() {
         return debugEnabled;
+    }
+
+    boolean isBackgroundTaskInstrumentationEnabled() {
+        return backgroundTaskInstrumentationEnabled;
     }
 
     boolean isAnrDetectionEnabled() {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -100,9 +100,13 @@ public class SplunkRum {
             return INSTANCE;
         }
 
-        INSTANCE =
-                new RumInitializer(builder, application, startupTimer)
-                        .initialize(currentNetworkProviderFactory, Looper.getMainLooper());
+        if(builder.isBackgroundTaskReportingEnabled()) {
+            INSTANCE = NoOpSplunkRum.INSTANCE;
+        } else {
+            INSTANCE =
+                    new RumInitializer(builder, application, startupTimer)
+                            .initialize(currentNetworkProviderFactory, Looper.getMainLooper());
+        }
 
         if (builder.isDebugEnabled()) {
             Log.i(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -100,7 +100,7 @@ public class SplunkRum {
             return INSTANCE;
         }
 
-        if (builder.isBackgroundTaskReportingEnabled()) {
+        if (!builder.isBackgroundTaskReportingEnabled() && builder.isBackgroundProcess) {
             INSTANCE = NoOpSplunkRum.INSTANCE;
         } else {
             INSTANCE =

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -100,7 +100,7 @@ public class SplunkRum {
             return INSTANCE;
         }
 
-        if (!builder.isBackgroundTaskReportingEnabled() && builder.isBackgroundProcess) {
+        if (builder.isBackgroundTaskReportingDisabled() && builder.isBackgroundProcess) {
             INSTANCE = SplunkRum.noop();
         } else {
             INSTANCE =

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -100,7 +100,7 @@ public class SplunkRum {
             return INSTANCE;
         }
 
-        if(builder.isBackgroundTaskReportingEnabled()) {
+        if (builder.isBackgroundTaskReportingEnabled()) {
             INSTANCE = NoOpSplunkRum.INSTANCE;
         } else {
             INSTANCE =

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -101,7 +101,7 @@ public class SplunkRum {
         }
 
         if (!builder.isBackgroundTaskReportingEnabled() && builder.isBackgroundProcess) {
-            INSTANCE = NoOpSplunkRum.INSTANCE;
+            INSTANCE = SplunkRum.noop();
         } else {
             INSTANCE =
                     new RumInitializer(builder, application, startupTimer)

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -316,7 +316,7 @@ public final class SplunkRumBuilder {
 
     public SplunkRumBuilder disableBackgroundTaskReporting(String applicationId) {
         Boolean isBackgroundProcess = BackgroundProcessDetector.isBackgroundProcess(applicationId);
-        if(isBackgroundProcess) {
+        if (isBackgroundProcess) {
             configFlags.disableBackgroundTaskDetection();
         }
         return this;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -314,6 +314,14 @@ public final class SplunkRumBuilder {
         return SplunkRum.initialize(this, application, CurrentNetworkProvider::createAndStart);
     }
 
+    public SplunkRumBuilder disableBackgroundTaskReporting(String applicationId) {
+        Boolean isBackgroundProcess = BackgroundProcessDetector.isBackgroundProcess(applicationId);
+        if(isBackgroundProcess) {
+            configFlags.disableBackgroundTaskDetection();
+        }
+        return this;
+    }
+
     // one day maybe these can use kotlin delegation
     ConfigFlags getConfigFlags() {
         return configFlags;
@@ -349,5 +357,9 @@ public final class SplunkRumBuilder {
 
     boolean isReactNativeSupportEnabled() {
         return configFlags.isReactNativeSupportEnabled();
+    }
+
+    boolean isBackgroundTaskReportingEnabled() {
+        return configFlags.isBackgroundTaskInstrumentationEnabled();
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -47,6 +47,7 @@ public final class SplunkRumBuilder {
     int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;
     boolean sessionBasedSamplerEnabled = false;
     double sessionBasedSamplerRatio = 1.0;
+    boolean isBackgroundProcess = false;
 
     /**
      * Sets the application name that will be used to identify your application in the Splunk RUM
@@ -315,10 +316,8 @@ public final class SplunkRumBuilder {
     }
 
     public SplunkRumBuilder disableBackgroundTaskReporting(String applicationId) {
-        Boolean isBackgroundProcess = BackgroundProcessDetector.isBackgroundProcess(applicationId);
-        if (isBackgroundProcess) {
-            configFlags.disableBackgroundTaskDetection();
-        }
+        isBackgroundProcess = BackgroundProcessDetector.isBackgroundProcess(applicationId);
+        configFlags.disableBackgroundTaskDetection();
         return this;
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -315,6 +315,14 @@ public final class SplunkRumBuilder {
         return SplunkRum.initialize(this, application, CurrentNetworkProvider::createAndStart);
     }
 
+    /**
+     * Disables the instrumentation of background process feature. If enabled, the background
+     * processes will be instrumented.
+     *
+     * <p>This feature is enabled by default. You can disable it by calling this method.
+     *
+     * @return {@code this}
+     */
     public SplunkRumBuilder disableBackgroundTaskReporting(String applicationId) {
         isBackgroundProcess = BackgroundProcessDetector.isBackgroundProcess(applicationId);
         configFlags.disableBackgroundTaskDetection();
@@ -360,7 +368,7 @@ public final class SplunkRumBuilder {
         return configFlags.isReactNativeSupportEnabled();
     }
 
-    boolean isBackgroundTaskReportingEnabled() {
-        return configFlags.isBackgroundTaskInstrumentationEnabled();
+    boolean isBackgroundTaskReportingDisabled() {
+        return !configFlags.isBackgroundTaskInstrumentationEnabled();
     }
 }


### PR DESCRIPTION
Provides user with an option to disable background process instrumentation using `disableBackgroundTaskReporting`. If the app is launched using background process, we initialize SplunkRum with No-op instance and thus stop the user from reporting any instrumetnation