### PR TITLE
fix: multiple server-tracing headers aren't handled

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumResponseAttributesExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumResponseAttributesExtractor.java
@@ -53,16 +53,18 @@ class RumResponseAttributesExtractor implements AttributesExtractor<Request, Res
     }
 
     private void onResponse(AttributesBuilder attributes, Response response) {
-        response.headers().forEach(header -> {
-            if (!header.getFirst().equalsIgnoreCase(SERVER_TIMING_HEADER)) {
-                return;
-            }
+        response.headers()
+                .forEach(
+                        header -> {
+                            if (!header.getFirst().equalsIgnoreCase(SERVER_TIMING_HEADER)) {
+                                return;
+                            }
 
-            String[] ids = serverTimingHeaderParser.parse(header.getSecond());
-            if (ids.length == 2) {
-                attributes.put(LINK_TRACE_ID_KEY, ids[0]);
-                attributes.put(LINK_SPAN_ID_KEY, ids[1]);
-            }
-        });
+                            String[] ids = serverTimingHeaderParser.parse(header.getSecond());
+                            if (ids.length == 2) {
+                                attributes.put(LINK_TRACE_ID_KEY, ids[0]);
+                                attributes.put(LINK_SPAN_ID_KEY, ids[1]);
+                            }
+                        });
     }
 }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumResponseAttributesExtractorTest.java
@@ -36,10 +36,6 @@ class RumResponseAttributesExtractorTest {
 
     @Test
     void spanDecoration() {
-        ServerTimingHeaderParser headerParser = mock(ServerTimingHeaderParser.class);
-        when(headerParser.parse("headerValue"))
-                .thenReturn(new String[] {"9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86"});
-
         Request fakeRequest = mock(Request.class);
         Response response =
                 new Response.Builder()
@@ -47,11 +43,13 @@ class RumResponseAttributesExtractorTest {
                         .protocol(Protocol.HTTP_1_1)
                         .message("hello")
                         .code(200)
-                        .addHeader("Server-Timing", "headerValue")
+                        .addHeader("Server-Timing", "othervalue 1")
+                        .addHeader("Server-Timing", "traceparent;desc=\"00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-01\"")
+                        .addHeader("Server-Timing", "othervalue 2")
                         .build();
 
         RumResponseAttributesExtractor attributesExtractor =
-                new RumResponseAttributesExtractor(headerParser);
+                new RumResponseAttributesExtractor(new ServerTimingHeaderParser());
         AttributesBuilder attributesBuilder = Attributes.builder();
         attributesExtractor.onStart(attributesBuilder, Context.root(), fakeRequest);
         attributesExtractor.onEnd(attributesBuilder, Context.root(), fakeRequest, response, null);


### PR DESCRIPTION
When multiple `server-tracing` headers are present, handle all of them. Previously only the first instance would be handled.