### PR TITLE
Prevent deletion attempt if dir doesn't exist

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileUtils.java
@@ -146,4 +146,8 @@ class FileUtils {
             Log.w(LOG_TAG, "Error deleting file " + file);
         }
     }
+
+    public boolean exists(File file) {
+        return file.exists();
+    }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
@@ -159,6 +159,9 @@ class StartTypeAwareSpanStorage implements SpanStorage {
                             fileUtils.safeDelete(dir);
                         });
         File backgroundDir = getCurrentSessionBackgroundDirectory();
+        if(!fileUtils.exists(backgroundDir)){
+            return;
+        }
         if (!fileUtils.listFilesRecursively(backgroundDir).findAny().isPresent()) {
             fileUtils.safeDelete(backgroundDir);
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/StartTypeAwareSpanStorage.java
@@ -159,7 +159,7 @@ class StartTypeAwareSpanStorage implements SpanStorage {
                             fileUtils.safeDelete(dir);
                         });
         File backgroundDir = getCurrentSessionBackgroundDirectory();
-        if(!fileUtils.exists(backgroundDir)){
+        if (!fileUtils.exists(backgroundDir)) {
             return;
         }
         if (!fileUtils.listFilesRecursively(backgroundDir).findAny().isPresent()) {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/StartTypeAwareSpanStorageTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,6 +63,7 @@ class StartTypeAwareSpanStorageTest {
         fileUtils = mock(FileUtils.class);
         when(fileUtils.listDirectories(any())).thenReturn(Stream.of(file));
         when(fileUtils.listFiles(file)).thenReturn(Stream.of(file));
+        when(fileUtils.exists(any())).thenReturn(true);
 
         fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
 
@@ -69,6 +71,19 @@ class StartTypeAwareSpanStorageTest {
         assertEquals(file, fileArgumentCaptor.getAllValues().get(0));
         assertEquals(
                 fileProvider.provideSpansDirectory(), fileArgumentCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    void doesNotAttemptIfBackgroundDirNotExist() {
+        fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
+        fileUtils = mock(FileUtils.class);
+        when(fileUtils.exists(any())).thenReturn(false);
+        when(fileUtils.listDirectories(any())).thenReturn(Stream.empty());
+
+        fileProvider = StartTypeAwareSpanStorage.create(visibleScreenTracker, fileUtils, rootDir);
+
+        verify(fileUtils, never()).listFiles(any());
+        verify(fileUtils, never()).safeDelete(any());
     }
 
     @Test


### PR DESCRIPTION
I noticed that in some circumstances the app repeatedly tries to delete the current background directory even when it doesn't exist. This isn't a huge problem, but does make the logs a bit chatty. Better not to attempt if we know that the dir doesn't exist.