### PR TITLE
Add android maintainers to CODEOWNERS lines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@ CODEOWNERS @signalfx/gdi-java-maintainers
 #
 #####################################################
 
-*.md    @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
-*.rst   @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
-docs/   @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
-README* @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers
+*.md    @signalfx/gdi-android-maintainers @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
+*.rst   @signalfx/gdi-android-maintainers @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
+docs/   @signalfx/gdi-android-maintainers @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs
+README* @signalfx/gdi-android-maintainers @signalfx/gdi-java-maintainers @signalfx/gdi-java-approvers @signalfx/gdi-docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers


### PR DESCRIPTION
There are PRs like #742 that are getting blocked even after getting approvals by reviewers in the @signalfx/gdi-android-maintainers group. It looks like the branch protection will use the most specific match in CODEOWNERS, rather than using the more general one. Makes sense, but our configuration has been wrong.