### PR TITLE
Suggested solution to disable RUM initialization for worker

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     implementation(project(":splunk-otel-android"))
     implementation(project(":splunk-otel-android-volley"))
     implementation("com.android.volley:volley:1.2.1")
+    implementation("androidx.work:work-runtime:2.8.1")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
 

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".SplunkBackgroundService"
+            android:exported="false"
+            android:process=":my_service_process"/>
+        <service
+            android:name=".DemoWorker"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/sample-app/src/main/java/com/splunk/android/sample/DemoWorker.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/DemoWorker.java
@@ -1,0 +1,47 @@
+package com.splunk.android.sample;
+
+import static com.splunk.android.sample.SampleApplication.INITIALIZE_RUM_KEY;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+public class DemoWorker extends Worker {
+
+    private Context context;
+    public static final String TAG = "DemoWorker";
+
+    public DemoWorker(
+            @NonNull Context context,
+            @NonNull WorkerParameters params
+    ) {
+        super(context, params);
+        this.context = context;
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        try {
+            startBackgroundService();
+            return Result.success();
+        } catch (Exception e) {
+            return Result.failure();
+        }
+    }
+
+    private void startBackgroundService() {
+        Intent serviceIntent = new Intent(context, SplunkBackgroundService.class);
+        SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences(SampleApplication.PREFERENCES, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(INITIALIZE_RUM_KEY, false);
+        editor.apply();
+        Log.d(TAG, "Starting background Service");
+        context.startService(serviceIntent);
+    }
+}

--- a/sample-app/src/main/java/com/splunk/android/sample/DemoWorker.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/DemoWorker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.android.sample;
 
 import static com.splunk.android.sample.SampleApplication.INITIALIZE_RUM_KEY;
@@ -6,7 +22,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
@@ -16,10 +31,7 @@ public class DemoWorker extends Worker {
     private Context context;
     public static final String TAG = "DemoWorker";
 
-    public DemoWorker(
-            @NonNull Context context,
-            @NonNull WorkerParameters params
-    ) {
+    public DemoWorker(@NonNull Context context, @NonNull WorkerParameters params) {
         super(context, params);
         this.context = context;
     }
@@ -37,7 +49,9 @@ public class DemoWorker extends Worker {
 
     private void startBackgroundService() {
         Intent serviceIntent = new Intent(context, SplunkBackgroundService.class);
-        SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences(SampleApplication.PREFERENCES, Context.MODE_PRIVATE);
+        SharedPreferences sharedPreferences =
+                getApplicationContext()
+                        .getSharedPreferences(SampleApplication.PREFERENCES, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean(INITIALIZE_RUM_KEY, false);
         editor.apply();

--- a/sample-app/src/main/java/com/splunk/android/sample/FirstFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/FirstFragment.java
@@ -109,6 +109,11 @@ public class FirstFragment extends Fragment {
                     volleyExample.doHttpRequest();
                 });
 
+        binding.workManager.setOnClickListener(
+                v -> {
+                    WorkManagerHelper.startWorkManager(this.getContext());
+                });
+
         sessionId.postValue(splunkRum.getRumSessionId());
     }
 

--- a/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
@@ -38,6 +38,8 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
 import com.splunk.android.sample.databinding.ActivityMainBinding;
 import com.splunk.rum.SplunkRum;
 import io.opentelemetry.api.common.Attributes;
@@ -74,12 +76,23 @@ public class MainActivity extends AppCompatActivity {
                 view -> {
                     new MailDialogFragment(this).show(getSupportFragmentManager(), "Mail");
                 });
+
+        setUpPeriodicWorker();
+    }
+
+    private void setUpPeriodicWorker() {
+        PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
+                DemoWorker.class,
+                2,
+                TimeUnit.MINUTES
+        ).build();
+
+        WorkManager.getInstance(this).enqueue(workRequest);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
                 == PackageManager.PERMISSION_GRANTED) {
             startListeningForLocations();

--- a/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/MainActivity.java
@@ -81,11 +81,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void setUpPeriodicWorker() {
-        PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
-                DemoWorker.class,
-                2,
-                TimeUnit.MINUTES
-        ).build();
+        PeriodicWorkRequest workRequest =
+                new PeriodicWorkRequest.Builder(DemoWorker.class, 2, TimeUnit.MINUTES).build();
 
         WorkManager.getInstance(this).enqueue(workRequest);
     }

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -22,13 +22,11 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
-
 import com.splunk.rum.SplunkRum;
 import com.splunk.rum.StandardAttributes;
 import io.opentelemetry.api.common.Attributes;
 import java.time.Duration;
 import java.util.regex.Pattern;
-
 
 public class SampleApplication extends Application {
     static final String PREFERENCES = "MyPrefs";
@@ -41,13 +39,14 @@ public class SampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        SharedPreferences sharedPreferences = getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+        SharedPreferences sharedPreferences =
+                getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
         // Read the variable from SharedPreferences to know if need to initialize RUM
         boolean initRum = sharedPreferences.getBoolean(INITIALIZE_RUM_KEY, true);
         Log.d(TAG, "Initialize Rum : " + initRum);
         sharedPreferences.edit().putBoolean(INITIALIZE_RUM_KEY, true).apply();
 
-        if(initRum) {
+        if (initRum) {
             SplunkRum.builder()
                     // note: for these values to be resolved, put them in your local.properties
                     // file as rum.beacon.url and rum.access.token
@@ -69,7 +68,8 @@ public class SampleApplication extends Application {
                             spanFilter ->
                                     spanFilter
                                             .removeSpanAttribute(stringKey("http.user_agent"))
-                                            .rejectSpansByName(spanName -> spanName.contains("ignored"))
+                                            .rejectSpansByName(
+                                                    spanName -> spanName.contains("ignored"))
                                             // sensitive data in the login http.url attribute
                                             // will be redacted before it hits the exporter
                                             .replaceSpanAttribute(

--- a/sample-app/src/main/java/com/splunk/android/sample/SplunkBackgroundService.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SplunkBackgroundService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.android.sample;
 
 import android.app.Service;

--- a/sample-app/src/main/java/com/splunk/android/sample/SplunkBackgroundService.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SplunkBackgroundService.java
@@ -1,0 +1,24 @@
+package com.splunk.android.sample;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+public class SplunkBackgroundService extends Service {
+    public static final String TAG = "SplunkBackgroundService";
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null) {
+            Log.d(TAG, "Service started on different thread");
+        }
+        stopSelf();
+        return START_STICKY;
+    }
+}

--- a/sample-app/src/main/java/com/splunk/android/sample/WorkManagerHelper.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/WorkManagerHelper.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.android.sample;
 
 import android.content.Context;
-
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
@@ -9,12 +24,7 @@ import androidx.work.WorkRequest;
 public class WorkManagerHelper {
 
     public static void startWorkManager(Context context) {
-        WorkRequest demoWorkRequest =
-                new OneTimeWorkRequest.Builder(DemoWorker.class)
-                        .build();
-        WorkManager
-                .getInstance(context)
-                .enqueue(demoWorkRequest);
+        WorkRequest demoWorkRequest = new OneTimeWorkRequest.Builder(DemoWorker.class).build();
+        WorkManager.getInstance(context).enqueue(demoWorkRequest);
     }
-
 }

--- a/sample-app/src/main/java/com/splunk/android/sample/WorkManagerHelper.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/WorkManagerHelper.java
@@ -1,0 +1,20 @@
+package com.splunk.android.sample;
+
+import android.content.Context;
+
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+
+public class WorkManagerHelper {
+
+    public static void startWorkManager(Context context) {
+        WorkRequest demoWorkRequest =
+                new OneTimeWorkRequest.Builder(DemoWorker.class)
+                        .build();
+        WorkManager
+                .getInstance(context)
+                .enqueue(demoWorkRequest);
+    }
+
+}

--- a/sample-app/src/main/res/layout/fragment_first.xml
+++ b/sample-app/src/main/res/layout/fragment_first.xml
@@ -77,6 +77,13 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/volley_client" />
 
+            <Button
+                android:id="@+id/work_manager"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/worker" />
+
             <TextView
                 android:id="@+id/session_id"
                 android:layout_width="wrap_content"

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="http_me_up">HTTP me up!</string>
     <string name="http_me_bad">Http Error</string>
     <string name="volley_client">Volley HTTP</string>
+    <string name="worker">Worker</string>
     <string name="http_not_found">HTTP Not Found</string>
 
     <string name="local_web_view">Local WebView</string>


### PR DESCRIPTION
This solution leverages Shared Preferences to initialize the RUM. The default value in Shared preferences is set to true. Thus when the app is launched, the SplunkRum is initialized and whenever worker is enqueued and backgroundService is run in doWork, we change the key in SHaredPreference to false, which is read in Application.java to not initialize RUM.

Lucid chart:
https://lucid.app/lucidchart/7d8a8cc9-b495-4659-8c41-bc934552745f/edit?view_items=qU5uVi6f-co2&invitationId=inv_c07e838d-c25a-4a24-ad3c-41f9499f66eb
![Uploading Screenshot 2023-09-15 at 10.05.51 AM.png…]()
