### PR TITLE
Update zipkin and sdk and instrumentation versions.

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -52,7 +52,7 @@ android {
     }
 }
 
-val otelVersion = "1.33.0-SNAPSHOT"
+val otelVersion = "1.32.1"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 val otelSemconvVersion = "1.23.1-alpha"
 

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
 
-//    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"))
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
 

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -44,7 +44,8 @@ android {
     }
 }
 
-val otelVersion = "1.32.0-SNAPSHOT"
+val otelVersion = "1.32.1"
+val otelSdkVersion = "1.35.0"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 val otelSemconvVersion = "1.23.1-alpha"
 
@@ -57,11 +58,15 @@ dependencies {
     implementation(project(":splunk-otel-android"))
 
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.35.0"))
+
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
 
-    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"))
+//    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"))
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
+
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
 
     testImplementation("junit:junit:4.13.2")

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation(project(":splunk-otel-android"))
 
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-    api(platform("io.opentelemetry:opentelemetry-bom:1.35.0"))
+    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
 
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesGetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyHttpClientAttributesGetter.java
@@ -23,7 +23,7 @@ import com.android.volley.AuthFailureError;
 import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HttpResponse;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
@@ -22,10 +22,10 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
@@ -259,15 +259,17 @@ public class TracingHurlStackTest {
         assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
         Attributes spanAttributes = span.getAttributes();
-        assertThat(spanAttributes.get(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE))
-                .isEqualTo(status);
-        assertThat(spanAttributes.get(SemanticAttributes.SERVER_PORT)).isEqualTo(url.getPort());
-        assertThat(spanAttributes.get(SemanticAttributes.SERVER_ADDRESS)).isEqualTo(url.getHost());
-        assertThat(spanAttributes.get(SemanticAttributes.URL_FULL)).isEqualTo(url.toString());
-        assertThat(spanAttributes.get(SemanticAttributes.HTTP_REQUEST_METHOD)).isEqualTo("GET");
+
+        // We continue using deprecated semconv for now. When 2.0.0 hits we will need to update
+        // these.
+        assertThat(spanAttributes.get(SemanticAttributes.HTTP_STATUS_CODE)).isEqualTo(status);
+        assertThat(spanAttributes.get(SemanticAttributes.NET_PEER_PORT)).isEqualTo(url.getPort());
+        assertThat(spanAttributes.get(SemanticAttributes.NET_PEER_NAME)).isEqualTo(url.getHost());
+        assertThat(spanAttributes.get(SemanticAttributes.HTTP_URL)).isEqualTo(url.toString());
+        assertThat(spanAttributes.get(SemanticAttributes.HTTP_METHOD)).isEqualTo("GET");
 
         if (responseBody != null) {
-            assertThat(span.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_BODY_SIZE))
+            assertThat(span.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH))
                     .isEqualTo(responseBody.length());
         }
     }

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
 
     api("io.opentelemetry:opentelemetry-api")
     api("com.squareup.okhttp3:okhttp:4.12.0")
-//    api("io.zipkin.reporter2:zipkin-sender-okhttp3:2.17.2")
     api("io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0")
 
     testImplementation("org.mockito:mockito-core:5.10.0")

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -39,12 +39,15 @@ android {
     }
 }
 
-val otelVersion = "1.33.0-SNAPSHOT"
+val otelVersion = "1.32.1"
+val otelSdkVersion = "1.35.0"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 val otelSemconvVersion = "1.23.1-alpha"
 
 dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.35.0"))
