### PR TITLE
Change session-based probabilistic sampling computation

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/SessionUtils.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/SessionUtils.java
@@ -1,0 +1,26 @@
+package com.splunk.rum.internal;
+
+import android.util.Log;
+
+public class SessionUtils {
+
+    /**
+     * Performs an unsigned 32-bit conversion of the hex session id to a long.
+     */
+    static long convertToUInt32(String sessionId) {
+        long acc = 0L;
+        for (int i = 0; i < sessionId.length(); i += 8) {
+            long chunk = 0;
+            try {
+                String chunkString = sessionId.substring(i, i+8);
+                chunk = Long.parseUnsignedLong(chunkString, 16);
+            } catch (NumberFormatException e) {
+                Log.w("SplunkRum", "Error parsing session id into long: " + sessionId);
+            }
+            acc = acc ^ chunk;
+        }
+        return acc;
+    }
+
+
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/SessionUtils.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/SessionUtils.java
@@ -1,18 +1,32 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.internal;
 
 import android.util.Log;
 
 public class SessionUtils {
 
-    /**
-     * Performs an unsigned 32-bit conversion of the hex session id to a long.
-     */
+    /** Performs an unsigned 32-bit conversion of the hex session id to a long. */
     static long convertToUInt32(String sessionId) {
         long acc = 0L;
         for (int i = 0; i < sessionId.length(); i += 8) {
             long chunk = 0;
             try {
-                String chunkString = sessionId.substring(i, i+8);
+                String chunkString = sessionId.substring(i, i + 8);
                 chunk = Long.parseUnsignedLong(chunkString, 16);
             } catch (NumberFormatException e) {
                 Log.w("SplunkRum", "Error parsing session id into long: " + sessionId);
@@ -21,6 +35,4 @@ public class SessionUtils {
         }
         return acc;
     }
-
-
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
@@ -63,6 +63,7 @@ public class UInt32QuadXorTraceIdRatioSampler implements Sampler {
         } else if (ratio == 1.0) {
             idUpperBound = Long.MAX_VALUE;
         } else {
+            // ratio * UInt32 max value
             idUpperBound = (long) (ratio * 0xFFFFFFFFL);
         }
         String description =

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
@@ -1,0 +1,86 @@
+package com.splunk.rum.internal;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+/**
+ * This class is internal and is hence not for public use.
+ * Its APIs are unstable and can change at any time.
+ *
+ * This class is very similar to the SessionIdRatioBasedSampler from
+ * upstream, but exists in order to perform a trace id into a long calculation
+ * in a way that is more consistent with iOS and js.
+ *
+ * This class should be considered a stop-gap measure until this problem
+ * is correctly spec'd in otel.
+ *
+ */
+public class UInt32QuadXorTraceIdRatioSampler implements Sampler {
+    static final SamplingResult POSITIVE_SAMPLING_RESULT = SamplingResult.recordAndSample();
+
+    static final SamplingResult NEGATIVE_SAMPLING_RESULT = SamplingResult.drop();
+    private final long idUpperBound;
+    private final String description;
+    private final Supplier<String> sessionIdSupplier;
+    private final Object lock = new Object();
+    private String lastSeenSessionId = "";
+    private SamplingResult lastSamplingResult = NEGATIVE_SAMPLING_RESULT;
+
+    static Sampler create(double ratio, Supplier<String> sessionIdSupplier) {
+        // Taken directly mostly from the TraceIdRatioBasedSampler in upstream, with a modification
+        // to the upper bound to make it within UInt32.
+        if (ratio < 0.0 || ratio > 1.0) {
+            throw new IllegalArgumentException("ratio must be in range [0.0, 1.0]");
+        }
+        long idUpperBound;
+        // Special case the limits, to avoid any possible issues with lack of precision across
+        // double/long boundaries. For probability == 0.0, we use Long.MIN_VALUE as this guarantees
+        // that we will never sample a trace, even in the case where the id == Long.MIN_VALUE, since
+        // Math.Abs(Long.MIN_VALUE) == Long.MIN_VALUE.
+        if (ratio == 0.0) {
+            idUpperBound = Long.MIN_VALUE;
+        } else if (ratio == 1.0) {
+            idUpperBound = Long.MAX_VALUE;
+        } else {
+            idUpperBound = (long) (ratio * 0xFFFFFFFFL);
+        }
+        String description = String.format(Locale.getDefault(),"UInt32QuadXorTraceIdRatioSampler{radio:%f}", ratio);
+        return new UInt32QuadXorTraceIdRatioSampler(idUpperBound, sessionIdSupplier, description);
+    }
+
+    private UInt32QuadXorTraceIdRatioSampler(long idUpperBound, Supplier<String> sessionIdSupplier, String description) {
+        this.idUpperBound = idUpperBound;
+        this.sessionIdSupplier = sessionIdSupplier;
+        this.description = description;
+    }
+
+    @Override
+    public SamplingResult shouldSample(Context parentContext, String traceId, String name,
+                                       SpanKind spanKind, Attributes attributes,
+                                       List<LinkData> parentLinks) {
+        String sessionId = sessionIdSupplier.get();
+        synchronized(lock){
+            if(lastSeenSessionId.equals(sessionId)){
+                return lastSamplingResult;
+            }
+            lastSeenSessionId = sessionId;
+            lastSamplingResult = SessionUtils.convertToUInt32(sessionId) < idUpperBound
+                    ? POSITIVE_SAMPLING_RESULT
+                    : NEGATIVE_SAMPLING_RESULT;
+            return lastSamplingResult;
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSampler.java
@@ -68,7 +68,7 @@ public class UInt32QuadXorTraceIdRatioSampler implements Sampler {
         }
         String description =
                 String.format(
-                        Locale.getDefault(), "UInt32QuadXorTraceIdRatioSampler{radio:%f}", ratio);
+                        Locale.getDefault(), "UInt32QuadXorTraceIdRatioSampler{ratio:%f}", ratio);
         return new UInt32QuadXorTraceIdRatioSampler(idUpperBound, sessionIdSupplier, description);
     }
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/internal/SessionUtilsTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/internal/SessionUtilsTest.java
@@ -1,0 +1,15 @@
+package com.splunk.rum.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SessionUtilsTest {
+
+    @Test
+    void testConvert(){
+        long result = SessionUtils.convertToUInt32("c06947ed1f53b1a69be3c6899bc11a3e");
+        assertEquals(3742903036L, result);
+    }
+
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/internal/SessionUtilsTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/internal/SessionUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -7,9 +23,8 @@ import org.junit.jupiter.api.Test;
 class SessionUtilsTest {
 
     @Test
-    void testConvert(){
+    void testConvert() {
         long result = SessionUtils.convertToUInt32("c06947ed1f53b1a69be3c6899bc11a3e");
         assertEquals(3742903036L, result);
     }
-
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSamplerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSamplerTest.java
@@ -1,0 +1,37 @@
+package com.splunk.rum.internal;
+
+import static com.splunk.rum.internal.UInt32QuadXorTraceIdRatioSampler.NEGATIVE_SAMPLING_RESULT;
+import static com.splunk.rum.internal.UInt32QuadXorTraceIdRatioSampler.POSITIVE_SAMPLING_RESULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+class UInt32QuadXorTraceIdRatioSamplerTest {
+
+    private final Context parentContext = Context.root().with(Span.getInvalid());
+    @Test
+    void sampleInclude(){
+        Sampler sampler = UInt32QuadXorTraceIdRatioSampler.create(0.5, () -> "4777abcd3f7777abcdefc6899bc11a3e");
+        SamplingResult result = sampler.shouldSample(parentContext, null, null, null, Attributes.empty(),
+                Collections.emptyList());
+        assertEquals(POSITIVE_SAMPLING_RESULT.getDecision(), result.getDecision());
+    }
+
+    @Test
+    void sampleDrop(){
+        Sampler sampler = UInt32QuadXorTraceIdRatioSampler.create(0.5, () -> "9777abcd3f7777abcdefc6899bc11a3e");
+        SamplingResult result = sampler.shouldSample(parentContext, null, null, null, Attributes.empty(),
+                Collections.emptyList());
+        assertEquals(NEGATIVE_SAMPLING_RESULT.getDecision(), result.getDecision());
+    }
+
+
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSamplerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/internal/UInt32QuadXorTraceIdRatioSamplerTest.java
@@ -1,37 +1,80 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.internal;
 
 import static com.splunk.rum.internal.UInt32QuadXorTraceIdRatioSampler.NEGATIVE_SAMPLING_RESULT;
 import static com.splunk.rum.internal.UInt32QuadXorTraceIdRatioSampler.POSITIVE_SAMPLING_RESULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
 
 class UInt32QuadXorTraceIdRatioSamplerTest {
 
     private final Context parentContext = Context.root().with(Span.getInvalid());
+
     @Test
-    void sampleInclude(){
-        Sampler sampler = UInt32QuadXorTraceIdRatioSampler.create(0.5, () -> "4777abcd3f7777abcdefc6899bc11a3e");
-        SamplingResult result = sampler.shouldSample(parentContext, null, null, null, Attributes.empty(),
-                Collections.emptyList());
+    void sampleInclude() {
+        Sampler sampler =
+                UInt32QuadXorTraceIdRatioSampler.create(
+                        0.5, () -> "4777abcd3f7777abcdefc6899bc11a3e");
+        SamplingResult result =
+                sampler.shouldSample(
+                        parentContext,
+                        null,
+                        null,
+                        null,
+                        Attributes.empty(),
+                        Collections.emptyList());
         assertEquals(POSITIVE_SAMPLING_RESULT.getDecision(), result.getDecision());
     }
 
     @Test
-    void sampleDrop(){
-        Sampler sampler = UInt32QuadXorTraceIdRatioSampler.create(0.5, () -> "9777abcd3f7777abcdefc6899bc11a3e");
-        SamplingResult result = sampler.shouldSample(parentContext, null, null, null, Attributes.empty(),
-                Collections.emptyList());
+    void sampleDrop() {
+        Sampler sampler =
+                UInt32QuadXorTraceIdRatioSampler.create(
+                        0.5, () -> "9777abcd3f7777abcdefc6899bc11a3e");
+        SamplingResult result =
+                sampler.shouldSample(
+                        parentContext,
+                        null,
+                        null,
+                        null,
+                        Attributes.empty(),
+                        Collections.emptyList());
         assertEquals(NEGATIVE_SAMPLING_RESULT.getDecision(), result.getDecision());
     }
 
-
+    @Test
+    void nullSessionMeansAlwaysPositive() {
+        Sampler sampler = UInt32QuadXorTraceIdRatioSampler.create(0.00000001, () -> null);
+        SamplingResult result =
+                sampler.shouldSample(
+                        parentContext,
+                        null,
+                        null,
+                        null,
+                        Attributes.empty(),
+                        Collections.emptyList());
+        assertEquals(POSITIVE_SAMPLING_RESULT.getDecision(), result.getDecision());
+    }
 }


### PR DESCRIPTION
We stray from the path here a little bit by introducing a bespoke sampler that differs from the upstream implementation. This is a stop-gap temporary measure to better align with web and iOS. Sessions sampling decisions can now be more consistent between the platforms.

See https://github.com/signalfx/splunk-otel-ios/pull/185 for a similar change in iOS that this borrowed from.