### PR TITLE
Adds a new API that can customize the ingest sender.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Unreleased
 
-* tbd
+* Add new incubating API: `SplunkRumBuilder.setHttpSenderCustomizer()` to allow customization
+  of the HTTP client used for sending data to Splunk. This can be useful when devices are
+  behind a proxy or API gateway.
 
 ## Version 1.3.1 - 2023-12-14
 

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -24,6 +24,7 @@ import com.splunk.rum.StandardAttributes;
 import io.opentelemetry.api.common.Attributes;
 import java.time.Duration;
 import java.util.regex.Pattern;
+import okhttp3.Request;
 
 public class SampleApplication extends Application {
 
@@ -65,6 +66,20 @@ public class SampleApplication extends Application {
                                                         HTTP_URL_SENSITIVE_DATA_PATTERN
                                                                 .matcher(value)
                                                                 .replaceAll("$1=<redacted>")))
+                .setHttpSenderCustomizer(
+                        okHttpBuilder -> {
+                            okHttpBuilder.compressionEnabled(true);
+                            okHttpBuilder
+                                    .clientBuilder()
+                                    .addInterceptor(
+                                            chain -> {
+                                                Request.Builder requestBuilder =
+                                                        chain.request().newBuilder();
+                                                requestBuilder.header(
+                                                        "X-My-Custom-Header", "abc123");
+                                                return chain.proceed(requestBuilder.build());
+                                            });
+                        })
                 .build(this);
     }
 }

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
 
     implementation("io.opentelemetry:opentelemetry-sdk")
     implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
