### PR TITLE
Predeclare spotless deps to work around gradle problem

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-extensions.configure<SpotlessExtension>("spotless") {
+spotless {
     java {
         googleJavaFormat().aosp()
         licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public)")
@@ -35,5 +35,24 @@ extensions.configure<SpotlessExtension>("spotless") {
         indentWithSpaces()
         trimTrailingWhitespace()
         endWithNewline()
+    }
+}
+
+// Use root declared tool deps to avoid issues with high concurrency.
+// see https://github.com/diffplug/spotless/tree/main/plugin-gradle#dependency-resolution-modes
+if (project == rootProject) {
+    spotless {
+        predeclareDeps()
+    }
+    with(extensions["spotlessPredeclare"] as SpotlessExtension) {
+        java {
+            googleJavaFormat()
+        }
+        kotlin {
+            ktlint()
+        }
+        kotlinGradle {
+            ktlint()
+        }
     }
 }


### PR DESCRIPTION
Borrowed pretty heavily from upstream.  We were seeing a lot of these warnings in the build output:

```
Configuration 'spotless996156776' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless865459188' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless996156776' was resolved during configuration time.
This is a build performance and scalability issue.
Se
e https://github.com/gradle/gradle/issues/2298
[...]
```