### PR TITLE
Downgrade androidx to allow lower compileSDK

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,15 @@
     {
       "matchPackagePrefixes": ["io.opentelemetry.instrumentation"],
       "groupName": "upstream otel instrumentation"
+    },
+    {
+      // Various androidx libraries released after Aug 7th, 2024 requires android compileSDK 35,
+      // forcing customers to require the same and further to upgrade their AGP and gradle
+      "matchPackageNames": [
+        "androidx.core:core",
+        "androidx.work:work-runtime"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,10 +31,10 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 zipkin-sender-okhttp = "io.zipkin.reporter2:zipkin-sender-okhttp3:3.4.2"
 
 androidx-browser = "androidx.browser:browser:1.8.0"
-androidx-core = "androidx.core:core:1.15.0"
+androidx-core = "androidx.core:core:1.13.1"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
 androidx-navigation-ui = "androidx.navigation:navigation-ui:2.7.7"
-androidx-work = "androidx.work:work-runtime:2.10.0"
+androidx-work = "androidx.work:work-runtime:2.9.1"
 androidx-webkit = "androidx.webkit:webkit:1.12.1"
 
 # Volley

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -13,7 +13,7 @@ localProperties.load(FileInputStream(rootProject.file("local.properties")))
 android {
     namespace = "com.splunk.android.sample"
 
-    compileSdk = 35
+    compileSdk = 34
     buildToolsVersion = "34.0.0"
 
     defaultConfig {

--- a/splunk-otel-android-volley/build.gradle.kts
+++ b/splunk-otel-android-volley/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 android {
     namespace = "com.splunk.android.rum.volley"
 
-    compileSdk = 35
+    compileSdk = 34
     buildToolsVersion = "34.0.0"
 
     defaultConfig {

--- a/splunk-otel-android/build.gradle.kts
+++ b/splunk-otel-android/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android {
     namespace = "com.splunk.android.rum"
 
-    compileSdk = 35
+    compileSdk = 34
     buildToolsVersion = "34.0.0"
 
     defaultConfig {


### PR DESCRIPTION
- Avoid forcing customers to upgrade to compileSDK = 35 and as a result to force them to upgrade AGP / Gradle. 
- Added renovate rule to ignore upgradation of known culprit dependencies. 

**Note** - We do not need to downgrade compileSDK version but I've downgraded it so next when renovate bumps the version of any of our androidx dependencies, build fails and we can add that dependency to renovate rule for ignoring. This is needed as Google has not mentioned exactly what androidx dependencies are requiring compileSDK = 35. The [documentation](https://developer.android.com/jetpack/androidx/versions) vaguely mentions "Various AndroidX libraries will start requiring compilesdk 35 after August 7th release. If you see AGP warnings when you upgrade compilesdk, you could suppress them."