### PR TITLE
Fix (?) dependabot in cla.yml allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,4 +27,4 @@ jobs:
           branch: main
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/splunk/cla-agreement/blob/main/CLA.md
-          allowlist: dependabot
+          allowlist: dependabot[bot]


### PR DESCRIPTION
https://github.com/marketplace/actions/cla-assistant-lite#5-users-and-bots-in-allowlist says that we should use `dependabot[bot]` in the allowlist; looks strange, but let's try it out