### PR TITLE
Adjust network provider

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -59,6 +59,12 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -22,13 +22,14 @@ import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
+import static java.util.Objects.requireNonNull;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
-import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -57,12 +58,6 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
-import java.time.Duration;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.logging.Level;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
@@ -91,8 +86,7 @@ class RumInitializer {
         initializationEvents.begin();
 
         OtelRumConfig config = new OtelRumConfig();
-        GlobalAttributesSupplier globalAttributeSupplier =
-                new GlobalAttributesSupplier(builder.globalAttributes);
+        GlobalAttributesSupplier globalAttributeSupplier = new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -22,13 +22,14 @@ import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
+import static java.util.Objects.requireNonNull;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
-import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -59,12 +60,6 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
-import java.time.Duration;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.logging.Level;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
@@ -95,8 +90,7 @@ class RumInitializer {
         initializationEvents.begin();
 
         OtelRumConfig config = new OtelRumConfig();
-        GlobalAttributesSupplier globalAttributeSupplier =
-                new GlobalAttributesSupplier(builder.globalAttributes);
+        GlobalAttributesSupplier globalAttributeSupplier = new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -103,18 +103,11 @@ class RumInitializer {
         initializationEvents.emit("resourceInitialized");
 
         CurrentNetworkProvider currentNetworkProvider = CurrentNetworkProvider.createAndStart(application);
+        otelRumBuilder.setCurrentNetworkProvider(currentNetworkProvider);
         initializationEvents.emit("connectionUtilInitialized");
 
         // TODO: How truly important is the order of these span processors? The location of event
         // generation should probably not be altered...
-
-        // Add span processor that appends network attributes.
-        otelRumBuilder.addTracerProviderCustomizer(
-                (tracerProviderBuilder, app) -> {
-                    SpanProcessor networkAttributesSpanAppender =
-                            NetworkAttributesSpanAppender.create(currentNetworkProvider);
-                    return tracerProviderBuilder.addSpanProcessor(networkAttributesSpanAppender);
-                });
 
         // Add batch span processor
         otelRumBuilder.addTracerProviderCustomizer(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -87,9 +87,7 @@ class RumInitializer {
         this.initializationEvents = new InitializationEvents(startupTimer);
     }
 
-    SplunkRum initialize(
-            Function<Application, CurrentNetworkProvider> currentNetworkProviderFactory,
-            Looper mainLooper) {
+    SplunkRum initialize(Looper mainLooper) {
         VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
 
         initializationEvents.begin();
@@ -104,8 +102,7 @@ class RumInitializer {
         otelRumBuilder.mergeResource(createSplunkResource());
         initializationEvents.emit("resourceInitialized");
 
-        CurrentNetworkProvider currentNetworkProvider =
-                currentNetworkProviderFactory.apply(application);
+        CurrentNetworkProvider currentNetworkProvider = CurrentNetworkProvider.createAndStart(application);
         initializationEvents.emit("connectionUtilInitialized");
 
         // TODO: How truly important is the order of these span processors? The location of event

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -42,7 +42,6 @@ import io.opentelemetry.android.instrumentation.anr.AnrDetector;
 import io.opentelemetry.android.instrumentation.crash.CrashReporter;
 import io.opentelemetry.android.instrumentation.lifecycle.AndroidLifecycleInstrumentation;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
-import io.opentelemetry.android.instrumentation.network.NetworkChangeMonitor;
 import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingDetector;
 import io.opentelemetry.android.instrumentation.startup.AppStartupTimer;
 import io.opentelemetry.api.trace.Tracer;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -93,6 +93,9 @@ class RumInitializer {
         GlobalAttributesSupplier globalAttributeSupplier =
                 new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
+        if(!builder.isNetworkMonitorEnabled()){
+            config.disableNetworkChangeMonitoring();
+        }
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -93,7 +93,7 @@ class RumInitializer {
         GlobalAttributesSupplier globalAttributeSupplier =
                 new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
-        if(!builder.isNetworkMonitorEnabled()){
+        if (!builder.isNetworkMonitorEnabled()) {
             config.disableNetworkChangeMonitoring();
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -22,14 +22,13 @@ import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
-import static java.util.Objects.requireNonNull;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -86,7 +85,8 @@ class RumInitializer {
         initializationEvents.begin();
 
         OtelRumConfig config = new OtelRumConfig();
-        GlobalAttributesSupplier globalAttributeSupplier = new GlobalAttributesSupplier(builder.globalAttributes);
+        GlobalAttributesSupplier globalAttributeSupplier =
+                new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -99,7 +99,8 @@ class RumInitializer {
         otelRumBuilder.mergeResource(createSplunkResource());
         initializationEvents.emit("resourceInitialized");
 
-        CurrentNetworkProvider currentNetworkProvider = CurrentNetworkProvider.createAndStart(application);
+        CurrentNetworkProvider currentNetworkProvider =
+                CurrentNetworkProvider.createAndStart(application);
         otelRumBuilder.setCurrentNetworkProvider(currentNetworkProvider);
         initializationEvents.emit("connectionUtilInitialized");
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -22,14 +22,13 @@ import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
-import static java.util.Objects.requireNonNull;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -90,7 +89,8 @@ class RumInitializer {
         initializationEvents.begin();
 
         OtelRumConfig config = new OtelRumConfig();
-        GlobalAttributesSupplier globalAttributeSupplier = new GlobalAttributesSupplier(builder.globalAttributes);
+        GlobalAttributesSupplier globalAttributeSupplier =
+                new GlobalAttributesSupplier(builder.globalAttributes);
         config.setGlobalAttributes(globalAttributeSupplier);
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -57,6 +57,12 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -42,7 +42,6 @@ import io.opentelemetry.android.instrumentation.anr.AnrDetector;
 import io.opentelemetry.android.instrumentation.crash.CrashReporter;
 import io.opentelemetry.android.instrumentation.lifecycle.AndroidLifecycleInstrumentation;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
-import io.opentelemetry.android.instrumentation.network.NetworkAttributesSpanAppender;
 import io.opentelemetry.android.instrumentation.network.NetworkChangeMonitor;
 import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingDetector;
 import io.opentelemetry.android.instrumentation.startup.AppStartupTimer;
@@ -53,7 +52,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.sdk.trace.SpanLimits;
-import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -102,7 +100,8 @@ class RumInitializer {
         otelRumBuilder.mergeResource(createSplunkResource());
         initializationEvents.emit("resourceInitialized");
 
-        CurrentNetworkProvider currentNetworkProvider = CurrentNetworkProvider.createAndStart(application);
+        CurrentNetworkProvider currentNetworkProvider =
+                CurrentNetworkProvider.createAndStart(application);
         otelRumBuilder.setCurrentNetworkProvider(currentNetworkProvider);
         initializationEvents.emit("connectionUtilInitialized");
 
@@ -183,9 +182,6 @@ class RumInitializer {
 
         if (builder.isAnrDetectionEnabled()) {
             installAnrDetector(otelRumBuilder, mainLooper);
-        }
-        if (builder.isNetworkMonitorEnabled()) {
-            installNetworkMonitor(otelRumBuilder, currentNetworkProvider);
         }
         if (builder.isSlowRenderingDetectionEnabled()) {
             installSlowRenderingDetector(otelRumBuilder);
@@ -279,16 +275,6 @@ class RumInitializer {
                             .installOn(instrumentedApplication);
 
                     initializationEvents.emit("anrMonitorInitialized");
-                });
-    }
-
-    private void installNetworkMonitor(
-            OpenTelemetryRumBuilder otelRumBuilder, CurrentNetworkProvider currentNetworkProvider) {
-        otelRumBuilder.addInstrumentation(
-                instrumentedApplication -> {
-                    NetworkChangeMonitor.create(currentNetworkProvider)
-                            .installOn(instrumentedApplication);
-                    initializationEvents.emit("networkMonitorInitialized");
                 });
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -100,8 +100,7 @@ class RumInitializer {
         otelRumBuilder.mergeResource(createSplunkResource());
         initializationEvents.emit("resourceInitialized");
 
-        CurrentNetworkProvider currentNetworkProvider =
-                CurrentNetworkProvider.createAndStart(application);
+        CurrentNetworkProvider currentNetworkProvider = CurrentNetworkProvider.createAndStart(application);
         otelRumBuilder.setCurrentNetworkProvider(currentNetworkProvider);
         initializationEvents.emit("connectionUtilInitialized");
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -26,6 +26,7 @@ import android.os.Looper;
 import android.util.Log;
 import android.webkit.WebView;
 import androidx.annotation.Nullable;
+
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -93,8 +93,7 @@ public class SplunkRum {
     // for testing purposes
     static SplunkRum initialize(
             SplunkRumBuilder builder,
-            Application application,
-            Function<Application, CurrentNetworkProvider> currentNetworkProviderFactory) {
+            Application application) {
         if (INSTANCE != null) {
             Log.w(LOG_TAG, "Singleton SplunkRum instance has already been initialized.");
             return INSTANCE;
@@ -105,7 +104,7 @@ public class SplunkRum {
         } else {
             INSTANCE =
                     new RumInitializer(builder, application, startupTimer)
-                            .initialize(currentNetworkProviderFactory, Looper.getMainLooper());
+                            .initialize(Looper.getMainLooper());
         }
 
         if (builder.isDebugEnabled()) {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -28,7 +28,6 @@ import android.webkit.WebView;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
-import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.android.instrumentation.startup.AppStartupTimer;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -40,7 +39,6 @@ import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 
@@ -91,9 +89,7 @@ public class SplunkRum {
     }
 
     // for testing purposes
-    static SplunkRum initialize(
-            SplunkRumBuilder builder,
-            Application application) {
+    static SplunkRum initialize(SplunkRumBuilder builder, Application application) {
         if (INSTANCE != null) {
             Log.w(LOG_TAG, "Singleton SplunkRum instance has already been initialized.");
             return INSTANCE;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -26,7 +26,6 @@ import android.os.Looper;
 import android.util.Log;
 import android.webkit.WebView;
 import androidx.annotation.Nullable;
-
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -21,7 +21,6 @@ import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB
 import android.app.Application;
 import android.util.Log;
 import androidx.annotation.Nullable;
-import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.time.Duration;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -312,7 +312,7 @@ public final class SplunkRumBuilder {
             throw new IllegalStateException(
                     "You must provide a rumAccessToken, a realm (or full beaconEndpoint), and an applicationName to create a valid Config instance.");
         }
-        return SplunkRum.initialize(this, application, CurrentNetworkProvider::createAndStart);
+        return SplunkRum.initialize(this, application);
     }
 
     /**

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,8 +81,7 @@ class RumInitializerTest {
                         return testExporter;
                     }
                 };
-        SplunkRum splunkRum =
-                testInitializer.initialize(mainLooper);
+        SplunkRum splunkRum = testInitializer.initialize(mainLooper);
         startupTimer.runCompletionCallback();
         splunkRum.flushSpans();
 
@@ -137,8 +135,7 @@ class RumInitializerTest {
                         return testExporter;
                     }
                 };
-        SplunkRum splunkRum =
-                testInitializer.initialize(mainLooper);
+        SplunkRum splunkRum = testInitializer.initialize(mainLooper);
         splunkRum.flushSpans();
 
         testExporter.reset();

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -105,7 +105,6 @@ class RumInitializerTest {
         checkEventExists(events, "activityLifecycleCallbacksInitialized");
         checkEventExists(events, "crashReportingInitialized");
         checkEventExists(events, "anrMonitorInitialized");
-        checkEventExists(events, "networkMonitorInitialized");
     }
 
     private void checkEventExists(List<EventData> events, String eventName) {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -83,8 +83,7 @@ class RumInitializerTest {
                     }
                 };
         SplunkRum splunkRum =
-                testInitializer.initialize(
-                        app -> mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS), mainLooper);
+                testInitializer.initialize(mainLooper);
         startupTimer.runCompletionCallback();
         splunkRum.flushSpans();
 
@@ -139,8 +138,7 @@ class RumInitializerTest {
                     }
                 };
         SplunkRum splunkRum =
-                testInitializer.initialize(
-                        app -> mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS), mainLooper);
+                testInitializer.initialize(mainLooper);
         splunkRum.flushSpans();
 
         testExporter.reset();
@@ -232,10 +230,6 @@ class RumInitializerTest {
 
         when(application.getApplicationContext()).thenReturn(context);
 
-        CurrentNetworkProvider currentNetworkProvider =
-                mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS);
-        when(currentNetworkProvider.refreshNetworkStatus().isOnline()).thenReturn(true);
-
         AppStartupTimer appStartupTimer = new AppStartupTimer();
         RumInitializer initializer =
                 new RumInitializer(splunkRumBuilder, application, appStartupTimer) {
@@ -245,7 +239,7 @@ class RumInitializerTest {
                     }
                 };
 
-        SplunkRum splunkRum = initializer.initialize(app -> currentNetworkProvider, mainLooper);
+        SplunkRum splunkRum = initializer.initialize(mainLooper);
         appStartupTimer.runCompletionCallback();
 
         Exception e = new IllegalArgumentException("booom!");

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -40,7 +40,6 @@ import com.splunk.rum.internal.GlobalAttributesSupplier;
 
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
-import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
@@ -82,8 +81,6 @@ public class SplunkRumTest {
     @Test
     void initialization_onlyOnce() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
-        CurrentNetworkProvider currentNetworkProvider =
-                mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS);
         Context context = mock(Context.class);
 
         SplunkRumBuilder splunkRumBuilder =
@@ -96,7 +93,7 @@ public class SplunkRumTest {
         when(application.getApplicationContext()).thenReturn(context);
 
         SplunkRum singleton =
-                SplunkRum.initialize(splunkRumBuilder, application, app -> currentNetworkProvider);
+                SplunkRum.initialize(splunkRumBuilder, application);
         SplunkRum sameInstance = splunkRumBuilder.build(application);
 
         assertSame(singleton, sameInstance);
@@ -111,8 +108,6 @@ public class SplunkRumTest {
     @Test
     void getInstance() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
-        CurrentNetworkProvider currentNetworkProvider =
-                mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS);
         Context context = mock(Context.class);
 
         SplunkRumBuilder splunkRumBuilder =
@@ -125,7 +120,7 @@ public class SplunkRumTest {
         when(application.getApplicationContext()).thenReturn(context);
 
         SplunkRum singleton =
-                SplunkRum.initialize(splunkRumBuilder, application, app -> currentNetworkProvider);
+                SplunkRum.initialize(splunkRumBuilder, application);
         assertSame(singleton, SplunkRum.getInstance());
     }
 
@@ -137,8 +132,6 @@ public class SplunkRumTest {
     @Test
     void nonNullMethods() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
-        CurrentNetworkProvider currentNetworkProvider =
-                mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS);
         Context context = mock(Context.class);
 
         when(application.getApplicationContext()).thenReturn(context);
@@ -151,7 +144,7 @@ public class SplunkRumTest {
                         .disableAnrDetection();
 
         SplunkRum splunkRum =
-                SplunkRum.initialize(splunkRumBuilder, application, app -> currentNetworkProvider);
+                SplunkRum.initialize(splunkRumBuilder, application);
         assertNotNull(splunkRum.getOpenTelemetry());
         assertNotNull(splunkRum.getRumSessionId());
     }
@@ -232,8 +225,6 @@ public class SplunkRumTest {
     @Test
     void integrateWithBrowserRum() {
         Application application = mock(Application.class, RETURNS_DEEP_STUBS);
-        CurrentNetworkProvider currentNetworkProvider =
-                mock(CurrentNetworkProvider.class, RETURNS_DEEP_STUBS);
         Context context = mock(Context.class);
         WebView webView = mock(WebView.class);
 
@@ -247,7 +238,7 @@ public class SplunkRumTest {
                         .disableAnrDetection();
 
         SplunkRum splunkRum =
-                SplunkRum.initialize(splunkRumBuilder, application, app -> currentNetworkProvider);
+                SplunkRum.initialize(splunkRumBuilder, application);
         splunkRum.integrateWithBrowserRum(webView);
 
         verify(webView)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -36,6 +36,9 @@ import android.app.Application;
 import android.content.Context;
 import android.location.Location;
 import android.webkit.WebView;
+
+import com.splunk.rum.internal.GlobalAttributesSupplier;
+
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -36,6 +36,9 @@ import android.app.Application;
 import android.content.Context;
 import android.location.Location;
 import android.webkit.WebView;
+
+import com.splunk.rum.internal.GlobalAttributesSupplier;
+
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 
 import com.splunk.rum.internal.GlobalAttributesSupplier;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -92,8 +92,7 @@ public class SplunkRumTest {
 
         when(application.getApplicationContext()).thenReturn(context);
 
-        SplunkRum singleton =
-                SplunkRum.initialize(splunkRumBuilder, application);
+        SplunkRum singleton = SplunkRum.initialize(splunkRumBuilder, application);
         SplunkRum sameInstance = splunkRumBuilder.build(application);
 
         assertSame(singleton, sameInstance);
@@ -119,8 +118,7 @@ public class SplunkRumTest {
 
         when(application.getApplicationContext()).thenReturn(context);
 
-        SplunkRum singleton =
-                SplunkRum.initialize(splunkRumBuilder, application);
+        SplunkRum singleton = SplunkRum.initialize(splunkRumBuilder, application);
         assertSame(singleton, SplunkRum.getInstance());
     }
 
@@ -143,8 +141,7 @@ public class SplunkRumTest {
                         .setRumAccessToken("abracadabra")
                         .disableAnrDetection();
 
-        SplunkRum splunkRum =
-                SplunkRum.initialize(splunkRumBuilder, application);
+        SplunkRum splunkRum = SplunkRum.initialize(splunkRumBuilder, application);
         assertNotNull(splunkRum.getOpenTelemetry());
         assertNotNull(splunkRum.getRumSessionId());
     }
@@ -237,8 +234,7 @@ public class SplunkRumTest {
                         .setRumAccessToken("abracadabra")
                         .disableAnrDetection();
 
-        SplunkRum splunkRum =
-                SplunkRum.initialize(splunkRumBuilder, application);
+        SplunkRum splunkRum = SplunkRum.initialize(splunkRumBuilder, application);
         splunkRum.integrateWithBrowserRum(webView);
 
         verify(webView)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -37,10 +37,6 @@ import android.content.Context;
 import android.location.Location;
 import android.webkit.WebView;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
-
-import com.splunk.rum.internal.GlobalAttributesSupplier;
-
-import com.splunk.rum.internal.GlobalAttributesSupplier;
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumTest.java
@@ -36,7 +36,6 @@ import android.app.Application;
 import android.content.Context;
 import android.location.Location;
 import android.webkit.WebView;
-
 import com.splunk.rum.internal.GlobalAttributesSupplier;
 
 import com.splunk.rum.internal.GlobalAttributesSupplier;


### PR DESCRIPTION
This needs to: 

1. Rebase after #710 is merged (this builds on that)
2. Wait until https://github.com/open-telemetry/opentelemetry-android/pull/176 in upstream is merged.

Moves the creation of the network provider closer to its usage and then calls the setter to allow sharing of the instance with the underlying implementation. It then removes the explicit setup/installation of the network component.

Note that the network provider is still used by the bespoke disk buffering exporter to ensure that the network is available for sending.