### PR TITLE
Added possibility to provide custom headers supplier and disabling requests gzip compression

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomHeadersRequestInterceptor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomHeadersRequestInterceptor.java
@@ -1,0 +1,33 @@
+package com.splunk.rum;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class CustomHeadersRequestInterceptor implements Interceptor {
+
+    @NonNull
+    private final Supplier<Map<String, String>> headersSupplier;
+
+
+    public CustomHeadersRequestInterceptor(@NonNull Supplier<Map<String, String>> headersSupplier) {
+        this.headersSupplier = headersSupplier;
+    }
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        Request.Builder requestBuilder = chain.request().newBuilder();
+        Map<String, String> headers = headersSupplier.get();
+        if (headers != null) {
+            headers.forEach(requestBuilder::header);
+        }
+        return chain.proceed(requestBuilder.build());
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -24,7 +24,9 @@ import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /** A builder of {@link SplunkRum}. */
 public final class SplunkRumBuilder {
@@ -47,6 +49,10 @@ public final class SplunkRumBuilder {
     boolean sessionBasedSamplerEnabled = false;
     double sessionBasedSamplerRatio = 1.0;
     boolean isSubprocess = false;
+
+    @Nullable Supplier<Map<String, String>> headersSupplier;
+
+    boolean gzipCompressionEnabled = true;
 
     /**
      * Sets the application name that will be used to identify your application in the Splunk RUM
@@ -289,6 +295,28 @@ public final class SplunkRumBuilder {
 
         this.sessionBasedSamplerEnabled = true;
         this.sessionBasedSamplerRatio = ratio;
+        return this;
+    }
+
+    /***
+     * Sets the supplier of headers, that will be added to every rum request.
+     * It can be used to provide additional Authorization headers.
+     *
+     * @param headersSupplier Headers supplier, that returns map of header names and header values
+     * @return {@code this}
+     */
+    public SplunkRumBuilder setHeadersSupplier(Supplier<Map<String, String>> headersSupplier) {
+        this.headersSupplier = headersSupplier;
+        return this;
+    }
+
+    /***
+     * Disables gzip compression of the rum requests.
+     *
+     * @return {@code this}
+     */
+    public SplunkRumBuilder disableGzipCompression() {
+        this.gzipCompressionEnabled = false;
         return this;
     }
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/CustomHeadersRequestInterceptorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/CustomHeadersRequestInterceptorTest.java
@@ -1,0 +1,149 @@
+package com.splunk.rum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Headers;
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class CustomHeadersRequestInterceptorTest {
+
+    @Test
+    void interceptorAddsHeaders() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Token");
+        headers.put("Header", "Value");
+        CustomHeadersRequestInterceptor interceptor = new CustomHeadersRequestInterceptor(() -> headers);
+
+        Headers initialHeaders = Headers.of("Connection", "keep-alive");
+        Consumer<Request> requestValidator = request -> {
+            assertEquals(3, request.headers().size());
+            assertEquals("keep-alive", request.headers().get("Connection"));
+            assertEquals("Token", request.headers().get("Authorization"));
+            assertEquals("Value", request.headers().get("Header"));
+        };
+
+        interceptor.intercept(testChain(initialHeaders, requestValidator));
+    }
+
+    @Test
+    void interceptorAddsNoHeaderWhenSupplierReturnsNull() throws IOException {
+        CustomHeadersRequestInterceptor interceptor = new CustomHeadersRequestInterceptor(() -> null);
+
+        Headers initialHeaders = Headers.of("Connection", "keep-alive");
+        Consumer<Request> requestValidator = request -> {
+            assertEquals(1, request.headers().size());
+            assertEquals("keep-alive", request.headers().get("Connection"));
+        };
+
+        interceptor.intercept(testChain(initialHeaders, requestValidator));
+    }
+
+
+    @Test
+    void interceptorAddsLatestHeadersFromSupplier() throws IOException {
+        AtomicReference<Integer> changingValue = new AtomicReference<>(0);
+        Supplier<Map<String, String>> headersSupplier = () -> {
+            changingValue.getAndSet(changingValue.get() + 1);
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Header", changingValue.toString());
+            return headers;
+        };
+
+        CustomHeadersRequestInterceptor interceptor = new CustomHeadersRequestInterceptor(headersSupplier);
+
+        interceptor.intercept(testChain(Headers.of(), request -> {
+            assertEquals(1, request.headers().size());
+            assertEquals("1", request.headers().get("Header"));
+        }));
+
+        interceptor.intercept(testChain(Headers.of(), request -> {
+            assertEquals(1, request.headers().size());
+            assertEquals("2", request.headers().get("Header"));
+        }));
+
+        interceptor.intercept(testChain(Headers.of(), request -> {
+            assertEquals(1, request.headers().size());
+            assertEquals("3", request.headers().get("Header"));
+        }));
+    }
+
+    private Interceptor.Chain testChain(Headers initialHeaders, Consumer<Request> requestValidator) {
+        return new Interceptor.Chain() {
+            @NonNull
+            @Override
+            public Request request() {
+                return new Request.Builder().url("https://splunk.rum/test").headers(initialHeaders).build();
+            }
+
+            @NonNull
+            @Override
+            public Response proceed(@NonNull Request request) {
+                requestValidator.accept(request);
+                return new Response.Builder().request(request).code(200).message("OK").protocol(Protocol.HTTP_2).build();
+            }
+
+            @Nullable
+            @Override
+            public Connection connection() {
+                return null;
+            }
+
+            @NonNull
+            @Override
+            public Call call() {
+                return null;
+            }
+
+            @Override
+            public int connectTimeoutMillis() {
+                return 0;
+            }
+
+            @NonNull
+            @Override
+            public Interceptor.Chain withConnectTimeout(int i, @NonNull TimeUnit timeUnit) {
+                return this;
+            }
+
+            @Override
+            public int readTimeoutMillis() {
+                return 0;
+            }
+
+            @NonNull
+            @Override
+            public Interceptor.Chain withReadTimeout(int i, @NonNull TimeUnit timeUnit) {
+                return this;
+            }
+
+            @Override
+            public int writeTimeoutMillis() {
+                return 0;
+            }
+
+            @NonNull
+            @Override
+            public Interceptor.Chain withWriteTimeout(int i, @NonNull TimeUnit timeUnit) {
+                return this;
+            }
+        };
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/SplunkRumBuilderTest.java
@@ -27,6 +27,9 @@ import android.app.Application;
 import io.opentelemetry.api.common.Attributes;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 class SplunkRumBuilderTest {
 
     @Test
@@ -89,5 +92,26 @@ class SplunkRumBuilderTest {
         SplunkRumBuilder builder =
                 SplunkRum.builder().setRealm("us0").setBeaconEndpoint("http://beacon");
         assertEquals("http://beacon", builder.beaconEndpoint);
+    }
+
+    @Test
+    void disableGzipCompression() {
+        SplunkRumBuilder builder =
+                SplunkRum.builder().disableGzipCompression();
+        assertFalse(builder.gzipCompressionEnabled);
+    }
+
+    @Test
+    void setHeadersSupplier() {
+        Map<String, String> headers = new HashMap<String, String>() {{
+            put("Authorization", "Bearer xyz");
+            put("name", "value");
+        } };
+        SplunkRumBuilder builder =
+                SplunkRum.builder().setHeadersSupplier( () -> headers);
+        assertEquals(headers.keySet(), builder.headersSupplier.get().keySet());
+        headers.forEach((key, value) ->
+                assertEquals(value, builder.headersSupplier.get().get(key))
+        );
     }
 }


### PR DESCRIPTION
Description
Added possibility to provide custom headers to requests. It is needed for example to provide auth headers.
Also added possibility to disable gzip compression as it is not always supported by splunk server. 

Changes

- Added two additional configurations in SplunkRumBuilder: setHeadersSupplier() and disableGzipCompression().
- Added request interceptor: CustomHeadersRequestInterceptor, that adds headers from headers supplier to the request.
- Configuring OkHttpSender in RumInitializer based on values in SplunkRumBuilder. If header supplier is provided, then CustomHeadersRequestInterceptor is added. Compression is enabled or disabled based on value of SplunkRumBuilder::gzipCompressionEnabled
