### PR TITLE
Fix resource blending

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -260,7 +260,7 @@ class RumInitializer {
         // applicationName can't be null at this stage
         String applicationName = requireNonNull(builder.applicationName);
         ResourceBuilder resourceBuilder =
-                Resource.getDefault().toBuilder().put(APP_NAME_KEY, applicationName);
+                Resource.builder().put(APP_NAME_KEY, applicationName);
         if (builder.deploymentEnvironment != null) {
             resourceBuilder.put(DEPLOYMENT_ENVIRONMENT, builder.deploymentEnvironment);
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -259,8 +259,7 @@ class RumInitializer {
     private Resource createSplunkResource() {
         // applicationName can't be null at this stage
         String applicationName = requireNonNull(builder.applicationName);
-        ResourceBuilder resourceBuilder =
-                Resource.builder().put(APP_NAME_KEY, applicationName);
+        ResourceBuilder resourceBuilder = Resource.builder().put(APP_NAME_KEY, applicationName);
         if (builder.deploymentEnvironment != null) {
             resourceBuilder.put(DEPLOYMENT_ENVIRONMENT, builder.deploymentEnvironment);
         }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -61,7 +61,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 @ExtendWith(MockitoExtension.class)
 class RumInitializerTest {
 
-    final static String APP_NAME = "Sick test app";
+    static final String APP_NAME = "Sick test app";
 
     @Mock Looper mainLooper;
     @Mock Application application;
@@ -121,8 +121,7 @@ class RumInitializerTest {
     }
 
     private void verifyResource(SpanData span) {
-        assertThat(span.getResource().getAttribute(stringKey("service.name")))
-                .isEqualTo(APP_NAME);
+        assertThat(span.getResource().getAttribute(stringKey("service.name"))).isEqualTo(APP_NAME);
     }
 
     private void checkEventExists(List<EventData> events, String eventName) {

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.os.Looper;
 import com.splunk.rum.incubating.HttpSenderCustomizer;
 import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
@@ -60,6 +61,8 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 @ExtendWith(MockitoExtension.class)
 class RumInitializerTest {
 
+    final static String APP_NAME = "Sick test app";
+
     @Mock Looper mainLooper;
     @Mock Application application;
     @Mock Context context;
@@ -72,7 +75,12 @@ class RumInitializerTest {
                         .setApplicationName("testApp")
                         .setRumAccessToken("accessToken");
 
+        ApplicationInfo appInfo = new ApplicationInfo();
+        appInfo.labelRes = 14;
+
         when(application.getApplicationContext()).thenReturn(context);
+        when(context.getApplicationInfo()).thenReturn(appInfo);
+        when(context.getString(appInfo.labelRes)).thenReturn(APP_NAME);
 
         InMemorySpanExporter testExporter = InMemorySpanExporter.create();
         AppStartupTimer startupTimer = new AppStartupTimer();
@@ -95,6 +103,7 @@ class RumInitializerTest {
         assertEquals(
                 initSpan.getParentSpanContext(), startupTimer.getStartupSpan().getSpanContext());
 
+        verifyResource(initSpan);
         assertEquals("SplunkRum.initialize", initSpan.getName());
         assertEquals("appstart", initSpan.getAttributes().get(COMPONENT_KEY));
         assertEquals(
@@ -109,6 +118,11 @@ class RumInitializerTest {
         checkEventExists(events, "activityLifecycleCallbacksInitialized");
         checkEventExists(events, "crashReportingInitialized");
         checkEventExists(events, "anrMonitorInitialized");
+    }
+
+    private void verifyResource(SpanData span) {
+        assertThat(span.getResource().getAttribute(stringKey("service.name")))
+                .isEqualTo(APP_NAME);
     }
 
     private void checkEventExists(List<EventData> events, String eventName) {


### PR DESCRIPTION
Somewhere in the past when the `AndroidResource` moved to upstream, we continue to source the _default_ resource here to build the Splunk-specific version. This breaks some of the work done in the upstream `AndroidResource` and was effectively overwriting the service name with unknown.

So this fixes that and adds test coverage.