### PR TITLE
POC Global Attributes implementation 

### DIFF
--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -23,6 +23,8 @@ import com.splunk.rum.integration.agent.api.SplunkRUMAgent
 import com.splunk.rum.integration.interactions.InteractionsModuleConfiguration
 import com.splunk.rum.integration.navigation.NavigationModuleConfiguration
 import com.splunk.rum.integration.sessionreplay.api.sessionReplay
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 import java.net.URL
 
 class App : Application() {
@@ -33,6 +35,14 @@ class App : Application() {
         // TODO: Reenable with the bridge support
         // BridgeManager.bridgeInterfaces += TomasBridgeInterface()
 
+        val globalAttributes = Attributes.of(
+            AttributeKey.stringKey("globKeyConfig1"), "12345",
+            AttributeKey.booleanKey("globKeyConfig2"), true,
+            AttributeKey.doubleKey("globKeyConfig3"), 1200.50,
+            AttributeKey.longKey("globKeyConfig4"), 30L,
+            AttributeKey.stringKey("globKeyConfig5"), "US"
+        )
+
         val agent = SplunkRUMAgent.install(
             application = this,
             agentConfiguration = AgentConfiguration(
@@ -40,6 +50,7 @@ class App : Application() {
                 appName = "smartlook-android",
                 appVersion = "0.1",
                 isDebugLogsEnabled = true,
+                globalAttributes = globalAttributes
             ),
             moduleConfigurations = arrayOf(
                 InteractionsModuleConfiguration(

--- a/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
@@ -30,6 +30,8 @@ import com.splunk.app.ui.okhttp.OkHttpFragment
 import com.splunk.app.util.FragmentAnimation
 import com.splunk.rum.customtracking.extension.customTracking
 import com.splunk.rum.integration.agent.api.SplunkRUMAgent
+import com.splunk.rum.integration.agent.api.attributes.GlobalAttributes
+import com.splunk.rum.integration.agent.api.attributes.extension.globalAttributes
 import com.splunk.rum.integration.agent.api.extension.splunkRumId
 import com.splunk.rum.integration.navigation.extension.navigation
 import io.opentelemetry.api.common.Attributes
@@ -129,6 +131,8 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                 showDoneToast("Track Workflow, Done!")
             }
             viewBinding.trackException.id -> {
+                SplunkRUMAgent.instance.globalAttributes.set("globkey12", "val12") // temporarily hijacking use of this button to also add global attribute on the fly
+
                 val e = Exception("Custom Exception To Be Tracked");
                 e.stackTrace = arrayOf(
                     StackTraceElement("android.fake.Crash", "crashMe", "NotARealFile.kt", 12),
@@ -139,6 +143,9 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                 showDoneToast("Track Exception, Done!")
             }
             viewBinding.trackExceptionWithAttributes.id -> {
+                SplunkRUMAgent.instance.globalAttributes.remove("globkey12") // temporarily hijacking use of this button to also remove global attribute on the fly
+                SplunkRUMAgent.instance.globalAttributes.remove("globkey")
+
                 val e = Exception("Custom Exception (with attributes) To Be Tracked");
                 e.stackTrace = arrayOf(
                     StackTraceElement("android.fake.Crash", "crashMe", "NotARealFile.kt", 12),

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.agent.api
 
+import io.opentelemetry.api.common.Attributes
 import java.net.URL
 
 /**
@@ -34,4 +35,5 @@ data class AgentConfiguration(
     var appName: String? = null,
     var appVersion: String? = null,
     var isDebugLogsEnabled: Boolean = false, // temporary name till product decides on more suitable one
+    var globalAttributes: Attributes = Attributes.empty() // Default to empty attributes if not provided
 )

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributeSpanProcessor2.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributeSpanProcessor2.kt
@@ -1,0 +1,34 @@
+package com.splunk.rum.integration.agent.api.attributes
+
+import com.cisco.android.common.utils.extensions.forEachFast
+import com.splunk.rum.integration.agent.api.attributes.GlobalAttributes
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+
+class GlobalAttributeSpanProcessor2 : SpanProcessor {
+
+    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+        // Fetch the current attributes from GlobalAttributes and apply them to the span
+        GlobalAttributes.instance.attributes.forEach { attribute ->
+            when (attribute) {
+                is GlobalAttributes.Attribute.Boolean -> span.setAttribute(attribute.name, attribute.value)
+                is GlobalAttributes.Attribute.Double -> span.setAttribute(attribute.name, attribute.value)
+                is GlobalAttributes.Attribute.Long -> span.setAttribute(attribute.name, attribute.value)
+                is GlobalAttributes.Attribute.String -> span.setAttribute(attribute.name, attribute.value)
+            }
+        }
+    }
+
+    override fun isStartRequired(): Boolean {
+        return true
+    }
+
+    override fun onEnd(span: ReadableSpan) {
+    }
+
+    override fun isEndRequired(): Boolean {
+        return true
+    }
+}

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributes.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributes.kt
@@ -8,20 +8,17 @@ class GlobalAttributes private constructor() {
         val instance: GlobalAttributes by lazy { GlobalAttributes() }
     }
 
-    // The list of global attributes. You can modify this list directly.
     private val _attributes: MutableList<Attribute> = ArrayList()
     val attributes: List<Attribute> get() = _attributes // Expose as immutable list
 
-    // Set a global attribute
+    // this method definitely can be streamlined
     operator fun set(key: Any, value: Any) {
         if (key is String) {
-            // Handle String key
             val existingAttribute = _attributes.find { it.name == key }
             if (existingAttribute != null) {
                 _attributes.remove(existingAttribute)
             }
 
-            // Add the new attribute
             _attributes += when (value) {
                 is String -> Attribute.String(key, value)
                 is Boolean -> Attribute.Boolean(key, value)
@@ -30,13 +27,11 @@ class GlobalAttributes private constructor() {
                 else -> throw IllegalArgumentException("Unsupported attribute type")
             }
         } else if (key is AttributeKey<*>) {
-            // Handle AttributeKey key
             val existingAttribute = _attributes.find { it.name == key.key }
             if (existingAttribute != null) {
                 _attributes.remove(existingAttribute)
             }
 
-            // Add the new attribute using the name of the AttributeKey
             _attributes += when (value) {
                 is String -> Attribute.String(key.key, value)
                 is Boolean -> Attribute.Boolean(key.key, value)
@@ -49,14 +44,10 @@ class GlobalAttributes private constructor() {
         }
     }
 
-
-
-    // Remove a global attribute by key
     fun remove(key: String) {
         _attributes.removeAll { it.name == key }
     }
 
-    // Sealed class for the attribute types (String, Boolean, Long, Double)
     sealed interface Attribute {
 
         val name: kotlin.String

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributes.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/GlobalAttributes.kt
@@ -1,0 +1,69 @@
+package com.splunk.rum.integration.agent.api.attributes
+
+import io.opentelemetry.api.common.AttributeKey
+
+class GlobalAttributes private constructor() {
+
+    companion object {
+        val instance: GlobalAttributes by lazy { GlobalAttributes() }
+    }
+
+    // The list of global attributes. You can modify this list directly.
+    private val _attributes: MutableList<Attribute> = ArrayList()
+    val attributes: List<Attribute> get() = _attributes // Expose as immutable list
+
+    // Set a global attribute
+    operator fun set(key: Any, value: Any) {
+        if (key is String) {
+            // Handle String key
+            val existingAttribute = _attributes.find { it.name == key }
+            if (existingAttribute != null) {
+                _attributes.remove(existingAttribute)
+            }
+
+            // Add the new attribute
+            _attributes += when (value) {
+                is String -> Attribute.String(key, value)
+                is Boolean -> Attribute.Boolean(key, value)
+                is Long -> Attribute.Long(key, value)
+                is Double -> Attribute.Double(key, value)
+                else -> throw IllegalArgumentException("Unsupported attribute type")
+            }
+        } else if (key is AttributeKey<*>) {
+            // Handle AttributeKey key
+            val existingAttribute = _attributes.find { it.name == key.key }
+            if (existingAttribute != null) {
+                _attributes.remove(existingAttribute)
+            }
+
+            // Add the new attribute using the name of the AttributeKey
+            _attributes += when (value) {
+                is String -> Attribute.String(key.key, value)
+                is Boolean -> Attribute.Boolean(key.key, value)
+                is Long -> Attribute.Long(key.key, value)
+                is Double -> Attribute.Double(key.key, value)
+                else -> throw IllegalArgumentException("Unsupported attribute type")
+            }
+        } else {
+            throw IllegalArgumentException("Key must be either String or AttributeKey")
+        }
+    }
+
+
+
+    // Remove a global attribute by key
+    fun remove(key: String) {
+        _attributes.removeAll { it.name == key }
+    }
+
+    // Sealed class for the attribute types (String, Boolean, Long, Double)
+    sealed interface Attribute {
+
+        val name: kotlin.String
+
+        data class Boolean(override val name: kotlin.String, val value: kotlin.Boolean) : Attribute
+        data class Double(override val name: kotlin.String, val value: kotlin.Double) : Attribute
+        data class String(override val name: kotlin.String, val value: kotlin.String) : Attribute
+        data class Long(override val name: kotlin.String, val value: kotlin.Long) : Attribute
+    }
+}

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/extension/SplunkRumAgentGlobalAttributesExt.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/extension/SplunkRumAgentGlobalAttributesExt.kt
@@ -1,0 +1,11 @@
+package com.splunk.rum.integration.agent.api.attributes.extension
+
+import com.splunk.rum.integration.agent.api.SplunkRUMAgent
+import com.splunk.rum.integration.agent.api.attributes.GlobalAttributes
+
+/**
+ * Extension property to access the [GlobalAttributes] instance via [SplunkRUMAgent].
+ */
+@Suppress("UnusedReceiverParameter")
+val SplunkRUMAgent.globalAttributes: GlobalAttributes
+    get() = GlobalAttributes.instance

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/MRUMAgentCore.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/MRUMAgentCore.kt
@@ -23,6 +23,8 @@ import com.splunk.sdk.common.otel.OpenTelemetryInitializer
 import com.splunk.rum.integration.agent.api.AgentConfiguration
 import com.splunk.rum.integration.agent.api.attributes.ErrorIdentifierAttributesSpanProcessor
 import com.splunk.rum.integration.agent.api.attributes.GenericAttributesLogProcessor
+import com.splunk.rum.integration.agent.api.attributes.GlobalAttributeSpanProcessor2
+import com.splunk.rum.integration.agent.api.attributes.GlobalAttributes
 import com.splunk.rum.integration.agent.api.configuration.ConfigurationManager
 import com.splunk.rum.integration.agent.api.extension.toResource
 import com.splunk.rum.integration.agent.api.sessionId.SessionIdLogProcessor
@@ -66,9 +68,15 @@ internal object MRUMAgentCore {
         SessionStartEventManager.obtainInstance(agentIntegration.sessionManager)
         SessionPulseEventManager.obtainInstance(agentIntegration.sessionManager)
 
+        // adding agent config global attributes to global attributes
+        agentConfiguration.globalAttributes.forEach { attributeKey, value ->
+            GlobalAttributes.instance[attributeKey] = value
+        }
+
         OpenTelemetryInitializer(application)
             .joinResources(finalConfiguration.toResource())
             .addSpanProcessor(ErrorIdentifierAttributesSpanProcessor(application))
+            .addSpanProcessor(GlobalAttributeSpanProcessor2())
             .addSpanProcessor(SessionIdSpanProcessor(agentIntegration.sessionManager))
             .addSpanProcessor(GlobalAttributeSpanProcessor())
             .addLogRecordProcessor(GenericAttributesLogProcessor())


### PR DESCRIPTION
POC Implementation of global attributes feature.

- added global attributes class and exposed API calls
- implemented only basic set and remove for now
- added global attributes to agent config
- copied a global attribute span processor into the integration:agent:api module and modified slightly so it can process spans from the global attributes class located in integration:agent:api
- tested both adding global attributes from agent config as well as adding and removing via sample app button during runtime