### PR TITLE
Remove containing dir when empty

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/DefaultSpanStorage.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DefaultSpanStorage.java
@@ -31,7 +31,7 @@ public class DefaultSpanStorage implements SpanStorage {
     }
 
     @Override
-    public File provideSpanFile() {
+    public File provideSpansDirectory() {
         File spansPath = fileUtils.getSpansDirectory(rootDir);
         if (spansPath.exists() || spansPath.mkdirs()) {
             return spansPath;
@@ -45,16 +45,16 @@ public class DefaultSpanStorage implements SpanStorage {
 
     @Override
     public Stream<File> getAllSpanFiles() {
-        return fileUtils.listSpanFiles(provideSpanFile());
+        return fileUtils.listSpanFiles(provideSpansDirectory());
     }
 
     @Override
     public long getTotalFileSizeInBytes() {
-        return fileUtils.getTotalFileSizeInBytes(provideSpanFile());
+        return fileUtils.getTotalFileSizeInBytes(provideSpansDirectory());
     }
 
     @Override
     public Stream<File> getPendingFiles() {
-        return fileUtils.listSpanFiles(provideSpanFile());
+        return fileUtils.listSpanFiles(provideSpansDirectory());
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DeviceSpanStorageLimiter.java
@@ -52,7 +52,7 @@ class DeviceSpanStorageLimiter {
     boolean ensureFreeSpace() {
         tryFreeingSpace();
         // play nice if disk is getting full
-        return fileProvider.provideSpanFile().getFreeSpace() > limitInBytes();
+        return fileProvider.provideSpansDirectory().getFreeSpace() > limitInBytes();
     }
 
     private void tryFreeingSpace() {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SpanStorage.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SpanStorage.java
@@ -26,10 +26,9 @@ import java.util.stream.Stream;
 interface SpanStorage {
 
     /***
-     * Provide location of storing spans
-     * @return
+     * Returns the location where spans are buffered.
      */
-    File provideSpanFile();
+    File provideSpansDirectory();
 
     /***
      * @return all spans including those that can be sent or not

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
@@ -19,9 +19,7 @@ package com.splunk.rum;
 import static com.splunk.rum.SplunkRum.LOG_TAG;
 
 import android.util.Log;
-
 import androidx.annotation.VisibleForTesting;
-
 import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
 import java.io.File;
 import java.util.UUID;
@@ -49,18 +47,25 @@ class StartTypeAwareSpanStorage implements SpanStorage {
 
     @VisibleForTesting
     static StartTypeAwareSpanStorage create(
-            VisibleScreenTracker visibleScreenTracker, FileUtils fileUtils, File rootDir,
-            File spansDir, String uniqueId) {
+            VisibleScreenTracker visibleScreenTracker,
+            FileUtils fileUtils,
+            File rootDir,
+            File spansDir,
+            String uniqueId) {
         StartTypeAwareSpanStorage startTypeAwareSpanStorage =
-                new StartTypeAwareSpanStorage(visibleScreenTracker, fileUtils, rootDir, spansDir, uniqueId);
+                new StartTypeAwareSpanStorage(
+                        visibleScreenTracker, fileUtils, rootDir, spansDir, uniqueId);
         startTypeAwareSpanStorage.cleanupUnsentBackgroundSpans();
         return startTypeAwareSpanStorage;
     }
 
     @VisibleForTesting
     StartTypeAwareSpanStorage(
-            VisibleScreenTracker visibleScreenTracker, FileUtils fileUtils, File rootDir,
-            File spansDir, String uniqueId) {
+            VisibleScreenTracker visibleScreenTracker,
+            FileUtils fileUtils,
+            File rootDir,
+            File spansDir,
+            String uniqueId) {
         this.visibleScreenTracker = visibleScreenTracker;
         this.fileUtils = fileUtils;
         this.rootDir = rootDir;
@@ -154,7 +159,7 @@ class StartTypeAwareSpanStorage implements SpanStorage {
                             fileUtils.safeDelete(dir);
                         });
         File backgroundDir = getCurrentSessionBackgroundDirectory();
-        if(!fileUtils.listFilesRecursively(backgroundDir).findAny().isPresent()){
+        if (!fileUtils.listFilesRecursively(backgroundDir).findAny().isPresent()) {
             fileUtils.safeDelete(backgroundDir);
         }
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinToDiskSender.java
@@ -81,7 +81,7 @@ class ZipkinToDiskSender extends Sender {
     }
 
     private File createFilename(long now) {
-        return new File(spanStorage.provideSpanFile(), now + ".spans");
+        return new File(spanStorage.provideSpansDirectory(), now + ".spans");
     }
 
     static Builder builder() {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DeviceSpanStorageLimiterTest.java
@@ -56,7 +56,7 @@ class DeviceSpanStorageLimiterTest {
     void ensureFreeSpace_littleUsageEnoughFreeSpace() {
         File mockFile = mock(File.class);
         when(spanStorage.getTotalFileSizeInBytes()).thenReturn(10 * 1024L);
-        when(spanStorage.provideSpanFile()).thenReturn(mockFile);
+        when(spanStorage.provideSpansDirectory()).thenReturn(mockFile);
         when(mockFile.getFreeSpace()).thenReturn(99L); // Disk is very full
         assertFalse(limiter.ensureFreeSpace());
         verify(fileUtils, never()).safeDelete(any());
@@ -66,7 +66,7 @@ class DeviceSpanStorageLimiterTest {
     void ensureFreeSpace_littleUsageButNotEnoughFreeSpace() {
         File mockFile = mock(File.class);
         when(spanStorage.getTotalFileSizeInBytes()).thenReturn(10 * 1024L);
-        when(spanStorage.provideSpanFile()).thenReturn(mockFile);
+        when(spanStorage.provideSpansDirectory()).thenReturn(mockFile);
         when(mockFile.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES * 99); // lots of room
         assertTrue(limiter.ensureFreeSpace());
         verify(fileUtils, never()).safeDelete(any());
@@ -75,7 +75,7 @@ class DeviceSpanStorageLimiterTest {
     @Test
     void ensureFreeSpace_underLimit() {
         File mockFile = mock(File.class);
-        when(spanStorage.provideSpanFile()).thenReturn(mockFile);
+        when(spanStorage.provideSpansDirectory()).thenReturn(mockFile);
 
         when(spanStorage.getTotalFileSizeInBytes()).thenReturn(MAX_STORAGE_USE_BYTES - 1);
         when(mockFile.getFreeSpace()).thenReturn(MAX_STORAGE_USE_BYTES + 1);
@@ -91,7 +91,7 @@ class DeviceSpanStorageLimiterTest {
         File file3 = new File("newest");
 
         File mockFile = mock(File.class);
-        when(spanStorage.provideSpanFile()).thenReturn(mockFile);
+        when(spanStorage.provideSpansDirectory()).thenReturn(mockFile);
         when(spanStorage.getTotalFileSizeInBytes()).thenReturn(MAX_STORAGE_USE_BYTES + 1);
         when(fileUtils.getModificationTime(file1)).thenReturn(1000L);
         when(fileUtils.getModificationTime(file2)).thenReturn(1001L);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
@@ -58,7 +58,10 @@ class DiskToZipkinExporterTest {
         file1 = new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "file1.spans");
         file2 = new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "file2.spans");
         imposter =
-                new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "someImposterFile.dll");
+                new File(
+                        SPAN_STORAGE.provideSpansDirectory()
+                                + File.separator
+                                + "someImposterFile.dll");
 
         when(currentNetworkProvider.refreshNetworkStatus()).thenReturn(currentNetwork);
         when(currentNetwork.isOnline()).thenReturn(true);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/DiskToZipkinExporterTest.java
@@ -54,11 +54,11 @@ class DiskToZipkinExporterTest {
     @BeforeEach
     void setup() throws Exception {
         Mockito.reset(SPAN_STORAGE);
-        when(SPAN_STORAGE.provideSpanFile()).thenReturn(spanFilesPath);
-        file1 = new File(SPAN_STORAGE.provideSpanFile() + File.separator + "file1.spans");
-        file2 = new File(SPAN_STORAGE.provideSpanFile() + File.separator + "file2.spans");
+        when(SPAN_STORAGE.provideSpansDirectory()).thenReturn(spanFilesPath);
+        file1 = new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "file1.spans");
+        file2 = new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "file2.spans");
         imposter =
-                new File(SPAN_STORAGE.provideSpanFile() + File.separator + "someImposterFile.dll");
+                new File(SPAN_STORAGE.provideSpansDirectory() + File.separator + "someImposterFile.dll");
 
         when(currentNetworkProvider.refreshNetworkStatus()).thenReturn(currentNetwork);
         when(currentNetwork.isOnline()).thenReturn(true);

--- a/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
@@ -21,30 +21,35 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-public class StartTypeAwareSpanStorageTest {
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-    private final FileUtils fileUtils = mock();
+import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
 
-    private final File rootDir = new File("files/");
-    private final VisibleScreenTracker visibleScreenTracker = mock();
+class StartTypeAwareSpanStorageTest {
+
+    final File rootDir = new File("files/");
+    VisibleScreenTracker visibleScreenTracker;
+    FileUtils fileUtils;
 
     private StartTypeAwareSpanStorage fileProvider;
 
     @BeforeEach
     void setup() {
+        visibleScreenTracker = mock();
+        fileUtils = mock();
         when(fileUtils.getSpansDirectory(rootDir)).thenReturn(new File(rootDir, "spans"));
         fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
     }
@@ -52,18 +57,45 @@ public class StartTypeAwareSpanStorageTest {
     @Test
     void create_onNewId_shouldCleanOldBackgroundFiles() {
         File file = mock();
-        when(file.getPath()).thenReturn("files/spans/background/123");
-        when(fileUtils.listDirectories(any())).thenReturn(Stream.of(file));
         ArgumentCaptor<File> fileArgumentCaptor = ArgumentCaptor.forClass(File.class);
+        when(file.getPath()).thenReturn("files/spans/background/123");
+
+        fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
+        fileUtils = mock(FileUtils.class);
+        when(fileUtils.listDirectories(any())).thenReturn(Stream.of(file));
+        when(fileUtils.listFiles(file)).thenReturn(Stream.of(file));
 
         fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
 
-        verify(fileUtils).safeDelete(fileArgumentCaptor.capture());
-        assertEquals(file.getPath(), fileArgumentCaptor.getValue().getPath());
+        verify(fileUtils, times(2)).safeDelete(fileArgumentCaptor.capture());
+        assertEquals(file, fileArgumentCaptor.getAllValues().get(0));
+        assertEquals(fileProvider.provideSpansDirectory(), fileArgumentCaptor.getAllValues().get(1));
     }
 
     @Test
-    void getPendingFiles_givenInBackground_shouldReturnForegoundOnlySpan() {
+    void create_cleanDoesntRemoveDirIfNotEmpty() {
+        String uniqueId = UUID.randomUUID().toString();
+        File spansDir = new File("files/spans");
+        File file = mock();
+        File file2 = mock();
+        fileUtils = mock(FileUtils.class);
+
+        ArgumentCaptor<File> fileArgumentCaptor = ArgumentCaptor.forClass(File.class);
+        when(file.getPath()).thenReturn("files/spans/background/123");
+
+        when(fileUtils.listDirectories(any())).thenReturn(Stream.of(file));
+        when(fileUtils.listFiles(file)).thenReturn(Stream.of(file));
+        when(fileUtils.listFilesRecursively(new File(spansDir, "background/" + uniqueId)))
+                .thenReturn(Stream.of(file2));
+
+        fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir, spansDir, uniqueId);
+
+        verify(fileUtils).safeDelete(fileArgumentCaptor.capture());
+        assertEquals(file, fileArgumentCaptor.getAllValues().get(0));
+    }
+
+    @Test
+    void getPendingFiles_givenInBackground_shouldReturnForegroundOnlySpan() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn(null);
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("unknown");
         List<File> spans = fileProvider.getPendingFiles().collect(Collectors.toList());
@@ -72,7 +104,7 @@ public class StartTypeAwareSpanStorageTest {
 
     @Test
     void
-            getPendingFiles_givenPrevouslyInBackground_shouldMoveBackgroundSpanToForegroundSpanForSending() {
+            getPendingFiles_givenPreviouslyInBackground_shouldMoveBackgroundSpanToForegroundSpanForSending() {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("LauncherActivity");
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("MainActivity");
 
@@ -104,7 +136,7 @@ public class StartTypeAwareSpanStorageTest {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn(null);
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("unknown");
 
-        File path = fileProvider.provideSpanFile();
+        File path = fileProvider.provideSpansDirectory();
 
         assertTrue(path.getPath().startsWith("files/spans/background/"));
     }
@@ -114,7 +146,7 @@ public class StartTypeAwareSpanStorageTest {
         when(visibleScreenTracker.getPreviouslyVisibleScreen()).thenReturn("LauncherActivity");
         when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn("MainActivity");
 
-        File path = fileProvider.provideSpanFile();
+        File path = fileProvider.provideSpansDirectory();
 
         assertFalse(path.getPath().startsWith("files/spans/background/"));
     }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
@@ -25,18 +25,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-
+import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class StartTypeAwareSpanStorageTest {
 
@@ -69,7 +67,8 @@ class StartTypeAwareSpanStorageTest {
 
         verify(fileUtils, times(2)).safeDelete(fileArgumentCaptor.capture());
         assertEquals(file, fileArgumentCaptor.getAllValues().get(0));
-        assertEquals(fileProvider.provideSpansDirectory(), fileArgumentCaptor.getAllValues().get(1));
+        assertEquals(
+                fileProvider.provideSpansDirectory(), fileArgumentCaptor.getAllValues().get(1));
     }
 
     @Test
@@ -88,7 +87,9 @@ class StartTypeAwareSpanStorageTest {
         when(fileUtils.listFilesRecursively(new File(spansDir, "background/" + uniqueId)))
                 .thenReturn(Stream.of(file2));
 
-        fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir, spansDir, uniqueId);
+        fileProvider =
+                StartTypeAwareSpanStorage.create(
+                        visibleScreenTracker, fileUtils, rootDir, spansDir, uniqueId);
 
         verify(fileUtils).safeDelete(fileArgumentCaptor.capture());
         assertEquals(file, fileArgumentCaptor.getAllValues().get(0));

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -63,7 +63,7 @@ class ZipkinToDiskSenderTest {
 
     @Test
     void testHappyPath() throws Exception {
-        when(spanStorage.provideSpanFile()).thenReturn(path);
+        when(spanStorage.provideSpansDirectory()).thenReturn(path);
 
         ZipkinToDiskSender sender =
                 ZipkinToDiskSender.builder()
@@ -91,7 +91,7 @@ class ZipkinToDiskSenderTest {
 
     @Test
     void testWriteFails() throws Exception {
-        when(spanStorage.provideSpanFile()).thenReturn(path);
+        when(spanStorage.provideSpansDirectory()).thenReturn(path);
         doThrow(new IOException("boom")).when(fileUtils).writeAsLines(finalPath, spans);
 
         ZipkinToDiskSender sender =


### PR DESCRIPTION
When doing some manual testing with the sample app, I noticed that when (re)launching the app when background telemetry had been buffered, the files were being moved but the empty subdirectories were left behind. This fixes that up by removing them.

Also renamed a few methods to clarify that the results are directories.