### PR TITLE
Update renovate 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": [
     "config:base"
   ],
-  "baseBranches": ["main", "v1.7.x"],
+  "baseBranches": ["main"],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,14 @@
   "baseBranches": ["main"],
   "packageRules": [
     {
+      // Don't bump upstream otel versions
+      "matchPackagePatterns": [
+        "^io.opentelemetry",
+        "^io.opentelemetry.instrumentation"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "io.opentelemetry:opentelemetry-api-incubator",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
@@ -17,15 +25,6 @@
       // of that release instead of the unstable version for a future release (but there's never any
       // stable version of opentelemetry-instrumentation-bom-alpha so this logic doesn't apply
       "ignoreUnstable": false
-    },
-    {
-      // Don't bump to 2.x in the 1.x line
-      "matchUpdateTypes": ["major"],
-      "matchPackagePatterns": [
-        "^io.opentelemetry.instrumentation"
-      ],
-      "matchBaseBranches": ["v1.7.x"],
-      "enabled": false
     },
     {
       // navigation-fragment 2.7.0 and above require android api 34+, which we are not ready for


### PR DESCRIPTION
After the 1.8 release yesterday, we need to make sure that renovate is updated again:

* 1.7.x is no longer given renovate updates -- the only development branch is once again the `main` branch.
* Pin upstream `io.opentelemetry` packages. This will need to be updated manually and carefully.