### PR TITLE
Integrate with opentelemetry-android (Redo)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,10 +5,8 @@ import java.net.InetAddress
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    //TODO: Causes issues while building with common:otel module in minifyR8 task.
-    // Need to figure out a way to depend on plugin project instead of published jar
-    // Uncomment this to test HttpURLConnection and build just the app to test
-    //id("com.cisco.android.rum-plugin") version "24.4.10-2246"
+    // Uncomment this to test HttpURLConnection instrumentation
+    //id("com.splunk.android.rum-plugin") version "24.4.1"
 }
 
 apply<ConfigAndroidApp>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,16 @@ buildscript {
 allprojects {
     apply<plugins.ConfigKtLint>()
 
+    // Enforce lower versions of certain libraries to avoid compatibility issues
+    // introduced by higher versions from OpenTelemetry dependencies.
+    configurations.all {
+        resolutionStrategy {
+            force("org.jetbrains.kotlin:kotlin-stdlib:1.8.0")
+            force("androidx.core:core:1.13.1")
+            force("androidx.core:core-ktx:1.13.1")
+        }
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,8 +6,8 @@ object Dependencies {
     private const val buildInfoExtractorGradleVersion = "4.25.5"
     private const val kotlinVersion = "1.8.0"
     private const val ktlintVersion = "1.2.0"
-    private const val desugarVersion = "2.0.3"
-    private const val bytebuddyVersion = "1.14.10"
+    private const val desugarVersion = "2.1.3"
+    private const val bytebuddyVersion = "1.17.2"
 
     const val gradle = "com.android.tools.build:gradle:$gradleVersion"
     const val gradleApi = "com.android.tools.build:gradle-api:$gradleVersion"
@@ -115,9 +115,11 @@ object Dependencies {
     object Otel {
         private const val otelVersion = "1.36.0"
         private const val otelAlphaVersion = "$otelVersion-alpha"
-        private const val otelSemConvVersion = "1.23.1-alpha"
+        private const val otelSemConvVersion = "1.30.0"
+        private const val otelSemConvAlphaVersion = "$otelSemConvVersion-alpha"
         private const val otelInstrumentationVersion = "1.32.0"
         private const val otelInstrumentationAlphaVersion = "$otelInstrumentationVersion-alpha"
+        public const val otelAndroidVersion = "0.10.0-alpha"
 
         const val api = "io.opentelemetry:opentelemetry-api:$otelVersion"
         const val context = "io.opentelemetry:opentelemetry-context:$otelVersion"
@@ -126,10 +128,15 @@ object Dependencies {
         const val exporterOtlpCommon = "io.opentelemetry:opentelemetry-exporter-otlp-common:$otelVersion"
         const val exporterOtlp = "io.opentelemetry:opentelemetry-exporter-otlp:$otelVersion"
         const val semConv = "io.opentelemetry.semconv:opentelemetry-semconv:$otelSemConvVersion"
+        const val semConvIncubating = "io.opentelemetry.semconv:opentelemetry-semconv-incubating:$otelSemConvAlphaVersion"
 
         const val instrumentationSemConv = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:$otelInstrumentationAlphaVersion"
         const val instrumentationApi = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:$otelInstrumentationVersion"
         const val instrumentationOkhttp3 = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:$otelInstrumentationAlphaVersion"
+
+        const val androidSession = "io.opentelemetry.android:session:$otelAndroidVersion"
+        const val androidInstrumentation = "io.opentelemetry.android:instrumentation-android-instrumentation:$otelAndroidVersion"
+        const val androidHttpUrlLibrary = "io.opentelemetry.android:instrumentation-httpurlconnection-library:$otelAndroidVersion"
     }
 
     object AndroidTest {

--- a/buildSrc/src/main/kotlin/utils/ProjectProperties.kt
+++ b/buildSrc/src/main/kotlin/utils/ProjectProperties.kt
@@ -1,6 +1,6 @@
 package utils
 
-const val defaultGroupId = "com.cisco.android"
+const val defaultGroupId = "com.splunk.android"
 const val artifactPrefix = "rum-"
 const val snapshotProperty = "maven.deploy.artifactory.snapshot"
 const val artifactIdProperty = "mavenArtifactId"

--- a/common/otel/build.gradle.kts
+++ b/common/otel/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
         exclude(group = "com.squareup.okhttp3", module = "okhttp")
     }
     api(Dependencies.Otel.semConv)
+    api(Dependencies.Otel.semConvIncubating)
 
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonJob)

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/OpenTelemetryInitializer.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/OpenTelemetryInitializer.kt
@@ -75,7 +75,7 @@ class OpenTelemetryInitializer(application: Application) {
 
         val sdk = if (global) instance.buildAndRegisterGlobal() else instance.build()
 
-        OpenTelemetry.instance = sdk
+        SplunkOpenTelemetrySdk.instance = sdk
 
         return sdk
     }

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/SplunkOpenTelemetrySdk.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/SplunkOpenTelemetrySdk.kt
@@ -18,7 +18,7 @@ package com.splunk.sdk.common.otel
 
 import io.opentelemetry.sdk.OpenTelemetrySdk
 
-object OpenTelemetry {
+object SplunkOpenTelemetrySdk {
     var instance: OpenTelemetrySdk? = null
     val listeners: MutableCollection<Listener> = HashSet()
 

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/internal/Resources.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/internal/Resources.kt
@@ -20,14 +20,14 @@ import android.os.Build
 import com.splunk.sdk.otel.BuildConfig
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.semconv.ResourceAttributes.DEVICE_ID
-import io.opentelemetry.semconv.ResourceAttributes.DEVICE_MANUFACTURER
-import io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_IDENTIFIER
-import io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_NAME
-import io.opentelemetry.semconv.ResourceAttributes.OS_DESCRIPTION
-import io.opentelemetry.semconv.ResourceAttributes.OS_NAME
-import io.opentelemetry.semconv.ResourceAttributes.OS_TYPE
-import io.opentelemetry.semconv.ResourceAttributes.OS_VERSION
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_ID
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION
 
 internal object Resources {
 

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/logRecord/AndroidLogRecordExporter.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/logRecord/AndroidLogRecordExporter.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.sdk.common.otel.logRecord
 
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
@@ -38,7 +38,7 @@ internal class AndroidLogRecordExporter : LogRecordExporter {
              val activeSpan = Span.fromContextOrNull(parentContext)
 
             // traceId and spanId should be inside the context already from global OTel instance
-            val spanBuilder = OpenTelemetry.instance!!.sdkTracerProvider.get(RumConstants.RUM_TRACER_NAME)
+            val spanBuilder = SplunkOpenTelemetrySdk.instance!!.sdkTracerProvider.get(RumConstants.RUM_TRACER_NAME)
                 .spanBuilder(log.attributes[AttributeKey.stringKey("event.name")] ?: "")
                 .setSpanKind(SpanKind.INTERNAL)
                 .setParent(parentContext)

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/span/UploadOtelSpanDataJob.kt
@@ -23,7 +23,6 @@ import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
 import android.os.PersistableBundle
-import android.util.Log
 import com.cisco.android.common.http.HttpClient
 import com.cisco.android.common.http.model.Header
 import com.cisco.android.common.http.model.Response

--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/span/UploadOtelSpanDataJob.kt
@@ -23,6 +23,7 @@ import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
 import android.os.PersistableBundle
+import android.util.Log
 import com.cisco.android.common.http.HttpClient
 import com.cisco.android.common.http.model.Header
 import com.cisco.android.common.http.model.Response

--- a/instrumentation/buildtime/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/plugin/build.gradle.kts
@@ -34,7 +34,7 @@ java {
 tasks.jar {
     manifest {
         attributes(
-            "Implementation-Version" to Configurations.sdkVersionName
+            "Implementation-Version" to Dependencies.Otel.otelAndroidVersion
         )
     }
     metaInf {
@@ -47,7 +47,7 @@ gradlePlugin {
         create("androidInstrumentationPlugin") {
             id = "$defaultGroupId.${artifactPrefix}plugin"
             implementationClass = "com.splunk.rum.plugin.AndroidInstrumentationPlugin"
-            displayName = "Cisco Android Auto-Instrumentation Plugin"
+            displayName = "Splunk Android Auto-Instrumentation Plugin"
         }
     }
 }

--- a/instrumentation/buildtime/plugin/src/main/java/com/splunk/rum/plugin/AndroidInstrumentationPlugin.java
+++ b/instrumentation/buildtime/plugin/src/main/java/com/splunk/rum/plugin/AndroidInstrumentationPlugin.java
@@ -20,6 +20,10 @@ import net.bytebuddy.build.gradle.android.ByteBuddyAndroidPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+/**
+ * This plugin adds the <a href="https://github.com/raphw/byte-buddy/tree/master/byte-buddy-gradle-plugin">Byte-Buddy Gradle plugin</a>
+ * and needed dependencies for automatic instrumentation of HTTP request made via HttpURLConnection APIs.
+ */
 public class AndroidInstrumentationPlugin implements Plugin<Project> {
 
     private Project project;
@@ -37,7 +41,6 @@ public class AndroidInstrumentationPlugin implements Plugin<Project> {
     }
 
     private void addAutoInstrumentationDependenciesForNRTracing() {
-        project.getDependencies().add("byteBuddy", "com.cisco.android:rum-network-request-bci:" + dependenciesVersion);
-        project.getDependencies().add("implementation", "com.cisco.android:rum-network-request-library:" + dependenciesVersion);
+        project.getDependencies().add("byteBuddy", "io.opentelemetry.android:instrumentation-httpurlconnection-agent:" + dependenciesVersion);
     }
 }

--- a/instrumentation/runtime/customtracking/src/main/java/com/splunk/rum/customtracking/CustomTracking.kt
+++ b/instrumentation/runtime/customtracking/src/main/java/com/splunk/rum/customtracking/CustomTracking.kt
@@ -17,7 +17,7 @@
 package com.splunk.rum.customtracking
 
 import com.cisco.android.common.logger.Logger
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -95,7 +95,7 @@ class CustomTracking internal constructor() {
      * @return A Tracer instance if available, or null if the OpenTelemetry instance is null.
      */
     private fun getTracer(): Tracer? {
-        return OpenTelemetry.instance?.sdkTracerProvider?.get(RumConstants.RUM_TRACER_NAME).also {
+        return SplunkOpenTelemetrySdk.instance?.sdkTracerProvider?.get(RumConstants.RUM_TRACER_NAME).also {
             if (it == null) {
                 Logger.e(
                     TAG,

--- a/integration/agent/api/build.gradle.kts
+++ b/integration/agent/api/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:storage"))
 
+    implementation(Dependencies.Otel.semConv)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonStorage)
     implementation(Dependencies.SessionReplay.commonUtils)

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
@@ -95,7 +95,7 @@ internal object SplunkRumAgentCore {
 
         isRunning = true
 
-        agentIntegration.install(application)
+        agentIntegration.install(application, openTelemetry)
 
         return openTelemetry
     }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionIdLogProcessor.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionIdLogProcessor.kt
@@ -18,12 +18,12 @@ package com.splunk.rum.integration.agent.api.sessionId
 
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.api.attributes.AttributeConstants.SESSION_ID_KEY
-import com.splunk.rum.integration.agent.internal.session.SessionManager
+import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
 
-internal class SessionIdLogProcessor(private val sessionManager: SessionManager) : LogRecordProcessor {
+internal class SessionIdLogProcessor(private val sessionManager: SplunkSessionManager) : LogRecordProcessor {
     override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
         val sessionId = sessionManager.sessionId
         Logger.d("SessionIdLogProcessor", "onEmit sessionId: $sessionId, ${logRecord.toLogRecordData().attributes}")

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionIdSpanProcessor.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionIdSpanProcessor.kt
@@ -17,13 +17,13 @@
 package com.splunk.rum.integration.agent.api.sessionId
 
 import com.splunk.rum.integration.agent.api.attributes.AttributeConstants.SESSION_ID_KEY
-import com.splunk.rum.integration.agent.internal.session.SessionManager
+import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
 
-internal class SessionIdSpanProcessor(private val sessionManager: SessionManager) : SpanProcessor {
+internal class SessionIdSpanProcessor(private val sessionManager: SplunkSessionManager) : SpanProcessor {
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
         span.setAttribute(SESSION_ID_KEY, sessionManager.sessionId)
     }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionStartEventManager.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/sessionId/SessionStartEventManager.kt
@@ -18,18 +18,18 @@ package com.splunk.rum.integration.agent.api.sessionId
 
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.api.attributes.AttributeConstants
-import com.splunk.rum.integration.agent.internal.session.SessionManager
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import java.util.concurrent.TimeUnit
 
-internal class SessionStartEventManager(sessionManager: SessionManager) {
+internal class SessionStartEventManager(sessionManager: SplunkSessionManager) {
 
     init {
         Logger.d(TAG, "init()")
 
-        sessionManager.sessionListeners += object : SessionManager.SessionListener {
+        sessionManager.sessionListeners += object : SplunkSessionManager.SessionListener {
             override fun onSessionChanged(sessionId: String) {
                 createSessionStartEvent(sessionId, sessionManager.anonId)
             }
@@ -39,7 +39,7 @@ internal class SessionStartEventManager(sessionManager: SessionManager) {
     private fun createSessionStartEvent(sessionId: String, userId: String) {
         Logger.d(TAG, "createSessionStartEvent() sessionId: $sessionId, userId: $userId")
 
-        val instance = OpenTelemetry.instance ?: return
+        val instance = SplunkOpenTelemetrySdk.instance ?: return
 
         val now = System.currentTimeMillis()
         val attributes = Attributes.of(
@@ -59,7 +59,7 @@ internal class SessionStartEventManager(sessionManager: SessionManager) {
     companion object {
         private const val TAG = "SessionStartEventManager"
         private var instanceInternal: SessionStartEventManager? = null
-        fun obtainInstance(sessionManager: SessionManager): SessionStartEventManager {
+        fun obtainInstance(sessionManager: SplunkSessionManager): SessionStartEventManager {
             if (instanceInternal == null)
                 instanceInternal =
                     SessionStartEventManager(sessionManager)

--- a/integration/agent/internal/build.gradle.kts
+++ b/integration/agent/internal/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation(project(":common:otel"))
     implementation(project(":common:storage"))
 
+    implementation(Dependencies.Otel.androidSession)
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonId)
     implementation(Dependencies.SessionReplay.commonHttp)

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
@@ -26,7 +26,7 @@ import com.splunk.sdk.common.storage.IAgentStorage
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 
-class SessionManager internal constructor(
+class SplunkSessionManager internal constructor(
     private val agentStorage: IAgentStorage
 ) {
 

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/span/AppStartSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/span/AppStartSpanProcessor.kt
@@ -19,7 +19,7 @@ package com.splunk.rum.integration.agent.internal.span
 import android.os.SystemClock
 import com.splunk.rum.integration.agent.internal.AgentIntegration.Companion.modules
 import com.splunk.rum.integration.agent.module.extension.toSplunkString
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
@@ -50,7 +50,7 @@ class AppStartSpanProcessor : SpanProcessor {
     }
 
     private fun reportInitialization(appStartSpan: Span) {
-        val provider = OpenTelemetry.instance?.sdkTracerProvider ?: throw IllegalStateException("unable to report initialization")
+        val provider = SplunkOpenTelemetrySdk.instance?.sdkTracerProvider ?: throw IllegalStateException("unable to report initialization")
         val modules = modules.values
 
         val firstInitialization = modules.minByOrNull { it.initialization?.startTimestamp ?: Long.MAX_VALUE }?.initialization ?: throw IllegalStateException("Module initialization did not started")

--- a/integration/anr/build.gradle.kts
+++ b/integration/anr/build.gradle.kts
@@ -25,6 +25,8 @@ android {
 dependencies {
     implementation(project(":integration:agent:internal"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonUtils)
 }

--- a/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrIntegration.kt
+++ b/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrIntegration.kt
@@ -22,6 +22,7 @@ import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.config.ModuleConfigurationManager
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
+import io.opentelemetry.android.instrumentation.InstallationContext
 
 @SuppressLint("LongLogTag")
 internal object AnrIntegration {
@@ -51,7 +52,7 @@ internal object AnrIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
             val integration = AgentIntegration.obtainInstance(context)
             integration.moduleConfigurationManager.listeners += configManagerListener

--- a/integration/crash/build.gradle.kts
+++ b/integration/crash/build.gradle.kts
@@ -25,6 +25,8 @@ android {
 dependencies {
     implementation(project(":integration:agent:internal"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonUtils)
 }

--- a/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashIntegration.kt
+++ b/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashIntegration.kt
@@ -22,6 +22,7 @@ import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.config.ModuleConfigurationManager
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
+import io.opentelemetry.android.instrumentation.InstallationContext
 
 @SuppressLint("LongLogTag")
 internal object CrashIntegration {
@@ -48,7 +49,7 @@ internal object CrashIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
             val integration = AgentIntegration.obtainInstance(context)
             integration.moduleConfigurationManager.listeners += configManagerListener

--- a/integration/interactions/build.gradle.kts
+++ b/integration/interactions/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation(project(":common:otel"))
     implementation(project(":integration:agent:internal"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.instrumentationSessionRecordingFrameCapturer)
     implementation(Dependencies.SessionReplay.instrumentationSessionRecordingInteractions)

--- a/integration/interactions/src/main/java/com/splunk/rum/integration/interactions/InteractionsIntegration.kt
+++ b/integration/interactions/src/main/java/com/splunk/rum/integration/interactions/InteractionsIntegration.kt
@@ -35,8 +35,9 @@ import com.splunk.rum.integration.agent.internal.identification.ComposeElementId
 import com.splunk.rum.integration.agent.internal.identification.ComposeElementIdentification.OrderPriority
 import com.splunk.rum.integration.agent.internal.utils.runIfComposeUiExists
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.TimeUnit
 
@@ -95,7 +96,7 @@ internal object InteractionsIntegration {
 
             Logger.d(TAG, "onInteraction(interaction: $interaction, legacyData: $legacyData)")
 
-            val logger = OpenTelemetry.instance?.sdkLoggerProvider ?: return
+            val logger = SplunkOpenTelemetrySdk.instance?.sdkLoggerProvider ?: return
 
             val actionName = when (interaction) {
                 is Interaction.Focus ->
@@ -148,7 +149,7 @@ internal object InteractionsIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
 
             val integration = AgentIntegration.obtainInstance(context)

--- a/integration/navigation/build.gradle.kts
+++ b/integration/navigation/build.gradle.kts
@@ -27,5 +27,7 @@ dependencies {
     implementation(project(":integration:agent:api"))
     implementation(project(":common:otel"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
 }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationIntegration.kt
@@ -23,8 +23,9 @@ import com.splunk.rum.integration.agent.internal.config.ModuleConfigurationManag
 import com.splunk.rum.integration.agent.internal.extension.find
 import com.splunk.rum.integration.agent.internal.span.GlobalAttributeSpanProcessor
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
+import io.opentelemetry.android.instrumentation.InstallationContext
 
 internal object NavigationIntegration {
 
@@ -52,7 +53,7 @@ internal object NavigationIntegration {
 
             Logger.d(TAG, "onScreenNameChanged(screenName: $screenName)")
 
-            val provider = OpenTelemetry.instance?.sdkTracerProvider ?: return
+            val provider = SplunkOpenTelemetrySdk.instance?.sdkTracerProvider ?: return
 
             GlobalAttributeSpanProcessor.attributes.removeIf { it.name == "screen.name" }
             GlobalAttributeSpanProcessor.attributes += GlobalAttributeSpanProcessor.Attribute.String("screen.name", screenName)
@@ -74,7 +75,7 @@ internal object NavigationIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
 
             val integration = AgentIntegration.obtainInstance(context)

--- a/integration/networkrequest/build.gradle.kts
+++ b/integration/networkrequest/build.gradle.kts
@@ -25,6 +25,8 @@ android {
 dependencies {
     implementation(project(":integration:agent:internal"))
 
+    implementation(Dependencies.Otel.androidHttpUrlLibrary)
+
     implementation(Dependencies.SessionReplay.commonLogger)
     implementation(Dependencies.SessionReplay.commonUtils)
 }

--- a/integration/networkrequest/src/main/java/com/splunk/rum/integration/networkrequest/NetworkRequestIntegration.kt
+++ b/integration/networkrequest/src/main/java/com/splunk/rum/integration/networkrequest/NetworkRequestIntegration.kt
@@ -21,14 +21,18 @@ import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.config.ModuleConfigurationManager
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlInstrumentation
+import com.splunk.rum.integration.agent.internal.extension.find
 
 internal object NetworkRequestIntegration {
 
     private const val TAG = "NetworkRequestIntegration"
     private const val MODULE_NAME = "networkTracing"
-    private const val DEFAULT_IS_ENABLED = true
 
-    private var isNetworkTracingEnabled: Boolean = DEFAULT_IS_ENABLED
+    private val defaultModuleConfiguration = NetworkRequestModuleConfiguration()
+    private var moduleConfiguration = defaultModuleConfiguration
 
     init {
         Logger.d(TAG, "init()")
@@ -42,17 +46,26 @@ internal object NetworkRequestIntegration {
 
     private val configManagerListener = object : ModuleConfigurationManager.Listener {
         override fun onSetup(configurations: List<ModuleConfiguration>) {
+            moduleConfiguration = configurations.find< NetworkRequestModuleConfiguration>() ?: defaultModuleConfiguration
+
+            Logger.d(TAG, "onSetup(moduleConfiguration: ${moduleConfiguration})")
         }
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
 
             val integration = AgentIntegration.obtainInstance(context)
             integration.moduleConfigurationManager.listeners += configManagerListener
 
             AgentIntegration.registerModuleInitializationEnd(MODULE_NAME)
+
+            //install HttpURLConnection auto-instrumentation if isEnabled is true
+            if(moduleConfiguration.isEnabled){
+                val httpUrlInstrumentation = AndroidInstrumentationLoader.getInstrumentation(HttpUrlInstrumentation::class.java)
+                httpUrlInstrumentation?.install(oTelInstallationContext)
+            }
         }
     }
 }

--- a/integration/networkrequest/src/main/java/com/splunk/rum/integration/networkrequest/NetworkRequestModuleConfiguration.kt
+++ b/integration/networkrequest/src/main/java/com/splunk/rum/integration/networkrequest/NetworkRequestModuleConfiguration.kt
@@ -18,10 +18,10 @@ package com.splunk.rum.integration.networkrequest
 
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
 
-class NetworkRequestModuleConfiguration : ModuleConfiguration {
+class NetworkRequestModuleConfiguration(val isEnabled: Boolean = true) : ModuleConfiguration {
     override val name: String = "network"
 
     override val attributes: List<Pair<String, String>> = listOf(
-        "enabled" to true.toString()
+        "enabled" to isEnabled.toString()
     )
 }

--- a/integration/sessionreplay/build.gradle.kts
+++ b/integration/sessionreplay/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation(project(":integration:agent:api"))
     implementation(project(":integration:agent:internal"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     api(Dependencies.SessionReplay.instrumentationSessionRecordingCore)
     implementation(Dependencies.SessionReplay.commonLogger)
 

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayIntegration.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayIntegration.kt
@@ -28,7 +28,8 @@ import com.splunk.rum.integration.agent.internal.identification.ComposeElementId
 import com.splunk.rum.integration.agent.internal.identification.ComposeElementIdentification.OrderPriority
 import com.splunk.rum.integration.agent.internal.utils.runIfComposeUiExists
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.extension.incubator.logs.AnyValue
@@ -71,7 +72,7 @@ internal object SessionReplayIntegration {
         override fun onData(data: ByteArray, metadata: Metadata): Boolean {
             Logger.d(TAG, "onData()")
 
-            val instance = OpenTelemetry.instance ?: return false
+            val instance = SplunkOpenTelemetrySdk.instance ?: return false
 
             val attributes = Attributes.of(
                 AttributeKey.stringKey("event.name"), "session_replay_data",
@@ -95,7 +96,7 @@ internal object SessionReplayIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
 
             val integration = AgentIntegration.obtainInstance(context)

--- a/integration/startup/build.gradle.kts
+++ b/integration/startup/build.gradle.kts
@@ -27,5 +27,7 @@ dependencies {
     implementation(project(":instrumentation:runtime:startup"))
     implementation(project(":common:otel"))
 
+    implementation(Dependencies.Otel.androidInstrumentation)
+
     implementation(Dependencies.SessionReplay.commonLogger)
 }

--- a/integration/startup/src/main/java/com/splunk/rum/integration/startup/StartupIntegration.kt
+++ b/integration/startup/src/main/java/com/splunk/rum/integration/startup/StartupIntegration.kt
@@ -25,8 +25,9 @@ import com.splunk.rum.integration.agent.internal.config.ModuleConfigurationManag
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
 import com.splunk.rum.integration.startup.model.StartupData
 import com.splunk.rum.startup.ApplicationStartupTimekeeper
-import com.splunk.sdk.common.otel.OpenTelemetry
+import com.splunk.sdk.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.sdk.common.otel.internal.RumConstants
+import io.opentelemetry.android.instrumentation.InstallationContext
 
 internal object StartupIntegration {
 
@@ -63,7 +64,7 @@ internal object StartupIntegration {
     }
 
     private fun reportEvent(startTimestamp: Long, endTimestamp: Long, name: String) {
-        val provider = OpenTelemetry.instance?.sdkTracerProvider ?: run {
+        val provider = SplunkOpenTelemetrySdk.instance?.sdkTracerProvider ?: run {
             cache += StartupData(startTimestamp, endTimestamp, name)
             return
         }
@@ -83,7 +84,7 @@ internal object StartupIntegration {
     }
 
     private val installationListener = object : AgentIntegration.Listener {
-        override fun onInstall(context: Context) {
+        override fun onInstall(context: Context, oTelInstallationContext: InstallationContext) {
             Logger.d(TAG, "onInstall()")
 
             val integration = AgentIntegration.obtainInstance(context)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,12 @@
+// Plugin management configuration
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        //uncomment to look for plugins in local maven (.m2) folder
+        //mavenLocal()
+    }
+}
+
 // Common modules
 include ':common:otel',
         ':common:storage',


### PR DESCRIPTION
**This PR covers the following:**

-  Setup for installing opentelemetry-android instrumentations
-  Integrated HttpURLConnection auto-instrumentation
-  Upgrades to necessary libraries as needed for the integration:
-- Desugar lib
-- Bytebuddy version
-- oTel semantic conventions
-  Forcing earlier versions of remaining to maintain compatibility with our SDK
--  kotlin-stdlib (1.8.0 - our SDK requirement)
--  androidx.core:core (last most used stable version 1.31.1)
--  androidx.core:core-ktx (last most used stable version 1.31.1)
-  Updates needed in plugin code and exsuring it’s usage in sample app and testing telemetry generation
-  Upgrades to certain API names to tell them apart from similar APIs coming from upstream like:
--  OpenTelemtry -> SplunkOpenTelemtrySdk
--  SessionManager -> SplunkSessionManager (this will be replaced later anyway when upstream SessionManager is used instead)
 
**Upcoming in future PRs:**

-  Based on one/two plugin approach we decide - integrate okHttp3 auto-instrumentation along with the changes needed for that.
-  Add additional attributes once atrribute extractors PR upstream is merged.
-  Validate all attributes for Network Request spans once we have all of the SDK setup for attributes in place.