### PR TITLE
split volley attribute extractor into 3 pieces.

### DIFF
--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyComponentKeySetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyComponentKeySetter.java
@@ -23,10 +23,9 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 
-
 /**
- * This class is just responsible for setting the COMPONENT_KEY attribute to "http"
- * on Volley client spans.
+ * This class is just responsible for setting the COMPONENT_KEY attribute to "http" on Volley client
+ * spans.
  */
 class VolleyComponentKeySetter implements AttributesExtractor<RequestWrapper, HttpResponse> {
     @Override

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyComponentKeySetter.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyComponentKeySetter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
+
+import com.android.volley.toolbox.HttpResponse;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+
+
+/**
+ * This class is just responsible for setting the COMPONENT_KEY attribute to "http"
+ * on Volley client spans.
+ */
+class VolleyComponentKeySetter implements AttributesExtractor<RequestWrapper, HttpResponse> {
+    @Override
+    public void onStart(
+            AttributesBuilder attributes, Context parentContext, RequestWrapper requestWrapper) {
+        attributes.put(COMPONENT_KEY, "http");
+    }
+
+    @Override
+    public void onEnd(
+            AttributesBuilder attributes,
+            Context context,
+            RequestWrapper requestWrapper,
+            HttpResponse httpResponse,
+            Throwable error) {}
+}

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyContentLengthAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyContentLengthAttributesExtractor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static com.splunk.rum.VolleyResponseUtils.getHeader;
+
+import androidx.annotation.Nullable;
+import com.android.volley.toolbox.HttpResponse;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.semconv.SemanticAttributes;
+
+/**
+ * This class is responsible for extracting the Content-Length header and assigning
+ * the value to an attribute.
+ */
+class VolleyContentLengthAttributesExtractor
+        implements AttributesExtractor<RequestWrapper, HttpResponse> {
+
+    @Override
+    public void onStart(
+            AttributesBuilder attributes, Context parentContext, RequestWrapper requestWrapper) {}
+
+    @Override
+    public void onEnd(
+            AttributesBuilder attributes,
+            Context context,
+            RequestWrapper requestWrapper,
+            @Nullable HttpResponse response,
+            @Nullable Throwable error) {
+        if (response != null) {
+            onResponse(attributes, response);
+        }
+    }
+
+    private void onResponse(AttributesBuilder attributes, HttpResponse response) {
+        String contentLength = getHeader(response, "Content-Length");
+        if (contentLength != null) {
+            attributes.put(
+                    SemanticAttributes.HTTP_RESPONSE_BODY_SIZE, Long.parseLong(contentLength));
+        }
+    }
+}

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyContentLengthAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyContentLengthAttributesExtractor.java
@@ -26,8 +26,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.SemanticAttributes;
 
 /**
- * This class is responsible for extracting the Content-Length header and assigning
- * the value to an attribute.
+ * This class is responsible for extracting the Content-Length header and assigning the value to an
+ * attribute.
  */
 class VolleyContentLengthAttributesExtractor
         implements AttributesExtractor<RequestWrapper, HttpResponse> {

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseUtils.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyResponseUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import androidx.annotation.Nullable;
+import com.android.volley.Header;
+import com.android.volley.toolbox.HttpResponse;
+
+class VolleyResponseUtils {
+    @Nullable
+    static String getHeader(HttpResponse response, String headerName) {
+        for (Header header : response.getHeaders()) {
+            if (header.getName().equals(headerName)) {
+                return header.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyServerTimingAttributesExtractor.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyServerTimingAttributesExtractor.java
@@ -26,14 +26,16 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 
 /**
- * This class is responsible for parsing the Server-Timing header and setting the
- * linked trace id and span id attributes.
+ * This class is responsible for parsing the Server-Timing header and setting the linked trace id
+ * and span id attributes.
  */
-class VolleyServerTimingAttributesExtractor implements AttributesExtractor<RequestWrapper, HttpResponse> {
+class VolleyServerTimingAttributesExtractor
+        implements AttributesExtractor<RequestWrapper, HttpResponse> {
 
     private final ServerTimingHeaderParser serverTimingHeaderParser;
 
-    public VolleyServerTimingAttributesExtractor(ServerTimingHeaderParser serverTimingHeaderParser) {
+    public VolleyServerTimingAttributesExtractor(
+            ServerTimingHeaderParser serverTimingHeaderParser) {
         this.serverTimingHeaderParser = serverTimingHeaderParser;
     }
 
@@ -48,7 +50,7 @@ class VolleyServerTimingAttributesExtractor implements AttributesExtractor<Reque
             RequestWrapper requestWrapper,
             HttpResponse httpResponse,
             Throwable error) {
-        if(httpResponse == null){
+        if (httpResponse == null) {
             return;
         }
         String serverTimingHeader = getHeader(httpResponse, "Server-Timing");

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
@@ -92,9 +92,9 @@ public final class VolleyTracingBuilder {
                                 openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
                         .setSpanStatusExtractor(spanStatusExtractor)
                         .addAttributesExtractor(httpClientAttributesExtractorBuilder.build())
-                        .addAttributesExtractor(
-                                new VolleyResponseAttributesExtractor(
-                                        new ServerTimingHeaderParser()))
+                        .addAttributesExtractor(new VolleyComponentKeySetter())
+                        .addAttributesExtractor(new VolleyContentLengthAttributesExtractor())
+                        .addAttributesExtractor(new VolleyServerTimingAttributesExtractor(new ServerTimingHeaderParser()))
                         .addAttributesExtractors(additionalExtractors)
                         .buildClientInstrumenter(ClientRequestHeaderSetter.INSTANCE);
 

--- a/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
+++ b/splunk-otel-android-volley/src/main/java/com/splunk/rum/VolleyTracingBuilder.java
@@ -94,7 +94,9 @@ public final class VolleyTracingBuilder {
                         .addAttributesExtractor(httpClientAttributesExtractorBuilder.build())
                         .addAttributesExtractor(new VolleyComponentKeySetter())
                         .addAttributesExtractor(new VolleyContentLengthAttributesExtractor())
-                        .addAttributesExtractor(new VolleyServerTimingAttributesExtractor(new ServerTimingHeaderParser()))
+                        .addAttributesExtractor(
+                                new VolleyServerTimingAttributesExtractor(
+                                        new ServerTimingHeaderParser()))
                         .addAttributesExtractors(additionalExtractors)
                         .buildClientInstrumenter(ClientRequestHeaderSetter.INSTANCE);
 

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
@@ -16,11 +16,10 @@
 
 package com.splunk.rum;
 
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
-
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/TracingHurlStackTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
 
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
+
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -269,7 +271,7 @@ public class TracingHurlStackTest {
         assertThat(spanAttributes.get(SemanticAttributes.HTTP_METHOD)).isEqualTo("GET");
 
         if (responseBody != null) {
-            assertThat(span.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH))
+            assertThat(span.getAttributes().get(HTTP_RESPONSE_BODY_SIZE))
                     .isEqualTo(responseBody.length());
         }
     }

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyComponentKeySetterTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyComponentKeySetterTest.java
@@ -1,0 +1,21 @@
+package com.splunk.rum;
+
+import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.Test;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+public class VolleyComponentKeySetterTest {
+
+    @Test
+    public void component(){
+        VolleyComponentKeySetter testClass = new VolleyComponentKeySetter();
+        AttributesBuilder attributes = Attributes.builder();
+        testClass.onStart(attributes, null, null);
+        assertThat(attributes.build().get(COMPONENT_KEY)).isEqualTo("http");
+    }
+
+}

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyComponentKeySetterTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyComponentKeySetterTest.java
@@ -1,21 +1,35 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum;
 
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import org.junit.Test;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import org.junit.Test;
 
 public class VolleyComponentKeySetterTest {
 
     @Test
-    public void component(){
+    public void component() {
         VolleyComponentKeySetter testClass = new VolleyComponentKeySetter();
         AttributesBuilder attributes = Attributes.builder();
         testClass.onStart(attributes, null, null);
         assertThat(attributes.build().get(COMPONENT_KEY)).isEqualTo("http");
     }
-
 }

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
@@ -16,21 +16,18 @@
 
 package com.splunk.rum;
 
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
 
 import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HttpResponse;
-
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
 
 public class VolleyContentLengthAttributesExtractorTest {
 
@@ -43,7 +40,8 @@ public class VolleyContentLengthAttributesExtractorTest {
                 new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, responseHeaders, "zzz".getBytes());
 
-        VolleyContentLengthAttributesExtractor attributesExtractor = new VolleyContentLengthAttributesExtractor();
+        VolleyContentLengthAttributesExtractor attributesExtractor =
+                new VolleyContentLengthAttributesExtractor();
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
@@ -43,8 +43,8 @@ public class VolleyContentLengthAttributesExtractorTest {
         VolleyContentLengthAttributesExtractor attributesExtractor =
                 new VolleyContentLengthAttributesExtractor();
         AttributesBuilder attributesBuilder = Attributes.builder();
-        attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);
+        attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         Attributes attributes = attributesBuilder.build();
 
         assertThat(attributes.get(HTTP_RESPONSE_BODY_SIZE)).isEqualTo(90210L);

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyContentLengthAttributesExtractorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
+
+import com.android.volley.Header;
+import com.android.volley.Request;
+import com.android.volley.toolbox.HttpResponse;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+public class VolleyContentLengthAttributesExtractorTest {
+
+    @Test
+    public void contentLength() {
+
+        List<Header> responseHeaders =
+                Collections.singletonList(new Header("Content-Length", "90210"));
+        RequestWrapper fakeRequest =
+                new RequestWrapper(mock(Request.class), Collections.emptyMap());
+        HttpResponse response = new HttpResponse(200, responseHeaders, "zzz".getBytes());
+
+        VolleyContentLengthAttributesExtractor attributesExtractor = new VolleyContentLengthAttributesExtractor();
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
+        attributesExtractor.onStart(attributesBuilder, null, fakeRequest);
+        Attributes attributes = attributesBuilder.build();
+
+        assertThat(attributes.get(HTTP_RESPONSE_BODY_SIZE)).isEqualTo(90210L);
+    }
+}

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyServerTimingAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyServerTimingAttributesExtractorTest.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum;
 
-import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -9,14 +24,11 @@ import static org.mockito.Mockito.when;
 import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HttpResponse;
-
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
-
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
 
 public class VolleyServerTimingAttributesExtractorTest {
 
@@ -26,8 +38,7 @@ public class VolleyServerTimingAttributesExtractorTest {
     @Test
     public void serverTiming() {
         ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
-        when(headerParser.parse("headerValue"))
-                .thenReturn(new String[]{TRACE_ID, SPAN_ID});
+        when(headerParser.parse("headerValue")).thenReturn(new String[] {TRACE_ID, SPAN_ID});
 
         List<Header> responseHeaders =
                 Collections.singletonList(new Header("Server-Timing", "headerValue"));
@@ -35,7 +46,8 @@ public class VolleyServerTimingAttributesExtractorTest {
                 new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
 
-        VolleyServerTimingAttributesExtractor attributesExtractor = new VolleyServerTimingAttributesExtractor(headerParser);
+        VolleyServerTimingAttributesExtractor attributesExtractor =
+                new VolleyServerTimingAttributesExtractor(headerParser);
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);
         attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
@@ -54,7 +66,8 @@ public class VolleyServerTimingAttributesExtractorTest {
                 new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, Collections.emptyList(), "hello".getBytes());
 
-        VolleyServerTimingAttributesExtractor attributesExtractor = new VolleyServerTimingAttributesExtractor(headerParser);
+        VolleyServerTimingAttributesExtractor attributesExtractor =
+                new VolleyServerTimingAttributesExtractor(headerParser);
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);

--- a/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyServerTimingAttributesExtractorTest.java
+++ b/splunk-otel-android-volley/src/test/java/com/splunk/rum/VolleyServerTimingAttributesExtractorTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.splunk.rum;
 
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
@@ -25,19 +9,25 @@ import static org.mockito.Mockito.when;
 import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HttpResponse;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
-import java.util.Collections;
-import java.util.List;
+
 import org.junit.Test;
 
-public class VolleyResponseAttributesExtractorTest {
+import java.util.Collections;
+import java.util.List;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+public class VolleyServerTimingAttributesExtractorTest {
+
+    static final String TRACE_ID = "9499195c502eb217c448a68bfe0f967c";
+    static final String SPAN_ID = "fe16eca542cd5d86";
 
     @Test
-    public void spanDecoration() {
+    public void serverTiming() {
         ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
         when(headerParser.parse("headerValue"))
-                .thenReturn(new String[] {"9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86"});
+                .thenReturn(new String[]{TRACE_ID, SPAN_ID});
 
         List<Header> responseHeaders =
                 Collections.singletonList(new Header("Server-Timing", "headerValue"));
@@ -45,17 +35,14 @@ public class VolleyResponseAttributesExtractorTest {
                 new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, responseHeaders, "hello".getBytes());
 
-        VolleyResponseAttributesExtractor attributesExtractor =
-                new VolleyResponseAttributesExtractor(headerParser);
+        VolleyServerTimingAttributesExtractor attributesExtractor = new VolleyServerTimingAttributesExtractor(headerParser);
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);
         attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         Attributes attributes = attributesBuilder.build();
 
-        assertEquals("http", attributes.get(COMPONENT_KEY));
-        assertEquals(
-                "9499195c502eb217c448a68bfe0f967c", attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
-        assertEquals("fe16eca542cd5d86", attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
+        assertEquals(TRACE_ID, attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
+        assertEquals(SPAN_ID, attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
     }
 
     @Test
@@ -67,14 +54,12 @@ public class VolleyResponseAttributesExtractorTest {
                 new RequestWrapper(mock(Request.class), Collections.emptyMap());
         HttpResponse response = new HttpResponse(200, Collections.emptyList(), "hello".getBytes());
 
-        VolleyResponseAttributesExtractor attributesExtractor =
-                new VolleyResponseAttributesExtractor(headerParser);
+        VolleyServerTimingAttributesExtractor attributesExtractor = new VolleyServerTimingAttributesExtractor(headerParser);
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onEnd(attributesBuilder, null, fakeRequest, response, null);
         attributesExtractor.onStart(attributesBuilder, null, fakeRequest);
         Attributes attributes = attributesBuilder.build();
 
-        assertEquals("http", attributes.get(COMPONENT_KEY));
         assertNull(attributes.get(SplunkRum.LINK_TRACE_ID_KEY));
         assertNull(attributes.get(SplunkRum.LINK_SPAN_ID_KEY));
     }


### PR DESCRIPTION
Based on (upstreaming the volley instrumentation)[https://github.com/open-telemetry/opentelemetry-android/pull/291] I think it makes sense here to decompose the volley attribute extractor into it's 3 constituent parts:

* component setter (http)
* server-timing parser
* content-length parser

I think this should help us integrate with upstream more smoothly, before all these pieces exist in upstream.