### PR TITLE
Fix build and prepare for 1.1.1 branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-* `splunk.rum.version` attribute has been renamed to `rum.sdk.version`
+* tbd
+
+## Version 1.1.1
+
+* Fix build to include `.aar` artifact. Please note that this version splits out an
+  additional dependency
+
+## Version 1.1.0
+
+This version had a critical defect which caused the `.aar` to not be published to maven central.
+Users should skip over this version and use the patch release 1.1.1 when it is available.
+
+* `splunk.rum.version` attribute has been renamed to `rum.sdk.version` (#524)
+* new API: `OpenTelemetryRumBuilder.mergeResource()` to allow merging into resource instead of replacing (#524)
+* new API: `SplunkRumBuilder.disableBackgroundTaskReporting(applicationId)` - pass the `applicationId` to this
+  method in order to disable instrumentation for background tasks. (#614) (#624)
+* OpenTelemetry SDK updated to [1.29.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.29.0)
 
 ## Version 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Version 1.1.1
 
 * Fix build to include `.aar` artifact. Please note that this version splits out an
-  additional dependency
+  additional required dependency: `com.splunk:opentelemetry-android-instrumentation`.
 
 ## Version 1.1.0
 

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -50,6 +50,17 @@ if (project.findProperty("release") == "true" && project.findProperty("skipSigni
 }
 
 project.afterEvaluate {
+    val javadoc by tasks.registering(Javadoc::class) {
+        source = android.sourceSets.named("main").get().java.getSourceFiles()
+        classpath += project.files(android.bootClasspath)
+
+        // grab the library variants, because apparently this is where the real classpath lives that
+        // is needed for javadoc generation.
+        val firstVariant = project.android.libraryVariants.toList().first()
+        val javaCompile = firstVariant.javaCompileProvider.get()
+        classpath += javaCompile.classpath
+        classpath += javaCompile.outputs.files
+    }
     publishing.publications {
         create<MavenPublication>("maven") {
             from(components.findByName(variantToPublish))

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -7,16 +7,24 @@ plugins {
     id("signing")
 }
 
-android {
-    lint {
-        warningsAsErrors = true
-        // A newer version of androidx.appcompat:appcompat than 1.3.1 is available: 1.4.1 [GradleDependency]
-        // we rely on dependabot for dependency updates
-        disable.add("GradleDependency")
-    }
+android.lint {
+    warningsAsErrors = true
+    // A newer version of androidx.appcompat:appcompat than 1.3.1 is available: 1.4.1 [GradleDependency]
+    // we rely on dependabot for dependency updates
+    disable.add("GradleDependency")
 }
 
-publishing {
+val isARelease = project.hasProperty("release") && project.property("release") == "true"
+val variantToPublish = "release"
+
+android.publishing {
+    singleVariant(variantToPublish) {
+        // Adding sources and javadoc artifacts only during a release.
+        if (isARelease) {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
     repositories {
         maven {
             val releasesRepoUrl = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2")
@@ -28,8 +36,23 @@ publishing {
             }
         }
     }
-    publications {
-        register<MavenPublication>("maven") {
+}
+
+
+if (project.findProperty("release") == "true" && project.findProperty("skipSigning") != "true") {
+    signing {
+        useGpgCmd()
+        val signingKey: String? by project
+        val signingPassword: String? by project
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["maven"])
+    }
+}
+
+project.afterEvaluate {
+    publishing.publications {
+        create<MavenPublication>("maven") {
+            from(components.findByName(variantToPublish))
             groupId = "com.splunk"
             artifactId = base.archivesName.get()
 
@@ -60,56 +83,6 @@ publishing {
                     developerConnection.set("https://github.com/signalfx/splunk-otel-android.git")
                     url.set("https://github.com/signalfx/splunk-otel-android")
                 }
-            }
-        }
-    }
-}
-
-if (project.findProperty("release") == "true") {
-    signing {
-        useGpgCmd()
-        val signingKey: String? by project
-        val signingPassword: String? by project
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["maven"])
-    }
-}
-
-val sourcesJar by tasks.registering(Jar::class) {
-
-    from(android.sourceSets.named("main").get().java.srcDirs)
-    archiveClassifier.set("sources")
-}
-
-project.afterEvaluate {
-
-    // note: we need to declare this here in afterEvaluate because the android plugin doesn't
-    // resolve dependencies early enough to make the libraryVariants hack work until here.
-    val javadoc by tasks.registering(Javadoc::class) {
-        source = android.sourceSets.named("main").get().java.getSourceFiles()
-        classpath += project.files(android.bootClasspath)
-
-        // grab the library variants, because apparently this is where the real classpath lives that
-        // is needed for javadoc generation.
-        val firstVariant = project.android.libraryVariants.toList().first()
-        val javaCompile = firstVariant.javaCompileProvider.get()
-        classpath += javaCompile.classpath
-        classpath += javaCompile.outputs.files
-    }
-
-    val javadocJar by tasks.registering(Jar::class) {
-        dependsOn(javadoc)
-        archiveClassifier.set("javadoc")
-        from(javadoc.get().destinationDir)
-    }
-
-    val component = project.components.findByName("release")
-    publishing {
-        publications {
-            named<MavenPublication>("maven") {
-                from(component)
-                artifact(tasks.named<Jar>("sourcesJar"))
-                artifact(javadocJar)
             }
         }
     }

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -39,7 +39,7 @@ android.publishing {
 }
 
 
-if (project.findProperty("release") == "true" && project.findProperty("skipSigning") != "true") {
+if (isARelease && project.findProperty("skipSigning") != "true") {
     signing {
         useGpgCmd()
         val signingKey: String? by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ android.useAndroidX=true
 # generate the BuildConfig class that contains the app version
 android.defaults.buildfeatures.buildconfig=true
 
-version=1.1.0
+version=1.1.1
 group=com.splunk

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -30,7 +29,6 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility(JavaVersion.VERSION_1_8)
         targetCompatibility(JavaVersion.VERSION_1_8)
     }


### PR DESCRIPTION
This simplifies the build a bit and actually produces the artifacts we need.

The `skipSigning` parameter is used when running locally with `publishToMavenLocal` when the signing secrets are not available.