### PR TITLE
Use version catalog in build

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,10 +19,8 @@ repositories {
 }
 
 dependencies {
-    // keep this version in sync with /build.gradle.kts
-    implementation("com.android.tools.build:gradle:8.3.2")
-
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
-    implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
-    implementation("net.ltgt.gradle:gradle-nullaway-plugin:2.0.0")
+    implementation(libs.android.plugin)
+    implementation(libs.spotless.plugin)
+    implementation(libs.errorprone.plugin)
+    implementation(libs.nullaway.plugin)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
     `kotlin-dsl`
+    alias(libs.plugins.spotless)
 
-    // When updating, update below in dependencies too
-    id("com.diffplug.spotless") version "6.25.0"
 }
 
 spotless {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -102,3 +102,13 @@ afterEvaluate {
         }
     }
 }
+
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+dependencies {
+    testImplementation(libs.findLibrary("assertj-core").get())
+    testImplementation(libs.findBundle("mocking").get())
+    testImplementation(libs.findBundle("junit").get())
+    testImplementation(libs.findLibrary("robolectric").get())
+    testImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
+    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,9 @@ opentelemetry-core = "1.36.0"
 opentelemetry-core-alpha = "1.36.0-alpha"
 opentelemetry-alpha = "1.33.1-alpha"
 opentelemetry-android = "0.4.0-alpha"
-opentelemetry-semconv = "1.25.0-alpha"
-opentelemetry-contrib = "1.34.0-alpha"
 mockito = "5.11.0"
 junit = "5.10.2"
-byteBuddy = "1.14.13"
-okhttp = "4.12.0"
 spotless = "6.25.0"
-kotlin = "1.9.23"
 
 [libraries]
 opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-alpha" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 #val otelSemconvVersion = "1.23.1-alpha"
 
 opentelemetry-core = "1.36.0"
-opentelemetry-core-alpha = "1.36.0"
+opentelemetry-core-alpha = "1.36.0-alpha"
 opentelemetry-alpha = "1.33.1-alpha"
 opentelemetry-android = "0.4.0-alpha"
 opentelemetry-semconv = "1.25.0-alpha"
@@ -22,6 +22,7 @@ opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry-core-alpha" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry-core" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry-core" }
+opentelemetry-api-events = { module = "io.opentelemetry:opentelemetry-api-events", version.ref = "opentelemetry-core-alpha" }
 opentelemetry-android = { module = "io.opentelemetry.android:instrumentation", version.ref = "opentelemetry-android" }
 opentelemetry-instrumenter-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api", version.ref = "opentelemetry-alpha" }
 opentelemetry-instrumenter-api-semconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry-alpha" }
@@ -33,8 +34,12 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 
 zipkin-sender-okhttp = "io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0"
 
+androidx-browser = "androidx.browser:browser:1.7.0"
 androidx-core = "androidx.core:core:1.12.0"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
+androidx-navigation-ui = "androidx.navigation:navigation-ui:2.7.7"
+androidx-work = "androidx.work:work-runtime:2.9.0"
+androidx-webkit = "androidx.webkit:webkit:1.10.0"
 
 # Volley
 android-volley = "com.android.volley:volley:1.2.1"
@@ -56,7 +61,8 @@ android-volley = "com.android.volley:volley:1.2.1"
 
 #Test tools
 #opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
-#androidx-test-core = "androidx.test:core:1.5.0"
+androidx-junit = "androidx.test.ext:junit:1.1.5"
+androidx-test-core = "androidx.test:core:1.5.0"
 #androidx-test-runner = "androidx.test:runner:1.5.2"
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,11 +74,11 @@ desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.4"
 #nullaway = "com.uber.nullaway:nullaway:0.10.25"
 #errorprone-core = "com.google.errorprone:error_prone_core:2.26.1"
 #errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-#spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-#errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
-#nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:2.0.0"
 #animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
-#android-plugin = "com.android.tools.build:gradle:8.3.2"
+android-plugin = "com.android.tools.build:gradle:8.3.2"
+errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
+nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:2.0.0"
+spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 #byteBuddy-plugin = { module = "net.bytebuddy:byte-buddy-gradle-plugin", version.ref = "byteBuddy" }
 #kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 
 zipkin-sender-okhttp = "io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0"
 
-androidx-browser = "androidx.browser:browser:1.7.0"
+androidx-browser = "androidx.browser:browser:1.8.0"
 androidx-core = "androidx.core:core:1.12.0"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
 androidx-navigation-ui = "androidx.navigation:navigation-ui:2.7.7"
@@ -38,7 +38,6 @@ androidx-webkit = "androidx.webkit:webkit:1.10.0"
 
 # Volley
 android-volley = "com.android.volley:volley:1.2.1"
-
 
 #Test tools
 androidx-junit = "androidx.test.ext:junit:1.1.5"
@@ -65,4 +64,3 @@ junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-#publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,4 @@
 [versions]
-#val otelVersion = "1.32.1"
-#val otelSdkVersion = "1.35.0"
-#val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-#val otelSemconvVersion = "1.23.1-alpha"
-
 opentelemetry-core = "1.36.0"
 opentelemetry-core-alpha = "1.36.0-alpha"
 opentelemetry-alpha = "1.33.1-alpha"
@@ -44,26 +39,10 @@ androidx-webkit = "androidx.webkit:webkit:1.10.0"
 # Volley
 android-volley = "com.android.volley:volley:1.2.1"
 
-#androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
-#androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
-#findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
-#byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
-#okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-#opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api" }
-#opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator" }
-#opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-alpha" }
-#opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
-#opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api" }
-#opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
-#opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
-#opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
-#opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 
 #Test tools
-#opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
 androidx-junit = "androidx.test.ext:junit:1.1.5"
 androidx-test-core = "androidx.test:core:1.5.0"
-#androidx-test-runner = "androidx.test:runner:1.5.2"
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
@@ -72,26 +51,18 @@ junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", vers
 mockwebserver = "com.google.mockwebserver:mockwebserver:20130706"
 robolectric = "org.robolectric:robolectric:4.12.1"
 assertj-core = "org.assertj:assertj-core:3.25.3"
-#awaitility = "org.awaitility:awaitility:4.2.1"
-#okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.4"
-#nullaway = "com.uber.nullaway:nullaway:0.10.25"
-#errorprone-core = "com.google.errorprone:error_prone_core:2.26.1"
-#errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-#animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
 android-plugin = "com.android.tools.build:gradle:8.3.2"
 errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:2.0.0"
 spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-#byteBuddy-plugin = { module = "net.bytebuddy:byte-buddy-gradle-plugin", version.ref = "byteBuddy" }
-#kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 [bundles]
 mocking = ["mockito-core", "mockito-junit-jupiter"]
 junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 
 [plugins]
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 #publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-#spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,91 @@
+[versions]
+#val otelVersion = "1.32.1"
+#val otelSdkVersion = "1.35.0"
+#val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+#val otelSemconvVersion = "1.23.1-alpha"
+
+opentelemetry-core = "1.36.0"
+opentelemetry-core-alpha = "1.36.0"
+opentelemetry-alpha = "1.33.1-alpha"
+opentelemetry-android = "0.4.0-alpha"
+opentelemetry-semconv = "1.25.0-alpha"
+opentelemetry-contrib = "1.34.0-alpha"
+mockito = "5.11.0"
+junit = "5.10.2"
+byteBuddy = "1.14.13"
+okhttp = "4.12.0"
+spotless = "6.25.0"
+kotlin = "1.9.23"
+
+[libraries]
+opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-alpha" }
+opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry-core-alpha" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry-core" }
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry-core" }
+opentelemetry-android = { module = "io.opentelemetry.android:instrumentation", version.ref = "opentelemetry-android" }
+opentelemetry-instrumenter-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api", version.ref = "opentelemetry-alpha" }
+opentelemetry-instrumenter-api-semconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry-alpha" }
+opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-alpha" }
+opentelemetry-exporter-zipkin = { module = "io.opentelemetry:opentelemetry-exporter-zipkin", version.ref = "opentelemetry-core" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry-core" }
+opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging", version.ref = "opentelemetry-core" }
+opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry-core" }
+
+zipkin-sender-okhttp = "io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0"
+
+androidx-core = "androidx.core:core:1.12.0"
+androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
+
+# Volley
+android-volley = "com.android.volley:volley:1.2.1"
+
+#androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
+#androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
+#findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
+#byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
+#okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+#opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api" }
+#opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator" }
+#opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-alpha" }
+#opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
+#opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api" }
+#opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
+#opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
+#opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
+#opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+
+#Test tools
+#opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
+#androidx-test-core = "androidx.test:core:1.5.0"
+#androidx-test-runner = "androidx.test:runner:1.5.2"
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
+mockwebserver = "com.google.mockwebserver:mockwebserver:20130706"
+robolectric = "org.robolectric:robolectric:4.12.1"
+assertj-core = "org.assertj:assertj-core:3.25.3"
+#awaitility = "org.awaitility:awaitility:4.2.1"
+#okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+
+#Compilation tools
+desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.4"
+#nullaway = "com.uber.nullaway:nullaway:0.10.25"
+#errorprone-core = "com.google.errorprone:error_prone_core:2.26.1"
+#errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
+#spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+#errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
+#nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:2.0.0"
+#animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
+#android-plugin = "com.android.tools.build:gradle:8.3.2"
+#byteBuddy-plugin = { module = "net.bytebuddy:byte-buddy-gradle-plugin", version.ref = "byteBuddy" }
+#kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+[bundles]
+mocking = ["mockito-core", "mockito-junit-jupiter"]
+junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
+
+[plugins]
+#publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
+#spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -52,37 +52,22 @@ android {
     }
 }
 
