### PR TITLE
Update to new usage of gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.2
 
-      - uses: gradle/wrapper-validation-action@v3.3.0
+      - uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.2
 
-      - uses: gradle/actions/wrapper-validation@v3
+      - uses: gradle/actions/wrapper-validation@v3.3.0


### PR DESCRIPTION
The release notes call this out:
https://github.com/gradle/wrapper-validation-action/releases/tag/v3.3.0