### PR TITLE
Allow upstream to be api dependency.

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -59,7 +59,6 @@ val otelSemconvVersion = "1.23.1-alpha"
 dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
 
-    implementation("io.opentelemetry.android:instrumentation:0.3.0-alpha")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
     api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
 
-    implementation("io.opentelemetry.android:instrumentation:0.3.0-alpha")
+    api("io.opentelemetry.android:instrumentation:0.3.0-alpha")
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.22"))
     implementation("androidx.appcompat:appcompat:1.6.1")


### PR DESCRIPTION
Having our dependency at `implementation` is a mistake. We depend on and expose various implementation classes from upstream for now. Changing this to API allows users to only take a dependency on us via `implementation` in order to get upstream automatically.