-val otelVersion = "1.33.1"
-val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelSemconvVersion = "1.23.1-alpha"
-
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
+    api(platform(libs.opentelemetry.instrumentation.bom))
 
-    implementation("androidx.legacy:legacy-support-v4:1.0.0")
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
-    androidTestImplementation("androidx.test:core:1.5.0")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.webkit:webkit:1.10.0")
-    implementation("androidx.browser:browser:1.7.0")
-    implementation("com.google.android.material:material:1.11.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.navigation:navigation-fragment:2.7.7")
-    implementation("androidx.navigation:navigation-ui:2.7.7")
     implementation(project(":splunk-otel-android"))
     implementation(project(":splunk-otel-android-volley"))
-    implementation("com.android.volley:volley:1.2.1")
-    implementation("androidx.work:work-runtime:2.9.0")
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
-    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
 
-    implementation("io.opentelemetry:opentelemetry-api-events")
-    implementation("io.opentelemetry:opentelemetry-sdk-logs")
-    implementation("io.opentelemetry:opentelemetry-sdk")
-    implementation("io.opentelemetry:opentelemetry-exporter-sender-okhttp")
+    coreLibraryDesugaring(libs.desugarJdkLibs)
 
-    implementation("junit:junit:4.13.2")
-    testImplementation("junit:junit:4.13.2")
+    implementation(libs.androidx.webkit)
+    implementation(libs.androidx.browser)
+    implementation(libs.androidx.navigation.fragment)
+    implementation(libs.androidx.navigation.ui)
+    implementation(libs.android.volley)
+    implementation(libs.androidx.work)
+    implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.api.events)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.junit)
 }

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.androidx.work)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.api.events)
+    testImplementation(libs.bundles.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
 }

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -44,39 +44,40 @@ android {
     }
 }
 
