### PR TITLE
Group upstream instrumentation version bumps (renovate)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,10 @@
     {
       "matchPackagePrefixes": ["com.diffplug.spotless"],
       "groupName": "spotless packages"
+    },
+    {
+      "matchPackagePrefixes": ["io.opentelemetry.instrumentation"],
+      "groupName": "upstream otel instrumentation"
     }
   ]
 }


### PR DESCRIPTION
See #885 and #886 for examples that were not grouped (alpha and non-alpha had separate PRs).