### PR TITLE
Disable upstream default exporter (for now)

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -32,6 +32,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
+import com.splunk.rum.internal.NoOpSpanExporter;
 import com.splunk.rum.internal.UInt32QuadXorTraceIdRatioSampler;
 import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.OpenTelemetryRumBuilder;
@@ -124,6 +125,9 @@ class RumInitializer {
                     initializationEvents.emit("batchSpanProcessorInitialized");
                     return tracerProviderBuilder.addSpanProcessor(batchSpanProcessor);
                 });
+
+        // Inhibit the upstream exporter because we add our own BatchSpanProcessor
+        otelRumBuilder.addSpanExporterCustomizer(x -> new NoOpSpanExporter());
 
         // Set span limits
         otelRumBuilder.addTracerProviderCustomizer(

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/NoOpSpanExporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/NoOpSpanExporter.java
@@ -1,10 +1,25 @@
-package com.splunk.rum.internal;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.Collection;
+package com.splunk.rum.internal;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collection;
 
 /*
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change

--- a/splunk-otel-android/src/main/java/com/splunk/rum/internal/NoOpSpanExporter.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/internal/NoOpSpanExporter.java
@@ -1,0 +1,28 @@
+package com.splunk.rum.internal;
+
+import java.util.Collection;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/*
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class NoOpSpanExporter implements SpanExporter {
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+    }
+}


### PR DESCRIPTION
Resolves #893

Upstream provides the `LoggingSpanExporter` as the default. For some configurations, this can cause a problem, so we disable it here. Our custom `BatchSpanProcessor` will take care of passing things to our exporter.