### PR TITLE
Continue making the build look more like upstream.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,8 +42,6 @@ build:
   extends: .prepare-android-environment
   script:
     - touch local.properties
-    - export SONATYPE_USER="$SONATYPE_USERNAME"
-    - export SONATYPE_KEY="$SONATYPE_PASSWORD"
     - ./gradlew build publish
 
 sast-scan:
@@ -76,6 +74,4 @@ release:
     - touch local.properties
     - export ORG_GRADLE_PROJECT_signingKey=$GPG_SECRET_KEY
     - export ORG_GRADLE_PROJECT_signingPassword=$GPG_PASSWORD
-    - export SONATYPE_USER="$SONATYPE_USERNAME"
-    - export SONATYPE_KEY="$SONATYPE_PASSWORD"
     - ./gradlew -Prelease=true --no-build-cache --no-daemon --rerun-tasks build signMavenPublication publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,9 +19,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-        }
     }
     if (findProperty("release") != "true") {
         version = "$version-SNAPSHOT"
@@ -34,7 +31,7 @@ subprojects {
 
 nexusPublishing.repositories {
     sonatype {
-        username.set(System.getenv("SONATYPE_USER"))
-        password.set(System.getenv("SONATYPE_KEY"))
+        username.set(System.getenv("SONATYPE_USERNAME"))
+        password.set(System.getenv("SONATYPE_PASSWORD"))
     }
 }

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -44,6 +44,13 @@ afterEvaluate {
         }
     }
     publishing {
+        repositories {
+            maven {
+                val releasesRepoUrl = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+                val snapshotsRepoUrl = URI("https://oss.sonatype.org/content/repositories/snapshots/")
+                url = if (project.findProperty("release") == "true") releasesRepoUrl else snapshotsRepoUrl
+            }
+        }
         publications {
             create<MavenPublication>("maven") {
                 from(components.findByName(variantToPublish))

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -44,13 +44,6 @@ afterEvaluate {
         }
     }
     publishing {
-        repositories {
-            maven {
-                val releasesRepoUrl = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-                val snapshotsRepoUrl = URI("https://oss.sonatype.org/content/repositories/snapshots/")
-                url = if (project.findProperty("release") == "true") releasesRepoUrl else snapshotsRepoUrl
-            }
-        }
         publications {
             create<MavenPublication>("maven") {
                 from(components.findByName(variantToPublish))

--- a/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.android-library-conventions.gradle.kts
@@ -44,17 +44,6 @@ afterEvaluate {
         }
     }
     publishing {
-        repositories {
-            maven {
-                val releasesRepoUrl = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-                val snapshotsRepoUrl = URI("https://oss.sonatype.org/content/repositories/snapshots/")
-                url = if (project.findProperty("release") == "true") releasesRepoUrl else snapshotsRepoUrl
-                credentials {
-                    username = findProperty("mavenCentralUsername") as String?
-                    password = findProperty("mavenCentralPassword") as String?
-                }
-            }
-        }
         publications {
             create<MavenPublication>("maven") {
                 from(components.findByName(variantToPublish))


### PR DESCRIPTION
A few things here:

* fix build breakage due to `mavenCentralUsername` being unset and `credentials.username` being unset. We expect to just be able to the environment vars.
* don't change the environment variable names, just use the ones coming in from gitlab.
* don't manually specify the maven url to publish to (snapshot/release) as the plugin accounts for this when the version ends with `-SNAPSHOT`. I was initially concerned about `SNAPSHOT-alpha` but we'll used 'alpha-SNAPSHOT` instead.