### PR TITLE
Add new experimental api to customize the currently visible screen name.

### DIFF
--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -80,6 +80,8 @@ public class SampleApplication extends Application {
                                                 return chain.proceed(requestBuilder.build());
                                             });
                         })
+                .setExperimentalCurrentScreenCustomizer(vs ->
+                        () -> "customized: " + vs.get())
                 .build(this);
     }
 }

--- a/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
+++ b/sample-app/src/main/java/com/splunk/android/sample/SampleApplication.java
@@ -80,8 +80,7 @@ public class SampleApplication extends Application {
                                                 return chain.proceed(requestBuilder.build());
                                             });
                         })
-                .setExperimentalCurrentScreenCustomizer(vs ->
-                        () -> "customized: " + vs.get())
+                .setExperimentalCurrentScreenCustomizer(vs -> () -> "customized: " + vs.get())
                 .build(this);
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -31,7 +31,6 @@ import android.app.Application;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.splunk.rum.incubating.CurrentlyVisibleScreen;
 import com.splunk.rum.incubating.internal.CurrentlyVisibleScreenAttributeSpanProcessor;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -101,7 +100,7 @@ class RumInitializer {
         if (!builder.isNetworkMonitorEnabled()) {
             config.disableNetworkChangeMonitoring();
         }
-        if(builder.hasExperimentalVisibleScreenCustomization()){
+        if (builder.hasExperimentalVisibleScreenCustomization()) {
             config.disableScreenAttributes();
         }
 
@@ -200,7 +199,7 @@ class RumInitializer {
             installCrashReporter(otelRumBuilder);
         }
 
-        if(builder.hasExperimentalVisibleScreenCustomization()){
+        if (builder.hasExperimentalVisibleScreenCustomization()) {
             customizeCurrentlyVisibleScreen(otelRumBuilder, visibleScreenTracker);
         }
 
@@ -218,14 +217,17 @@ class RumInitializer {
         return new SplunkRum(openTelemetryRum, globalAttributeSupplier);
     }
 
-    private void customizeCurrentlyVisibleScreen(OpenTelemetryRumBuilder otelRumBuilder, VisibleScreenTracker visibleScreenTracker) {
-        if(builder.experimentalCurrentScreenCustomizer == null){
+    private void customizeCurrentlyVisibleScreen(
+            OpenTelemetryRumBuilder otelRumBuilder, VisibleScreenTracker visibleScreenTracker) {
+        if (builder.experimentalCurrentScreenCustomizer == null) {
             return;
         }
-        Function<CurrentlyVisibleScreen, CurrentlyVisibleScreen> customizer = builder.experimentalCurrentScreenCustomizer;
+        Function<CurrentlyVisibleScreen, CurrentlyVisibleScreen> customizer =
+                builder.experimentalCurrentScreenCustomizer;
         otelRumBuilder.addTracerProviderCustomizer(
                 (tracerProviderBuilder, app) -> {
-                    CurrentlyVisibleScreen visibleScreen = visibleScreenTracker::getCurrentlyVisibleScreen;
+                    CurrentlyVisibleScreen visibleScreen =
+                            visibleScreenTracker::getCurrentlyVisibleScreen;
                     CurrentlyVisibleScreen customized = customizer.apply(visibleScreen);
                     SpanProcessor screenAttributesAppender =
                             new CurrentlyVisibleScreenAttributeSpanProcessor(customized);

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java
@@ -21,7 +21,6 @@ import static com.splunk.rum.DeviceSpanStorageLimiter.DEFAULT_MAX_STORAGE_USE_MB
 import android.app.Application;
 import android.util.Log;
 import androidx.annotation.Nullable;
-
 import com.splunk.rum.incubating.CurrentlyVisibleScreen;
 import com.splunk.rum.incubating.HttpSenderCustomizer;
 import io.opentelemetry.api.common.Attributes;
@@ -401,18 +400,17 @@ public final class SplunkRumBuilder {
     }
 
     /**
-     * This method can be used to provide a customer that is able of altering the
-     * value of the "current screen". Typically, SplunkRum will track Fragment and
-     * Activity state changes to automatically determine the name of the current "screen".
-     * By passing a customizer Function here, you can override the default behavior
-     * by customizing (at initialization time) the instance of CurrentlyVisibleScreen
-     * that will be used when setting the screen.name attribute on telemetry.
-     * Note that this does not alter the screen.name assigned to spans created by
-     * the ActivityTracer and FragmentTracer. Those will continue to mirror the name
-     * of the Activity or Fragment.
-     * Status: Experimental. API is subject to potential change or removal in the future.
+     * This method can be used to provide a customer that is able of altering the value of the
+     * "current screen". Typically, SplunkRum will track Fragment and Activity state changes to
+     * automatically determine the name of the current "screen". By passing a customizer Function
+     * here, you can override the default behavior by customizing (at initialization time) the
+     * instance of CurrentlyVisibleScreen that will be used when setting the screen.name attribute
+     * on telemetry. Note that this does not alter the screen.name assigned to spans created by the
+     * ActivityTracer and FragmentTracer. Those will continue to mirror the name of the Activity or
+     * Fragment. Status: Experimental. API is subject to potential change or removal in the future.
      */
-    public SplunkRumBuilder setExperimentalCurrentScreenCustomizer(Function<CurrentlyVisibleScreen,CurrentlyVisibleScreen> customizer){
+    public SplunkRumBuilder setExperimentalCurrentScreenCustomizer(
+            Function<CurrentlyVisibleScreen, CurrentlyVisibleScreen> customizer) {
         this.experimentalCurrentScreenCustomizer = customizer;
         return this;
     }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/incubating/CurrentlyVisibleScreen.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/incubating/CurrentlyVisibleScreen.java
@@ -1,0 +1,10 @@
+package com.splunk.rum.incubating;
+
+import java.util.function.Supplier;
+
+/**
+ * Experimental interface, used to return the name of the currently visible screen.
+ */
+public interface CurrentlyVisibleScreen extends Supplier<String> {
+
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/incubating/CurrentlyVisibleScreen.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/incubating/CurrentlyVisibleScreen.java
@@ -1,10 +1,22 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.incubating;
 
 import java.util.function.Supplier;
 
-/**
- * Experimental interface, used to return the name of the currently visible screen.
- */
-public interface CurrentlyVisibleScreen extends Supplier<String> {
-
-}
+/** Experimental interface, used to return the name of the currently visible screen. */
+public interface CurrentlyVisibleScreen extends Supplier<String> {}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/incubating/internal/CurrentlyVisibleScreenAttributeSpanProcessor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/incubating/internal/CurrentlyVisibleScreenAttributeSpanProcessor.java
@@ -1,6 +1,17 @@
 /*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.rum.incubating.internal;
@@ -8,17 +19,16 @@ package com.splunk.rum.incubating.internal;
 import static io.opentelemetry.android.RumConstants.SCREEN_NAME_KEY;
 
 import com.splunk.rum.incubating.CurrentlyVisibleScreen;
-
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
 /**
- * Experimental SpanProcessor that sets the screen.name attribute on all
- * Spans. It obtains the screen name from an instance of CurrentlyVisibleScreen,
- * and exists primarily as a copy of ScreenAttributesSpanProcessor from upstream,
- * without the problems of coupling to the VisibleScreenTracker.
+ * Experimental SpanProcessor that sets the screen.name attribute on all Spans. It obtains the
+ * screen name from an instance of CurrentlyVisibleScreen, and exists primarily as a copy of
+ * ScreenAttributesSpanProcessor from upstream, without the problems of coupling to the
+ * VisibleScreenTracker.
  */
 public final class CurrentlyVisibleScreenAttributeSpanProcessor implements SpanProcessor {
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/incubating/internal/CurrentlyVisibleScreenAttributeSpanProcessor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/incubating/internal/CurrentlyVisibleScreenAttributeSpanProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.rum.incubating.internal;
+
+import static io.opentelemetry.android.RumConstants.SCREEN_NAME_KEY;
+
+import com.splunk.rum.incubating.CurrentlyVisibleScreen;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+/**
+ * Experimental SpanProcessor that sets the screen.name attribute on all
+ * Spans. It obtains the screen name from an instance of CurrentlyVisibleScreen,
+ * and exists primarily as a copy of ScreenAttributesSpanProcessor from upstream,
+ * without the problems of coupling to the VisibleScreenTracker.
+ */
+public final class CurrentlyVisibleScreenAttributeSpanProcessor implements SpanProcessor {
+
+    private final CurrentlyVisibleScreen visibleScreen;
+
+    public CurrentlyVisibleScreenAttributeSpanProcessor(CurrentlyVisibleScreen visibleScreen) {
+        this.visibleScreen = visibleScreen;
+    }
+
+    @Override
+    public void onStart(Context parentContext, ReadWriteSpan span) {
+        String currentScreen = visibleScreen.get();
+        span.setAttribute(SCREEN_NAME_KEY, currentScreen);
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        // nop
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return false;
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -32,7 +32,6 @@ import android.app.Application;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.os.Looper;
-
 import com.splunk.rum.incubating.CurrentlyVisibleScreen;
 import com.splunk.rum.incubating.HttpSenderCustomizer;
 import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
@@ -55,7 +54,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -263,9 +261,10 @@ class RumInitializerTest {
     }
 
     @Test
-    void canCustomizeCurrentScreenName(){
+    void canCustomizeCurrentScreenName() {
         InMemorySpanExporter testExporter = InMemorySpanExporter.create();
-        Function<CurrentlyVisibleScreen, CurrentlyVisibleScreen> customizer = cvs -> () -> "custom:" + cvs.get();
+        Function<CurrentlyVisibleScreen, CurrentlyVisibleScreen> customizer =
+                cvs -> () -> "custom:" + cvs.get();
         SplunkRumBuilder splunkRumBuilder =
                 new SplunkRumBuilder()
                         .setRealm("us0")
@@ -278,7 +277,7 @@ class RumInitializerTest {
         when(application.getMainLooper()).thenReturn(mainLooper);
 
         RumInitializer testInitializer =
-                new RumInitializer(splunkRumBuilder, application, new AppStartupTimer()){
+                new RumInitializer(splunkRumBuilder, application, new AppStartupTimer()) {
                     @Override
                     SpanExporter getCoreSpanExporter() {
                         return testExporter;
@@ -291,7 +290,8 @@ class RumInitializerTest {
         List<SpanData> spans = testExporter.getFinishedSpanItems();
         assertThat(spans.size()).isEqualTo(1);
         assertThat(spans.get(0).getName()).isEqualTo("foo");
-        assertThat(spans.get(0).getAttributes().get(stringKey("screen.name"))).isEqualTo("custom:unknown");
+        assertThat(spans.get(0).getAttributes().get(stringKey("screen.name")))
+                .isEqualTo("custom:unknown");
     }
 
     @Test


### PR DESCRIPTION
This adds a new api to the `SplunkRumBuilder` called `setExperimentalCurrentScreenCustomizer()`. A user can use this to pass a customizer which allows them to take full control over determining the name of the current screen. A new interface called `CurrentlyVisibleScreen` is introduced, to prevent additional use of or coupling to the existing upstream `VisibleScreenTracker`. Additionally, a new `SpanProcessor` called `CurrentlyVisibleScreenAttributeSpanProcessor` is added (to replace `ScreenAttributesAppender`), which does not couple to the `VisibleScreenTracker` but instead uses an instance of `CurrentlyVisibleScreen`.

Specifying the "current screen name" can be done thought delegation to the existing/default `CurrentlyVisibleScreen` instance and/or through screen tracking mechanism a user might wish to build.

This is an alternate approach to #851 that does not subclass `VisibleScreenTracker`. Instead, it uses the more established OpenTelemetry java pattern of allowing the user to pass a customizer. This customizer is given control of determining the name of the "currently visible screen".

This approach is NOT opinionated about specific frameworks (such as Jetpack compose), and there is no built-in tracking of lifecycle for unknown components. The user of this new experimental API is responsible for tracking their own navigation state and determining when a "screen" has changed, and to generate the appropriate events (create, pause, destroy, whatever their framework offers).