### PR TITLE
Make the build look more like upstream.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,9 @@ build:
   extends: .prepare-android-environment
   script:
     - touch local.properties
-    - ./gradlew build publish -PmavenCentralUsername=$SONATYPE_USERNAME -PmavenCentralPassword=$SONATYPE_PASSWORD
+    - export SONATYPE_USER="$SONATYPE_USERNAME"
+    - export SONATYPE_KEY="$SONATYPE_PASSWORD"
+    - ./gradlew build publish
 
 sast-scan:
   stage: verify
@@ -69,8 +71,11 @@ release:
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/'
   extends: .prepare-android-environment
+  variables:
   script:
     - touch local.properties
     - export ORG_GRADLE_PROJECT_signingKey=$GPG_SECRET_KEY
     - export ORG_GRADLE_PROJECT_signingPassword=$GPG_PASSWORD
-    - ./gradlew -Prelease=true --no-build-cache --no-daemon --rerun-tasks -PmavenCentralUsername=$SONATYPE_USERNAME -PmavenCentralPassword=$SONATYPE_PASSWORD build signMavenPublication publish
+    - export SONATYPE_USER="$SONATYPE_USERNAME"
+    - export SONATYPE_KEY="$SONATYPE_PASSWORD"
+    - ./gradlew -Prelease=true --no-build-cache --no-daemon --rerun-tasks build signMavenPublication publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,19 +14,14 @@ This is the process to use to do a release:
    assumes that the remote is named `origin`, if you named yours differently you might have to push
    the tag manually.
 
-3) Wait for gitlab to run the release job.
+3) Wait for gitlab to run the release job. If all goes well, it will automatically close
+   and release the "staging" repository...which means the build has been published to sonatype
+   and will appear in maven with in a day or two at most (typically a few hours).
 
-4) Log in to `oss.sonatype.org` with a profile that has permissions to see and release the `com.splunk`
-   staging repository.
-
-5) Close the staging repository, and then release it via the oss.sonatype.org UI.
-   Ideally, verify that publishing worked by pulling down the dependency in some sample project
-   and build an application against it. This will double-check that it's a working release.
-
-6) Create a PR to update the version in the `gradle.properties` to the next development
+4) Create a PR to update the version in the `gradle.properties` to the next development
    version. This PR can and probably should also include updating any documentation (CHANGELOG.md,
    README.md, etc) that mentions the previous version. Make sure the badge in the top README.md
    reflects the accurate upstream otel version.
 
-7) Once this PR is merged, create a release in Github that points at the newly created version,
+5) Once this PR is merged, create a release in Github that points at the newly created version,
    and make sure to provide release notes that at least mirror the contents of the CHANGELOG.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,4 +38,3 @@ nexusPublishing.repositories {
         password.set(System.getenv("SONATYPE_KEY"))
     }
 }
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,12 +6,13 @@ buildscript {
     }
     dependencies {
         // keep this version in sync with /buildSrc/build.gradle.kts
-        classpath("com.android.tools.build:gradle:8.4.0")
+        classpath(libs.android.plugin)
     }
 }
 
 plugins {
     id("splunk.spotless-conventions")
+    alias(libs.plugins.publishPlugin)
 }
 
 allprojects {
@@ -30,3 +31,11 @@ allprojects {
 subprojects {
     apply(plugin = "splunk.spotless-conventions")
 }
+
+nexusPublishing.repositories {
+    sonatype {
+        username.set(System.getenv("SONATYPE_USER"))
+        password.set(System.getenv("SONATYPE_KEY"))
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,3 +60,4 @@ junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }


### PR DESCRIPTION
This also simplifies the release process. There was some historical reason (I can't remember exactly) why we were manually logging into sonatype and pushing the close/release cycle....which is tedious toilsome manual work. Since the upstream repos (including android!) have been auto-closing/releasing, it's time to try that here now.

If this goes well, the next step could be to stage the release page with the gh cli (also like upstream)