### PR TITLE
Change scheduler to prevent build issue

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
@@ -190,7 +190,7 @@ public class SecondFragment extends Fragment {
         if (spamTask == null) {
             resetLabel();
             spamTask =
-                    spammer.scheduleAtFixedRate(this::createSpamSpan, 0, 50, TimeUnit.MILLISECONDS);
+                    spammer.scheduleWithFixedDelay(this::createSpamSpan, 0, 50, TimeUnit.MILLISECONDS);
             binding.buttonSpam.setText(R.string.stop_spam);
         } else {
             spamTask.cancel(false);

--- a/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SecondFragment.java
@@ -190,7 +190,8 @@ public class SecondFragment extends Fragment {
         if (spamTask == null) {
             resetLabel();
             spamTask =
-                    spammer.scheduleWithFixedDelay(this::createSpamSpan, 0, 50, TimeUnit.MILLISECONDS);
+                    spammer.scheduleWithFixedDelay(
+                            this::createSpamSpan, 0, 50, TimeUnit.MILLISECONDS);
             binding.buttonSpam.setText(R.string.stop_spam);
         } else {
             spamTask.cancel(false);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/DiskToZipkinExporter.java
@@ -58,7 +58,7 @@ class DiskToZipkinExporter {
     // the returned future is very unlikely to fail
     @SuppressWarnings("FutureReturnValueIgnored")
     void startPolling() {
-        threadPool.scheduleAtFixedRate(this::doExportCycle, 5, 5, TimeUnit.SECONDS);
+        threadPool.scheduleWithFixedDelay(this::doExportCycle, 5, 5, TimeUnit.SECONDS);
     }
 
     // Visible for testing


### PR DESCRIPTION
The upgrade of gradle tools in #824 fails the build due to this:

```
Error: Use of scheduleAtFixedRate is strongly discouraged because it can lead to unexpected behavior when Android processes become cached (tasks may unexpectedly execute hundreds or thousands of times in quick succession when a process changes from cached to uncached); prefer using scheduleWithFixedDelay [DiscouragedApi]
          threadPool.scheduleAtFixedRate(this::doExportCycle, 5, 5, TimeUnit.SECONDS);
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
     Explanation for issues of type "DiscouragedApi":
     Discouraged APIs are allowed and are not deprecated, but they may be unfit
     for common use (e.g. due to slow performance or subtle behavior).
  
  1 errors, 0 warnings
```

The difference between rate and delay should be fine in these uses.