-val otelVersion = "1.32.1"
-val otelSdkVersion = "1.35.0"
-val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelSemconvVersion = "1.23.1-alpha"
+//val otelVersion = "1.32.1"
+//val otelSdkVersion = "1.35.0"
+//val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+//val otelSemconvVersion = "1.23.1-alpha"
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.navigation:navigation-fragment:2.7.7")
-    compileOnly("com.android.volley:volley:1.2.1")
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
-
     implementation(project(":splunk-otel-android"))
+    api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.opentelemetry.bom))
+    compileOnly(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.instrumenter.api)
+    implementation(libs.opentelemetry.instrumenter.api.semconv)
+    compileOnly(libs.android.volley)
+    implementation(libs.androidx.core)
 
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
-
-    api("io.opentelemetry:opentelemetry-api")
-    implementation("io.opentelemetry:opentelemetry-sdk")
-
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
-
-    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
-
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.assertj:assertj-core:3.25.3")
-    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-    testImplementation("org.robolectric:robolectric:4.12.1")
-    testImplementation("org.mockito:mockito-core:5.11.0")
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation("com.google.mockwebserver:mockwebserver:20130706")
-    testImplementation("com.android.volley:volley:1.2.1")
-    testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
+//    implementation("androidx.appcompat:appcompat:1.6.1")
+//    implementation("androidx.navigation:navigation-fragment:2.7.7")
+//    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+//
+//
+//    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
+//    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
+//
+//    api("io.opentelemetry:opentelemetry-api")
+//    implementation("io.opentelemetry:opentelemetry-sdk")
+//
+//
+//    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
+//
+//    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+//    testImplementation("androidx.test:core:1.5.0")
+    testImplementation(libs.mockwebserver)
+    testImplementation(libs.android.volley)
+//    testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
 }
 
 tasks.withType<Test>().configureEach {

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -44,11 +44,6 @@ android {
     }
 }
 