-    implementation("io.zipkin.reporter2:zipkin-sender-okhttp3")
     implementation("io.opentelemetry:opentelemetry-exporter-logging")
 
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
@@ -62,6 +61,7 @@ dependencies {
 
     api("io.opentelemetry:opentelemetry-api")
     api("com.squareup.okhttp3:okhttp:4.12.0")
+    api("io.zipkin.reporter2:zipkin-sender-okhttp3")
 
     testImplementation("org.mockito:mockito-core:5.8.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.8.0")

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
     api("io.opentelemetry:opentelemetry-api")
     api("com.squareup.okhttp3:okhttp:4.12.0")
-    api("io.zipkin.reporter2:zipkin-sender-okhttp3")
+    api("io.zipkin.reporter2:zipkin-sender-okhttp3:2.17.2")
 
     testImplementation("org.mockito:mockito-core:5.8.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.8.0")

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -397,15 +397,13 @@ class RumInitializer {
         // return a lazy init exporter so the main thread doesn't block on the setup.
         return new LazyInitSpanExporter(
                 () -> {
-                    ZipkinSpanExporter exp =
-                            ZipkinSpanExporter.builder()
-                                    .setEncoder(new CustomZipkinEncoder())
-                                    .setEndpoint(endpoint)
-                                    // remove the local IP address
-                                    .setLocalIpAddressSupplier(() -> null)
-                                    .setSender(buildCustomizedZipkinSender())
-                                    .build();
-                    return exp;
+                    return ZipkinSpanExporter.builder()
+                            .setEncoder(new CustomZipkinEncoder())
+                            .setEndpoint(endpoint)
+                            // remove the local IP address
+                            .setLocalIpAddressSupplier(() -> null)
+                            .setSender(buildCustomizedZipkinSender())
+                            .build();
                 });
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -342,7 +342,8 @@ class RumInitializer {
 
     private SpanExporter buildStorageBufferingExporter(
             CurrentNetworkProvider currentNetworkProvider, SpanStorage spanStorage) {
-        Sender sender = OkHttpSender.newBuilder().endpoint(getEndpoint()).build();
+        Sender sender = buildCustomizedZipkinSender();
+
         BandwidthTracker bandwidthTracker = new BandwidthTracker();
 
         FileSender fileSender =
@@ -357,6 +358,13 @@ class RumInitializer {
         diskToZipkinExporter.startPolling();
 
         return getToDiskExporter(spanStorage);
+    }
+
+    @NonNull
+    private Sender buildCustomizedZipkinSender() {
+        OkHttpSender.Builder okBuilder = OkHttpSender.newBuilder().endpoint(getEndpoint());
+        builder.httpSenderCustomizer.customize(okBuilder);
+        return okBuilder.build();
     }
 
     @NonNull
@@ -388,13 +396,17 @@ class RumInitializer {
     SpanExporter getCoreSpanExporter(String endpoint) {
         // return a lazy init exporter so the main thread doesn't block on the setup.
         return new LazyInitSpanExporter(
-                () ->
-                        ZipkinSpanExporter.builder()
-                                .setEncoder(new CustomZipkinEncoder())
-                                .setEndpoint(endpoint)
-                                // remove the local IP address
-                                .setLocalIpAddressSupplier(() -> null)
-                                .build());
+                () -> {
+                    ZipkinSpanExporter exp =
+                            ZipkinSpanExporter.builder()
+                                    .setEncoder(new CustomZipkinEncoder())
+                                    .setEndpoint(endpoint)
+                                    // remove the local IP address
+                                    .setLocalIpAddressSupplier(() -> null)
+                                    .setSender(buildCustomizedZipkinSender())
+                                    .build();
+                    return exp;
+                });
     }
 
     private static class LazyInitSpanExporter implements SpanExporter {

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -21,6 +21,7 @@ import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB
 import android.app.Application;
 import android.util.Log;
 import androidx.annotation.Nullable;
+import com.splunk.rum.incubating.HttpSenderCustomizer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.time.Duration;
@@ -42,6 +43,7 @@ public final class SplunkRumBuilder {
     Duration slowRenderingDetectionPollInterval = DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
     Attributes globalAttributes = Attributes.empty();
     @Nullable String deploymentEnvironment;
+    HttpSenderCustomizer httpSenderCustomizer = HttpSenderCustomizer.DEFAULT;
     private Consumer<SpanFilterBuilder> spanFilterConfigurer = x -> {};
     int maxUsageMegabytes = DEFAULT_MAX_STORAGE_USE_MB;
     boolean sessionBasedSamplerEnabled = false;
@@ -75,6 +77,23 @@ public final class SplunkRumBuilder {
             realm = null;
         }
         this.beaconEndpoint = beaconEndpoint;
+        return this;
+    }
+
+    /**
+     * This method can be used to provide a customizer that will have access to the
+     * OkHttpSender.Builder before the sender is created. Typical use cases for this are to provide
+     * custom headers or to modify compression settings. This is a pretty large hammer and should be
+     * used with caution.
+     *
+     * <p>This API is considered incubating and is subject to change.
+     *
+     * @param customizer that can make changes to the OkHttpSender.Builder
+     * @return {@code this}
+     * @since 1.4.0
+     */
+    public SplunkRumBuilder setHttpSenderCustomizer(HttpSenderCustomizer customizer) {
+        this.httpSenderCustomizer = customizer;
         return this;
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/incubating/HttpSenderCustomizer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/incubating/HttpSenderCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.incubating;
+
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+/**
+ * This interface can be used to customize the exporter used to send telemetry to Splunk. It is not
+ * yet stable and its APIs are subject to change at any time.
+ *
+ * @since 1.4.0
+ */
+public interface HttpSenderCustomizer {
+
+    HttpSenderCustomizer DEFAULT = x -> {};
+
+    void customize(OkHttpSender.Builder builder);
+}


### PR DESCRIPTION
This allows users to get access to the guts of the Zipkin `OkHttpSender.Builder` in order to do things like add custom headers and control compression settings, etc. The sender used in both paths (with or without disk buffering) can be impacted by this customizer.

It also includes a sample usage in the sample app.

This would ideally supersede #739. Thanks to @magdamagda for the original ideas and inspiration here.