### PR TITLE
Consolidate naming around build id field

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 
 public class ErrorIdentifierExtractor {
 
-    private static final String SPLUNK_UUID_MANIFEST_KEY = "splunk.build_id";
+    private static final String SPLUNK_BUILD_ID = "splunk.build_id";
     private final Application application;
     private final PackageManager packageManager;
     @Nullable private final ApplicationInfo applicationInfo;
@@ -52,7 +52,7 @@ public class ErrorIdentifierExtractor {
     public ErrorIdentifierInfo extractInfo() {
         String applicationId = null;
         String versionCode = retrieveVersionCode();
-        String customUUID = retrieveCustomUUID();
+        String splunkBuildID = retrieveSplunkBuildID();
 
         if (applicationInfo != null) {
             applicationId = applicationInfo.packageName;
@@ -60,7 +60,7 @@ public class ErrorIdentifierExtractor {
             Log.e(SplunkRum.LOG_TAG, "ApplicationInfo is null, cannot extract applicationId");
         }
 
-        return new ErrorIdentifierInfo(applicationId, versionCode, customUUID);
+        return new ErrorIdentifierInfo(applicationId, versionCode, splunkBuildID);
     }
 
     @Nullable
@@ -76,14 +76,14 @@ public class ErrorIdentifierExtractor {
     }
 
     @Nullable
-    private String retrieveCustomUUID() {
+    private String retrieveSplunkBuildID() {
         if (applicationInfo == null) {
-            Log.e(SplunkRum.LOG_TAG, "ApplicationInfo is null; cannot retrieve Custom UUID.");
+            Log.e(SplunkRum.LOG_TAG, "ApplicationInfo is null; cannot retrieve Splunk Build ID.");
             return null;
         }
         Bundle bundle = applicationInfo.metaData;
         if (bundle != null) {
-            return bundle.getString(SPLUNK_UUID_MANIFEST_KEY);
+            return bundle.getString(SPLUNK_BUILD_ID);
         } else {
             Log.e(SplunkRum.LOG_TAG, "Application MetaData bundle is null");
             return null;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -85,7 +85,7 @@ public class ErrorIdentifierExtractor {
 
         Bundle bundle = applicationInfo.metaData;
         if (bundle == null) {
-            Log.d(SplunkRum.LOG_TAG, "Application MetaData bundle is null - no metadata present");
+            Log.d(SplunkRum.LOG_TAG, "Application metadata bundle is null - no metadata present");
             return null;
         }
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierExtractor.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 
 public class ErrorIdentifierExtractor {
 
-    private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_O11Y_CUSTOM_UUID";
+    private static final String SPLUNK_UUID_MANIFEST_KEY = "splunk.build_id";
     private final Application application;
     private final PackageManager packageManager;
     @Nullable private final ApplicationInfo applicationInfo;

--- a/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierInfo.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/ErrorIdentifierInfo.java
@@ -21,15 +21,15 @@ import androidx.annotation.Nullable;
 public class ErrorIdentifierInfo {
     @Nullable private final String applicationId;
     @Nullable private final String versionCode;
-    @Nullable private final String customUUID;
+    @Nullable private final String splunkBuildID;
 
     public ErrorIdentifierInfo(
             @Nullable String applicationId,
             @Nullable String versionCode,
-            @Nullable String customUUID) {
+            @Nullable String splunkBuildID) {
         this.applicationId = applicationId;
         this.versionCode = versionCode;
-        this.customUUID = customUUID;
+        this.splunkBuildID = splunkBuildID;
     }
 
     @Nullable
@@ -43,7 +43,7 @@ public class ErrorIdentifierInfo {
     }
 
     @Nullable
-    public String getCustomUUID() {
-        return customUUID;
+    public String getSplunkBuildID() {
+        return splunkBuildID;
     }
 }

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -24,7 +24,7 @@ import static com.splunk.rum.SplunkRum.COMPONENT_ERROR;
 import static com.splunk.rum.SplunkRum.COMPONENT_KEY;
 import static com.splunk.rum.SplunkRum.COMPONENT_UI;
 import static com.splunk.rum.SplunkRum.RUM_TRACER_NAME;
-import static com.splunk.rum.SplunkRum.SPLUNK_OLLY_UUID_KEY;
+import static com.splunk.rum.SplunkRum.SPLUNK_BUILD_ID;
 import static io.opentelemetry.android.RumConstants.APP_START_SPAN_NAME;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.semconv.ResourceAttributes.DEPLOYMENT_ENVIRONMENT;
@@ -295,7 +295,7 @@ class RumInitializer {
                     ErrorIdentifierInfo errorIdentifierInfo = extractor.extractInfo();
                     String applicationId = errorIdentifierInfo.getApplicationId();
                     String versionCode = errorIdentifierInfo.getVersionCode();
-                    String uuid = errorIdentifierInfo.getCustomUUID();
+                    String splunkBuildID = errorIdentifierInfo.getSplunkBuildID();
 
                     AnrDetectorBuilder builder = AnrDetector.builder();
                     builder.addAttributesExtractor(constant(COMPONENT_KEY, COMPONENT_ERROR));
@@ -304,8 +304,8 @@ class RumInitializer {
                         builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
                     if (versionCode != null)
                         builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
-                    if (uuid != null)
-                        builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
+                    if (splunkBuildID != null)
+                        builder.addAttributesExtractor(constant(SPLUNK_BUILD_ID, splunkBuildID));
 
                     builder.setMainLooper(mainLooper).build().installOn(instrumentedApplication);
 
@@ -320,7 +320,7 @@ class RumInitializer {
                     ErrorIdentifierInfo errorIdentifierInfo = extractor.extractInfo();
                     String applicationId = errorIdentifierInfo.getApplicationId();
                     String versionCode = errorIdentifierInfo.getVersionCode();
-                    String uuid = errorIdentifierInfo.getCustomUUID();
+                    String splunkBuildId = errorIdentifierInfo.getSplunkBuildID();
 
                     CrashReporterBuilder builder = CrashReporter.builder();
                     builder.addAttributesExtractor(
@@ -334,8 +334,8 @@ class RumInitializer {
                         builder.addAttributesExtractor(constant(APPLICATION_ID_KEY, applicationId));
                     if (versionCode != null)
                         builder.addAttributesExtractor(constant(APP_VERSION_CODE_KEY, versionCode));
-                    if (uuid != null)
-                        builder.addAttributesExtractor(constant(SPLUNK_OLLY_UUID_KEY, uuid));
+                    if (splunkBuildId != null)
+                        builder.addAttributesExtractor(constant(SPLUNK_BUILD_ID, splunkBuildId));
 
                     builder.build().installOn(instrumentedApplication);
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -69,7 +69,7 @@ public class SplunkRum {
     static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rum.version");
     static final AttributeKey<String> APPLICATION_ID_KEY = stringKey("service.application_id");
     static final AttributeKey<String> APP_VERSION_CODE_KEY = stringKey("service.version_code");
-    static final AttributeKey<String> SPLUNK_OLLY_UUID_KEY = stringKey("service.o11y.key");
+    static final AttributeKey<String> SPLUNK_OLLY_UUID_KEY = stringKey("splunk.build_id");
 
     @Nullable private static SplunkRum INSTANCE;
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRum.java
@@ -69,7 +69,7 @@ public class SplunkRum {
     static final AttributeKey<String> RUM_VERSION_KEY = stringKey("splunk.rum.version");
     static final AttributeKey<String> APPLICATION_ID_KEY = stringKey("service.application_id");
     static final AttributeKey<String> APP_VERSION_CODE_KEY = stringKey("service.version_code");
-    static final AttributeKey<String> SPLUNK_OLLY_UUID_KEY = stringKey("splunk.build_id");
+    static final AttributeKey<String> SPLUNK_BUILD_ID = stringKey("splunk.build_id");
 
     @Nullable private static SplunkRum INSTANCE;
 

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ErrorIdentifierExtractorTest {
-    private static final String SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_O11Y_CUSTOM_UUID";
+    private static final String SPLUNK_UUID_MANIFEST_KEY = "splunk.build_id";
     private static final String TEST_PACKAGE_NAME = "splunk.test.package.name";
     private static final String TEST_VERSION_CODE = "123";
     private static final String TEST_UUID = "test-uuid";

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
@@ -54,7 +54,8 @@ public class ErrorIdentifierExtractorTest {
 
         when(mockPackageManager.getApplicationInfo(TEST_PACKAGE_NAME, PackageManager.GET_META_DATA))
                 .thenReturn(mockApplicationInfo);
-        when(mockMetadata.getString(SPLUNK_BUILD_ID)).thenReturn(TEST_SPLUNK_BUILDID);
+        when(mockMetadata.containsKey(SPLUNK_BUILD_ID)).thenReturn(true);
+        when(mockMetadata.get(SPLUNK_BUILD_ID)).thenReturn(TEST_SPLUNK_BUILDID);
 
         mockPackageInfo.versionCode = 123;
         when(mockPackageManager.getPackageInfo(TEST_PACKAGE_NAME, 0)).thenReturn(mockPackageInfo);
@@ -80,7 +81,7 @@ public class ErrorIdentifierExtractorTest {
 
     @Test
     public void testSplunkBuildIDButDoesNotExist() {
-        when(mockMetadata.getString(SPLUNK_BUILD_ID)).thenReturn(null);
+        when(mockMetadata.containsKey(SPLUNK_BUILD_ID)).thenReturn(false);
         ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(mockApplication);
         assertNull(extractor.extractInfo().getSplunkBuildID());
     }

--- a/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/ErrorIdentifierExtractorTest.java
@@ -30,10 +30,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ErrorIdentifierExtractorTest {
-    private static final String SPLUNK_UUID_MANIFEST_KEY = "splunk.build_id";
+    private static final String SPLUNK_BUILD_ID = "splunk.build_id";
     private static final String TEST_PACKAGE_NAME = "splunk.test.package.name";
     private static final String TEST_VERSION_CODE = "123";
-    private static final String TEST_UUID = "test-uuid";
+    private static final String TEST_SPLUNK_BUILDID = "test-splunk-build-id";
 
     @Mock private Application mockApplication;
     @Mock private PackageManager mockPackageManager;
@@ -54,7 +54,7 @@ public class ErrorIdentifierExtractorTest {
 
         when(mockPackageManager.getApplicationInfo(TEST_PACKAGE_NAME, PackageManager.GET_META_DATA))
                 .thenReturn(mockApplicationInfo);
-        when(mockMetadata.getString(SPLUNK_UUID_MANIFEST_KEY)).thenReturn(TEST_UUID);
+        when(mockMetadata.getString(SPLUNK_BUILD_ID)).thenReturn(TEST_SPLUNK_BUILDID);
 
         mockPackageInfo.versionCode = 123;
         when(mockPackageManager.getPackageInfo(TEST_PACKAGE_NAME, 0)).thenReturn(mockPackageInfo);
@@ -73,16 +73,16 @@ public class ErrorIdentifierExtractorTest {
     }
 
     @Test
-    public void testGetCustomUUID() {
+    public void testGetSplunkBuildID() {
         ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(mockApplication);
-        assertEquals(TEST_UUID, extractor.extractInfo().getCustomUUID());
+        assertEquals(TEST_SPLUNK_BUILDID, extractor.extractInfo().getSplunkBuildID());
     }
 
     @Test
-    public void testCustomUUIDButDoesNotExist() {
-        when(mockMetadata.getString(SPLUNK_UUID_MANIFEST_KEY)).thenReturn(null);
+    public void testSplunkBuildIDButDoesNotExist() {
+        when(mockMetadata.getString(SPLUNK_BUILD_ID)).thenReturn(null);
         ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(mockApplication);
-        assertNull(extractor.extractInfo().getCustomUUID());
+        assertNull(extractor.extractInfo().getSplunkBuildID());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class ErrorIdentifierExtractorTest {
                 .thenReturn(applicationInfoWithNullMetaData);
 
         ErrorIdentifierExtractor extractor = new ErrorIdentifierExtractor(mockApplication);
-        assertNull(extractor.extractInfo().getCustomUUID());
+        assertNull(extractor.extractInfo().getSplunkBuildID());
     }
 
     @Test
@@ -117,6 +117,6 @@ public class ErrorIdentifierExtractorTest {
         ErrorIdentifierInfo info = extractor.extractInfo();
         assertNull(info.getApplicationId());
         assertEquals(TEST_VERSION_CODE, info.getVersionCode());
-        assertNull(info.getCustomUUID());
+        assertNull(info.getSplunkBuildID());
     }
 }


### PR DESCRIPTION
Renamed all methods, variables and values that pertain to the optional unique identifier field that gets set by the user in the AndroidManifest.xml file and included in crash/error span attributes to splunk build id. Now the field that the user sets, as well as the attribute tag that gets sent to the backend are: `splunk.build_id` 

Also updated the method that retrieves this build ID to handle non string values more gracefully and better debug logging instead of error logging