-//val otelVersion = "1.32.1"
-//val otelSdkVersion = "1.35.0"
-//val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-//val otelSemconvVersion = "1.23.1-alpha"
-
 dependencies {
     implementation(project(":splunk-otel-android"))
     api(platform(libs.opentelemetry.instrumentation.bom))
@@ -58,26 +53,8 @@ dependencies {
     implementation(libs.opentelemetry.instrumenter.api.semconv)
     compileOnly(libs.android.volley)
     implementation(libs.androidx.core)
-
-//    implementation("androidx.appcompat:appcompat:1.6.1")
-//    implementation("androidx.navigation:navigation-fragment:2.7.7")
-//    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
-//
-//
-//    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-//    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
-//
-//    api("io.opentelemetry:opentelemetry-api")
-//    implementation("io.opentelemetry:opentelemetry-sdk")
-//
-//
-//    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
-//
-//    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-//    testImplementation("androidx.test:core:1.5.0")
     testImplementation(libs.mockwebserver)
     testImplementation(libs.android.volley)
-//    testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
 }
 
 tasks.withType<Test>().configureEach {

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -39,11 +39,6 @@ android {
     }
 }
 
-//val otelVersion = "1.33.1"
-//val otelSdkVersion = "1.36.0"
-//val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-//val otelSemconvVersion = "1.23.1-alpha"
-
 dependencies {
     api(platform(libs.opentelemetry.instrumentation.bom))
     api(platform(libs.opentelemetry.bom))
@@ -54,36 +49,9 @@ dependencies {
     implementation(libs.opentelemetry.exporter.zipkin)
     implementation(libs.opentelemetry.exporter.otlp)
     implementation(libs.opentelemetry.exporter.logging)
-
-//    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-//    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
-//
-//    api("io.opentelemetry.android:instrumentation:0.4.0-alpha")
-//
-//    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.23"))
-//    implementation("androidx.appcompat:appcompat:1.6.1")
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.fragment)
-//
-//
-//    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
-//
-//    api("io.opentelemetry:opentelemetry-api")
-//    api("com.squareup.okhttp3:okhttp:4.12.0")
     api(libs.zipkin.sender.okhttp)
-//
-//    testImplementation("org.mockito:mockito-core:5.11.0")
-//    testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
-//    testImplementation(platform("org.junit:junit-bom:5.10.2"))
-//    testImplementation("org.junit.jupiter:junit-jupiter-api")
-//    testImplementation("org.junit.jupiter:junit-jupiter-engine")
-//    testImplementation("org.junit.vintage:junit-vintage-engine")
-//    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-//    testImplementation("org.robolectric:robolectric:4.12.1")
-//    testImplementation("androidx.test:core:1.5.0")
-//    testImplementation("org.assertj:assertj-core:3.25.3")
-//
-//    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }
 
 tasks.withType<Test> {

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -39,46 +39,51 @@ android {
     }
 }
 
-val otelVersion = "1.33.1"
-val otelSdkVersion = "1.36.0"
-val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelSemconvVersion = "1.23.1-alpha"
+//val otelVersion = "1.33.1"
+//val otelSdkVersion = "1.36.0"
+//val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+//val otelSemconvVersion = "1.23.1-alpha"
 
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
-    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
+    api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.opentelemetry.bom))
+    api(libs.opentelemetry.android)
 
