### PR TITLE
OTLP fixes for Resource and SpanEvents.

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -320,7 +320,10 @@ class RumInitializer {
             VisibleScreenTracker visibleScreenTracker) {
         SpanExporter exporter = buildExporter(currentNetworkProvider, visibleScreenTracker);
         SpanExporter splunkTranslatedExporter =
-                new SplunkSpanDataModifier(exporter, builder.isReactNativeSupportEnabled());
+                new SplunkSpanDataModifier(
+                        exporter,
+                        builder.isReactNativeSupportEnabled(),
+                        builder.shouldUseOtlpExporter());
         SpanExporter filteredExporter = builder.decorateWithSpanFilter(splunkTranslatedExporter);
         initializationEvents.emit("zipkin exporter initialized");
         return filteredExporter;


### PR DESCRIPTION
This prevents the SpanDataModifier from flattening Resource and SpanEvents into (zipkin) attributes when experimental OTLP support is enabled.