### PR TITLE
Suppress missing javadoc warnings

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -95,6 +95,10 @@ project.afterEvaluate {
         val javaCompile = firstVariant.javaCompileProvider.get()
         classpath += javaCompile.classpath
         classpath += javaCompile.outputs.files
+
+        with(options as StandardJavadocDocletOptions) {
+            addBooleanOption("Xdoclint:all,-missing", true)
+        }
     }
 
     val javadocJar by tasks.registering(Jar::class) {


### PR DESCRIPTION
I noticed tons of missing warnings in the build logs. Let's suppress those.