-    api("io.opentelemetry.android:instrumentation:0.4.0-alpha")
+    implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.instrumentation.okhttp)
+    implementation(libs.opentelemetry.exporter.zipkin)
+    implementation(libs.opentelemetry.exporter.otlp)
+    implementation(libs.opentelemetry.exporter.logging)
 
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.23"))
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.core:core:1.12.0")
-    implementation("androidx.navigation:navigation-fragment:2.7.7")
-
-    implementation("io.opentelemetry:opentelemetry-sdk")
-    implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
-    implementation("io.opentelemetry:opentelemetry-exporter-logging")
-
-    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
-    implementation("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0")
-
-    api("io.opentelemetry:opentelemetry-api")
-    api("com.squareup.okhttp3:okhttp:4.12.0")
-    api("io.zipkin.reporter2:zipkin-sender-okhttp3:3.3.0")
-
-    testImplementation("org.mockito:mockito-core:5.11.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
-    testImplementation(platform("org.junit:junit-bom:5.10.2"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.junit.vintage:junit-vintage-engine")
-    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-    testImplementation("org.robolectric:robolectric:4.12.1")
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation("org.assertj:assertj-core:3.25.3")
-
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+//    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion"))
+//    api(platform("io.opentelemetry:opentelemetry-bom:$otelSdkVersion"))
+//
+//    api("io.opentelemetry.android:instrumentation:0.4.0-alpha")
+//
+//    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.23"))
+//    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.navigation.fragment)
+//
+//
+//    implementation("io.opentelemetry.semconv:opentelemetry-semconv:$otelSemconvVersion")
+//
+//    api("io.opentelemetry:opentelemetry-api")
+//    api("com.squareup.okhttp3:okhttp:4.12.0")
+    api(libs.zipkin.sender.okhttp)
+//
+//    testImplementation("org.mockito:mockito-core:5.11.0")
+//    testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
+//    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+//    testImplementation("org.junit.jupiter:junit-jupiter-api")
+//    testImplementation("org.junit.jupiter:junit-jupiter-engine")
+//    testImplementation("org.junit.vintage:junit-vintage-engine")
+//    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+//    testImplementation("org.robolectric:robolectric:4.12.1")
+//    testImplementation("androidx.test:core:1.5.0")
+//    testImplementation("org.assertj:assertj-core:3.25.3")
+//
+//    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
This changes how dependencies are defined and versioned, and switches over to using a [version catalog](https://developer.android.com/build/migrate-to-catalogs). In addition to being a google/android recommended approach, it's also what upstream uses and makes project maintenance more consistent.

Going forward, all dependency versions should be defined in the `.toml` catalog. 