+
     implementation("io.opentelemetry.android:instrumentation:0.3.0-alpha")
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.22"))
@@ -61,7 +64,8 @@ dependencies {
 
     api("io.opentelemetry:opentelemetry-api")
     api("com.squareup.okhttp3:okhttp:4.12.0")
-    api("io.zipkin.reporter2:zipkin-sender-okhttp3:2.17.2")
+//    api("io.zipkin.reporter2:zipkin-sender-okhttp3:2.17.2")
+    api("io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0")
 
     testImplementation("org.mockito:mockito-core:5.10.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.10.0")

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -46,7 +46,7 @@ val otelSemconvVersion = "1.23.1-alpha"
 
 dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-    api(platform("io.opentelemetry:opentelemetry-bom:1.35.0"))
+    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
 
     implementation("io.opentelemetry.android:instrumentation:0.3.0-alpha")
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/CustomZipkinEncoder.java
@@ -17,13 +17,12 @@
 package com.splunk.rum;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import zipkin2.Span;
-import zipkin2.codec.BytesEncoder;
-import zipkin2.codec.Encoding;
 import zipkin2.internal.JsonCodec;
 import zipkin2.internal.V2SpanWriter;
 import zipkin2.internal.WriteBuffer;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
 
 /**
  * We need a custom encoder to correct for the fact that the zipkin Span.Builder lowercases all Span
@@ -59,11 +58,5 @@ class CustomZipkinEncoder implements BytesEncoder<Span> {
                                 "\"name\":\"" + span.name() + "\"",
                                 "\"name\":\"" + properSpanName + "\"");
         return renamedResult.getBytes(StandardCharsets.UTF_8);
-    }
-
-    @Override
-    public byte[] encodeList(List<Span> spans) {
-        // note: this doesn't appear to be called in our current code paths, so let's leave it be.
-        return JsonCodec.writeList(this.writer, spans);
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/FileSender.java
@@ -29,14 +29,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import zipkin2.Call;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 
 class FileSender {
 
     private static final int DEFAULT_MAX_RETRIES = 20;
 
-    private final Sender sender;
+    private final BytesMessageSender sender;
     private final FileUtils fileUtils;
     private final BandwidthTracker bandwidthTracker;
     private final RetryTracker retryTracker;
@@ -78,8 +77,7 @@ class FileSender {
     private boolean attemptSend(File file, List<byte[]> encodedSpans) {
         try {
             bandwidthTracker.tick(encodedSpans);
-            Call<Void> httpCall = sender.sendSpans(encodedSpans);
-            httpCall.execute();
+            sender.send(encodedSpans);
             Log.d(LOG_TAG, "File content " + file + " successfully uploaded");
             return true;
         } catch (IOException e) {
@@ -154,13 +152,13 @@ class FileSender {
 
     static class Builder {
 
-        @Nullable private Sender sender;
+        @Nullable private BytesMessageSender sender;
         private FileUtils fileUtils = new FileUtils();
         @Nullable private BandwidthTracker bandwidthTracker;
         private int maxRetries = DEFAULT_MAX_RETRIES;
         private Consumer<Integer> backoff = new DefaultBackoff();
 
-        Builder sender(Sender sender) {
+        Builder sender(BytesMessageSender sender) {
             this.sender = sender;
             return this;
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ZipkinWriteToDiskExporterFactory.java
@@ -17,7 +17,7 @@
 package com.splunk.rum;
 
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 
 /**
  * Creates a ZipkinSpanExporter that is configured with an instance of a ZipkinToDiskSender that
@@ -35,7 +35,7 @@ class ZipkinWriteToDiskExporterFactory {
                         .fileProvider(spanStorage)
                         .maxStorageUseMb(maxUsageMegabytes)
                         .build();
-        Sender sender =
+        BytesMessageSender sender =
                 ZipkinToDiskSender.builder()
                         .spanFileProvider(spanStorage)
                         .fileUtils(fileUtils)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ZipkinToDiskSenderTest.java
@@ -72,20 +72,20 @@ class ZipkinToDiskSenderTest {
                         .clock(clock)
                         .storageLimiter(limiter)
                         .build();
-        sender.sendSpans(spans);
+        sender.send(spans);
 
         verify(fileUtils).writeAsLines(finalPath, spans);
     }
 
     @Test
-    void testEmptyListDoesNotWriteFile() {
+    void testEmptyListDoesNotWriteFile() throws Exception {
         ZipkinToDiskSender sender =
                 ZipkinToDiskSender.builder()
                         .spanFileProvider(spanStorage)
                         .fileUtils(fileUtils)
                         .storageLimiter(limiter)
                         .build();
-        sender.sendSpans(emptyList());
+        sender.send(emptyList());
         verifyNoInteractions(fileUtils);
     }
 
@@ -102,12 +102,12 @@ class ZipkinToDiskSenderTest {
                         .storageLimiter(limiter)
                         .build();
 
-        sender.sendSpans(spans);
+        sender.send(spans);
         // Exception not thrown
     }
 
     @Test
-    void testLimitExceeded() {
+    void testLimitExceeded() throws Exception {
         Mockito.reset(clock);
         when(limiter.ensureFreeSpace()).thenReturn(false);
 
@@ -119,7 +119,7 @@ class ZipkinToDiskSenderTest {
                         .storageLimiter(limiter)
                         .build();
 
-        sender.sendSpans(spans);
+        sender.send(spans);
 
         verifyNoMoreInteractions(clock);
         verifyNoMoreInteractions(fileUtils);


### PR DESCRIPTION
Zipkin has some deprecations that needed addressing, and we had previously (and accidentally) consumed a few newer semantic conventions in a test, because of the `1.33.0-SNAPSHOT` dependency. We never expect upstream to go above 1.32.x unless something major is discovered (unlikely), so that snapshot build was a farce.

