### PR TITLE
Added versionCode, applicationID, and customUUID from AndroidManifest.XML (if it exists) to crash and ANR spans

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum;
 
 import android.app.Application;
@@ -7,30 +23,28 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
 
 public class ErrorIdentifierExtractor {
 
     private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_OLLY_CUSTOM_UUID";
-    @Nullable
-    private static ErrorIdentifierExtractor instance = null;
+    @Nullable private static ErrorIdentifierExtractor instance = null;
 
     private final Context context;
     private final PackageManager packageManager;
     private final ApplicationInfo applicationInfo;
 
-    @Nullable
-    private final String applicationId;
-    @Nullable
-    private final String versionCode;
-    @Nullable
-    private final String customUUID;
+    @Nullable private final String applicationId;
+    @Nullable private final String versionCode;
+    @Nullable private final String customUUID;
 
-    private ErrorIdentifierExtractor(Application application) throws PackageManager.NameNotFoundException {
+    private ErrorIdentifierExtractor(Application application)
+            throws PackageManager.NameNotFoundException {
         this.context = application.getApplicationContext();
         this.packageManager = context.getPackageManager();
-        this.applicationInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        this.applicationInfo =
+                packageManager.getApplicationInfo(
+                        context.getPackageName(), PackageManager.GET_META_DATA);
 
         // Initialize values
         this.applicationId = applicationInfo.packageName;
@@ -44,7 +58,9 @@ public class ErrorIdentifierExtractor {
             try {
                 instance = new ErrorIdentifierExtractor(application);
             } catch (PackageManager.NameNotFoundException e) {
-                Log.e(SplunkRum.LOG_TAG, "Failed to initialize ErrorIdentifierExtractor: " + e.getMessage());
+                Log.e(
+                        SplunkRum.LOG_TAG,
+                        "Failed to initialize ErrorIdentifierExtractor: " + e.getMessage());
             }
         }
         return instance;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -1,0 +1,90 @@
+package com.splunk.rum;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+public class ErrorIdentifierExtractor {
+
+    private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_OLLY_CUSTOM_UUID";
+    @Nullable
+    private static ErrorIdentifierExtractor instance = null;
+
+    private final Context context;
+    private final PackageManager packageManager;
+    private final ApplicationInfo applicationInfo;
+
+    @Nullable
+    private final String applicationId;
+    @Nullable
+    private final String versionCode;
+    @Nullable
+    private final String customUUID;
+
+    private ErrorIdentifierExtractor(Application application) throws PackageManager.NameNotFoundException {
+        this.context = application.getApplicationContext();
+        this.packageManager = context.getPackageManager();
+        this.applicationInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+
+        // Initialize values
+        this.applicationId = applicationInfo.packageName;
+        this.versionCode = retrieveVersionCode();
+        this.customUUID = retrieveCustomUUID();
+    }
+
+    @Nullable
+    public static synchronized ErrorIdentifierExtractor getInstance(Application application) {
+        if (instance == null) {
+            try {
+                instance = new ErrorIdentifierExtractor(application);
+            } catch (PackageManager.NameNotFoundException e) {
+                Log.e(SplunkRum.LOG_TAG, "Failed to initialize ErrorIdentifierExtractor: " + e.getMessage());
+            }
+        }
+        return instance;
+    }
+
+    @Nullable
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    @Nullable
+    public String getVersionCode() {
+        return versionCode;
+    }
+
+    @Nullable
+    public String getCustomUUID() {
+        return customUUID;
+    }
+
+    @Nullable
+    private String retrieveVersionCode() {
+        try {
+            PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), 0);
+            return String.valueOf(packageInfo.versionCode);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(SplunkRum.LOG_TAG, "Failed to get application version code", e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private String retrieveCustomUUID() {
+        Bundle bundle = applicationInfo.metaData;
+
+        if (bundle != null) {
+            return bundle.getString(SPLUNK_UUID_MANIFEST_KEY);
+        } else {
+            Log.e(SplunkRum.LOG_TAG, "Application MetaData bundle is null");
+            return null;
+        }
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -69,7 +69,7 @@ public class ErrorIdentifierExtractor {
             PackageInfo packageInfo =
                     packageManager.getPackageInfo(application.getPackageName(), 0);
             return String.valueOf(packageInfo.versionCode);
-        } catch (PackageManager.NameNotFoundException e) {
+        } catch (Exception e) {
             Log.e(SplunkRum.LOG_TAG, "Failed to get application version code", e);
             return null;
         }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -46,7 +46,6 @@ public class ErrorIdentifierExtractor {
                 packageManager.getApplicationInfo(
                         context.getPackageName(), PackageManager.GET_META_DATA);
 
-        // Initialize values
         this.applicationId = applicationInfo.packageName;
         this.versionCode = retrieveVersionCode();
         this.customUUID = retrieveCustomUUID();

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierInfo.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum;
+
+import androidx.annotation.Nullable;
+
+public class ErrorIdentifierInfo {
+    @Nullable private final String applicationId;
+    @Nullable private final String versionCode;
+    @Nullable private final String customUUID;
+
+    public ErrorIdentifierInfo(
+            @Nullable String applicationId,
+            @Nullable String versionCode,
+            @Nullable String customUUID) {
+        this.applicationId = applicationId;
+        this.versionCode = versionCode;
+        this.customUUID = customUUID;
+    }
+
+    @Nullable
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    @Nullable
+    public String getVersionCode() {
+        return versionCode;
+    }
+
+    @Nullable
+    public String getCustomUUID() {
+        return customUUID;
+    }
+}

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -32,7 +32,6 @@ import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -295,7 +294,8 @@ class RumInitializer {
                     String applicationId = null;
                     String versionCode = null;
                     String uuid = null;
-                    ErrorIdentifierExtractor extractor = ErrorIdentifierExtractor.getInstance(application);
+                    ErrorIdentifierExtractor extractor =
+                            ErrorIdentifierExtractor.getInstance(application);
 
                     if (extractor != null) {
                         applicationId = extractor.getApplicationId();
@@ -316,14 +316,11 @@ class RumInitializer {
                         builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
                     }
 
-                    builder.setMainLooper(mainLooper)
-                            .build()
-                            .installOn(instrumentedApplication);
+                    builder.setMainLooper(mainLooper).build().installOn(instrumentedApplication);
 
                     initializationEvents.emit("anrMonitorInitialized");
                 });
     }
-
 
     private void installCrashReporter(OpenTelemetryRumBuilder otelRumBuilder) {
         otelRumBuilder.addInstrumentation(
@@ -331,7 +328,8 @@ class RumInitializer {
                     String applicationId = null;
                     String versionCode = null;
                     String uuid = null;
-                    ErrorIdentifierExtractor extractor = ErrorIdentifierExtractor.getInstance(application);
+                    ErrorIdentifierExtractor extractor =
+                            ErrorIdentifierExtractor.getInstance(application);
 
                     if (extractor != null) {
                         applicationId = extractor.getApplicationId();
@@ -340,9 +338,12 @@ class RumInitializer {
                     }
 
                     CrashReporterBuilder builder = CrashReporter.builder();
-                    builder.addAttributesExtractor(RuntimeDetailsExtractor.create(
-                            instrumentedApplication.getApplication().getApplicationContext())).
-                            addAttributesExtractor(new CrashComponentExtractor());
+                    builder.addAttributesExtractor(
+                                    RuntimeDetailsExtractor.create(
+                                            instrumentedApplication
+                                                    .getApplication()
+                                                    .getApplicationContext()))
+                            .addAttributesExtractor(new CrashComponentExtractor());
 
                     if (applicationId != null && !applicationId.isEmpty()) {
                         builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
@@ -354,8 +355,7 @@ class RumInitializer {
                         builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
                     }
 
-                    builder.build()
-                            .installOn(instrumentedApplication);
+                    builder.build().installOn(instrumentedApplication);
 
                     initializationEvents.emit("crashReportingInitialized");
                 });

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -291,30 +291,21 @@ class RumInitializer {
     private void installAnrDetector(OpenTelemetryRumBuilder otelRumBuilder, Looper mainLooper) {
         otelRumBuilder.addInstrumentation(
                 instrumentedApplication -> {
-                    String applicationId = null;
-                    String versionCode = null;
-                    String uuid = null;
-                    ErrorIdentifierExtractor extractor =
-                            ErrorIdentifierExtractor.getInstance(application);
-
-                    if (extractor != null) {
-                        applicationId = extractor.getApplicationId();
-                        versionCode = extractor.getVersionCode();
-                        uuid = extractor.getCustomUUID();
-                    }
+                    ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(application);
+                    ErrorIdentifierInfo errorIdentifierInfo = extractor.extractInfo();
+                    String applicationId = errorIdentifierInfo.getApplicationId();
+                    String versionCode = errorIdentifierInfo.getVersionCode();
+                    String uuid = errorIdentifierInfo.getCustomUUID();
 
                     AnrDetectorBuilder builder = AnrDetector.builder();
                     builder.addAttributesExtractor(constant(COMPONENT_KEY, COMPONENT_ERROR));
 
-                    if (applicationId != null && !applicationId.isEmpty()) {
+                    if (applicationId != null)
                         builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
-                    }
-                    if (versionCode != null && !versionCode.isEmpty()) {
+                    if (versionCode != null)
                         builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
-                    }
-                    if (uuid != null && !uuid.isEmpty()) {
+                    if (uuid != null)
                         builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
-                    }
 
                     builder.setMainLooper(mainLooper).build().installOn(instrumentedApplication);
 
@@ -325,17 +316,11 @@ class RumInitializer {
     private void installCrashReporter(OpenTelemetryRumBuilder otelRumBuilder) {
         otelRumBuilder.addInstrumentation(
                 instrumentedApplication -> {
-                    String applicationId = null;
-                    String versionCode = null;
-                    String uuid = null;
-                    ErrorIdentifierExtractor extractor =
-                            ErrorIdentifierExtractor.getInstance(application);
-
-                    if (extractor != null) {
-                        applicationId = extractor.getApplicationId();
-                        versionCode = extractor.getVersionCode();
-                        uuid = extractor.getCustomUUID();
-                    }
+                    ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(application);
+                    ErrorIdentifierInfo errorIdentifierInfo = extractor.extractInfo();
+                    String applicationId = errorIdentifierInfo.getApplicationId();
+                    String versionCode = errorIdentifierInfo.getVersionCode();
+                    String uuid = errorIdentifierInfo.getCustomUUID();
 
                     CrashReporterBuilder builder = CrashReporter.builder();
                     builder.addAttributesExtractor(
@@ -345,15 +330,12 @@ class RumInitializer {
                                                     .getApplicationContext()))
                             .addAttributesExtractor(new CrashComponentExtractor());
 
-                    if (applicationId != null && !applicationId.isEmpty()) {
+                    if (applicationId != null)
                         builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
-                    }
-                    if (versionCode != null && !versionCode.isEmpty()) {
+                    if (versionCode != null)
                         builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
-                    }
-                    if (uuid != null && !uuid.isEmpty()) {
+                    if (uuid != null)
                         builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
-                    }
 
                     builder.build().installOn(instrumentedApplication);
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -16,12 +16,15 @@
 
 package com.splunk.rum;
 
+import static com.splunk.rum.SplunkRum.APPLICATION_ID_KEY;
 import static com.splunk.rum.SplunkRum.APP_NAME_KEY;
+import static com.splunk.rum.SplunkRum.APP_VERSION_CODE_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_APPSTART;
 import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
+import static com.splunk.rum.SplunkRum.SPLUNK_OLLY_UUID_KEY;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
@@ -29,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.splunk.rum.internal.GlobalAttributesSupplier;
@@ -40,7 +44,9 @@ import io.opentelemetry.android.RuntimeDetailsExtractor;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.android.instrumentation.anr.AnrDetector;
+import io.opentelemetry.android.instrumentation.anr.AnrDetectorBuilder;
 import io.opentelemetry.android.instrumentation.crash.CrashReporter;
+import io.opentelemetry.android.instrumentation.crash.CrashReporterBuilder;
 import io.opentelemetry.android.instrumentation.lifecycle.AndroidLifecycleInstrumentation;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingDetector;
@@ -286,13 +292,72 @@ class RumInitializer {
     private void installAnrDetector(OpenTelemetryRumBuilder otelRumBuilder, Looper mainLooper) {
         otelRumBuilder.addInstrumentation(
                 instrumentedApplication -> {
-                    AnrDetector.builder()
-                            .addAttributesExtractor(constant(COMPONENT_KEY, COMPONENT_ERROR))
-                            .setMainLooper(mainLooper)
+                    String applicationId = null;
+                    String versionCode = null;
+                    String uuid = null;
+                    ErrorIdentifierExtractor extractor = ErrorIdentifierExtractor.getInstance(application);
+
+                    if (extractor != null) {
+                        applicationId = extractor.getApplicationId();
+                        versionCode = extractor.getVersionCode();
+                        uuid = extractor.getCustomUUID();
+                    }
+
+                    AnrDetectorBuilder builder = AnrDetector.builder();
+                    builder.addAttributesExtractor(constant(COMPONENT_KEY, COMPONENT_ERROR));
+
+                    if (applicationId != null && !applicationId.isEmpty()) {
+                        builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
+                    }
+                    if (versionCode != null && !versionCode.isEmpty()) {
+                        builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
+                    }
+                    if (uuid != null && !uuid.isEmpty()) {
+                        builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
+                    }
+
+                    builder.setMainLooper(mainLooper)
                             .build()
                             .installOn(instrumentedApplication);
 
                     initializationEvents.emit("anrMonitorInitialized");
+                });
+    }
+
+
+    private void installCrashReporter(OpenTelemetryRumBuilder otelRumBuilder) {
+        otelRumBuilder.addInstrumentation(
+                instrumentedApplication -> {
+                    String applicationId = null;
+                    String versionCode = null;
+                    String uuid = null;
+                    ErrorIdentifierExtractor extractor = ErrorIdentifierExtractor.getInstance(application);
+
+                    if (extractor != null) {
+                        applicationId = extractor.getApplicationId();
+                        versionCode = extractor.getVersionCode();
+                        uuid = extractor.getCustomUUID();
+                    }
+
+                    CrashReporterBuilder builder = CrashReporter.builder();
+                    builder.addAttributesExtractor(RuntimeDetailsExtractor.create(
+                            instrumentedApplication.getApplication().getApplicationContext())).
+                            addAttributesExtractor(new CrashComponentExtractor());
+
+                    if (applicationId != null && !applicationId.isEmpty()) {
+                        builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
+                    }
+                    if (versionCode != null && !versionCode.isEmpty()) {
+                        builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
+                    }
+                    if (uuid != null && !uuid.isEmpty()) {
+                        builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
+                    }
+
+                    builder.build()
+                            .installOn(instrumentedApplication);
+
+                    initializationEvents.emit("crashReportingInitialized");
                 });
     }
 
@@ -305,23 +370,6 @@ class RumInitializer {
                             .build()
                             .installOn(instrumentedApplication);
                     initializationEvents.emit("slowRenderingDetectorInitialized");
-                });
-    }
-
-    private void installCrashReporter(OpenTelemetryRumBuilder otelRumBuilder) {
-        otelRumBuilder.addInstrumentation(
-                instrumentedApplication -> {
-                    CrashReporter.builder()
-                            .addAttributesExtractor(
-                                    RuntimeDetailsExtractor.create(
-                                            instrumentedApplication
-                                                    .getApplication()
-                                                    .getApplicationContext()))
-                            .addAttributesExtractor(new CrashComponentExtractor())
-                            .build()
-                            .installOn(instrumentedApplication);
-
-                    initializationEvents.emit("crashReportingInitialized");
                 });
     }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -55,6 +55,7 @@ public class SplunkRum {
     static final AttributeKey<Double> LOCATION_LATITUDE_KEY = doubleKey("location.lat");
     static final AttributeKey<Double> LOCATION_LONGITUDE_KEY = doubleKey("location.long");
 
+
     static final String COMPONENT_APPSTART = "appstart";
     static final String COMPONENT_UI = "ui";
     static final String COMPONENT_CRASH = "crash";
@@ -67,6 +68,9 @@ public class SplunkRum {
 
     static final AttributeKey<String> APP_NAME_KEY = stringKey("app");
     static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rum.version");
+    static final AttributeKey<String> APPLICATION_ID_KEY = stringKey("app.application.id");
+    static final AttributeKey<String> APP_VERSION_CODE_KEY = stringKey("app.version.code");
+    static final AttributeKey<String> SPLUNK_OLLY_UUID_KEY = stringKey("app.splunk.olly.uuid");
 
     @Nullable private static SplunkRum INSTANCE;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -55,7 +55,6 @@ public class SplunkRum {
     static final AttributeKey<Double> LOCATION_LATITUDE_KEY = doubleKey("location.lat");
     static final AttributeKey<Double> LOCATION_LONGITUDE_KEY = doubleKey("location.long");
 
-
     static final String COMPONENT_APPSTART = "appstart";
     static final String COMPONENT_UI = "ui";
     static final String COMPONENT_CRASH = "crash";

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
@@ -1,0 +1,76 @@
+package com.splunk.rum;
+
+import android.app.Application;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ErrorIdentifierExtractorTest {
+    private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_OLLY_CUSTOM_UUID";
+
+    @Mock
+    private Application mockApplication;
+
+    @Mock
+    private PackageManager mockPackageManager;
+
+    @Mock
+    private PackageInfo mockPackageInfo;
+
+    @Mock
+    private ApplicationInfo mockApplicationInfo;
+
+    private ErrorIdentifierExtractor extractor;
+
+    @Mock
+    private Bundle mockMetadata;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        when(mockApplication.getApplicationContext()).thenReturn(mockApplication);
+        when(mockApplication.getPackageManager()).thenReturn(mockPackageManager);
+        when(mockApplication.getPackageName()).thenReturn("com.splunk.test");
+
+        mockApplicationInfo.packageName = "com.splunk.test";
+        mockApplicationInfo.metaData = mockMetadata;
+
+        when(mockPackageManager.getApplicationInfo("com.splunk.test", PackageManager.GET_META_DATA))
+                .thenReturn(mockApplicationInfo);
+        when(mockMetadata.getString(SPLUNK_UUID_MANIFEST_KEY)).thenReturn("test-uuid");
+
+        mockPackageInfo.versionCode = 123;
+        when(mockPackageManager.getPackageInfo("com.splunk.test", 0)).thenReturn(mockPackageInfo);
+
+        extractor = ErrorIdentifierExtractor.getInstance(mockApplication);
+    }
+
+
+    @Test
+    public void testGetApplicationId() {
+        assertEquals("com.splunk.test", extractor.getApplicationId());
+    }
+
+    @Test
+    public void testGetVersionCode() {
+        assertEquals("123", extractor.getVersionCode());
+    }
+
+    @Test
+    public void testGetCustomUUID() {
+        extractor = ErrorIdentifierExtractor.getInstance(mockApplication);
+
+        assert extractor != null;
+        assertEquals("test-uuid", extractor.getCustomUUID());
+    }
+}

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
@@ -1,38 +1,48 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import android.app.Application;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 public class ErrorIdentifierExtractorTest {
     private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_OLLY_CUSTOM_UUID";
 
-    @Mock
-    private Application mockApplication;
+    @Mock private Application mockApplication;
 
-    @Mock
-    private PackageManager mockPackageManager;
+    @Mock private PackageManager mockPackageManager;
 
-    @Mock
-    private PackageInfo mockPackageInfo;
+    @Mock private PackageInfo mockPackageInfo;
 
-    @Mock
-    private ApplicationInfo mockApplicationInfo;
+    @Mock private ApplicationInfo mockApplicationInfo;
 
     private ErrorIdentifierExtractor extractor;
 
-    @Mock
-    private Bundle mockMetadata;
+    @Mock private Bundle mockMetadata;
 
     @Before
     public void setUp() throws Exception {
@@ -54,7 +64,6 @@ public class ErrorIdentifierExtractorTest {
 
         extractor = ErrorIdentifierExtractor.getInstance(mockApplication);
     }
-
 
     @Test
     public void testGetApplicationId() {


### PR DESCRIPTION
Implemented an extractor class, which will fetch the app's applicationID and versionCode, and a custom uuid (if it exists in the app manifest as metadata under key "SPLUNK_OLLY_CUSTOM_UUID").

These will be added as attributes to the ANR and Crash reporters in order to help correlate and identify stacktraces with their correct mapping files. 

Added unit tests and also manually tested with sample app and verified