### PR TITLE
Consolidate build id naming in feature/next-gen branch

### DIFF
--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/internal/RumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/internal/RumConstants.kt
@@ -27,5 +27,5 @@ object RumConstants {
 
     val APPLICATION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("service.application_id")
     val APP_VERSION_CODE_KEY: AttributeKey<String> = AttributeKey.stringKey("service.version_code")
-    val SPLUNK_OLLY_UUID_KEY: AttributeKey<String> = AttributeKey.stringKey("service.o11y.key")
+    val SPLUNK_BUILD_ID: AttributeKey<String> = AttributeKey.stringKey("splunk.build_id")
 }

--- a/common/utils/src/main/java/com/splunk/sdk/utils/ApplicationInfoUtils.kt
+++ b/common/utils/src/main/java/com/splunk/sdk/utils/ApplicationInfoUtils.kt
@@ -56,14 +56,14 @@ class ApplicationInfoUtils {
                 return null
             }
 
-            val metaData = applicationInfo.metaData
-            if (metaData == null) {
+            val metadata = applicationInfo.metaData
+            if (metadata == null) {
                 Logger.d(TAG, "Application metadata bundle is null - no metadata present")
                 return null
             }
 
-            if (metaData.containsKey(SPLUNK_BUILD_ID)) {
-                val value = metaData.get(SPLUNK_BUILD_ID)
+            if (metadata.containsKey(SPLUNK_BUILD_ID)) {
+                val value = metadata.get(SPLUNK_BUILD_ID)
                 if (value == null) {
                     Logger.d(TAG, "Splunk Build ID exists but has null value")
                     return null

--- a/common/utils/src/main/java/com/splunk/sdk/utils/ApplicationInfoUtils.kt
+++ b/common/utils/src/main/java/com/splunk/sdk/utils/ApplicationInfoUtils.kt
@@ -10,7 +10,7 @@ class ApplicationInfoUtils {
     companion object {
 
         private const val TAG = "ErrorIdentifier"
-        private const val SPLUNK_UUID_MANIFEST_KEY = "SPLUNK_O11Y_CUSTOM_UUID"
+        private const val SPLUNK_BUILD_ID = "splunk.build_id"
 
         fun retrieveApplicationId(application: Application): String? {
             val packageManager: PackageManager = application.packageManager
@@ -45,7 +45,7 @@ class ApplicationInfoUtils {
             }
         }
 
-        fun retrieveCustomUUID(application: Application): String? {
+        fun retrieveSplunkBuildID(application: Application): String? {
             val packageManager: PackageManager = application.packageManager
             val applicationInfo: ApplicationInfo?
 
@@ -56,11 +56,24 @@ class ApplicationInfoUtils {
                 return null
             }
 
-            return applicationInfo.metaData?.getString(SPLUNK_UUID_MANIFEST_KEY)?.takeIf {
-                it.isNotEmpty()
-            } ?: run {
-                Logger.e(TAG, "Application MetaData bundle is null or does not contain the UUID")
-                null
+            val metaData = applicationInfo.metaData
+            if (metaData == null) {
+                Logger.d(TAG, "Application metadata bundle is null - no metadata present")
+                return null
+            }
+
+            if (metaData.containsKey(SPLUNK_BUILD_ID)) {
+                val value = metaData.get(SPLUNK_BUILD_ID)
+                if (value == null) {
+                    Logger.d(TAG, "Splunk Build ID exists but has null value")
+                    return null
+                }
+                val buildId = value.toString()
+                Logger.d(TAG, "Found Splunk Build ID: $buildId")
+                return buildId
+            } else {
+                Logger.d(TAG, "Optional Splunk Build ID not found in metadata")
+                return null
             }
         }
     }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/ErrorIdentifierAttributesSpanProcessor.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/ErrorIdentifierAttributesSpanProcessor.kt
@@ -12,12 +12,12 @@ internal class ErrorIdentifierAttributesSpanProcessor(application: Application) 
 
     private var applicationId: String? = null
     private var versionCode: String? = null
-    private var customUUID: String? = null
+    private var splunkBuildId: String? = null
 
     init {
         applicationId = ApplicationInfoUtils.retrieveApplicationId(application)
         versionCode = ApplicationInfoUtils.retrieveVersionCode(application)
-        customUUID = ApplicationInfoUtils.retrieveCustomUUID(application)
+        splunkBuildId = ApplicationInfoUtils.retrieveSplunkBuildID(application)
     }
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
@@ -29,8 +29,8 @@ internal class ErrorIdentifierAttributesSpanProcessor(application: Application) 
             versionCode?.let {
                 span.setAttribute(RumConstants.APP_VERSION_CODE_KEY, it)
             }
-            customUUID?.let {
-                span.setAttribute(RumConstants.SPLUNK_OLLY_UUID_KEY, it)
+            splunkBuildId?.let {
+                span.setAttribute(RumConstants.SPLUNK_BUILD_ID, it)
             }
         }
     }


### PR DESCRIPTION
Mirrors this commit in the main branch:
https://github.com/signalfx/splunk-otel-android/commit/f54871a5c6a43c2b298bd3487554355bf6a34cdf

Renamed all methods, variables and values that pertain to the optional unique identifier field that gets set by the user in the AndroidManifest.xml file and included in crash/error span attributes to splunk build id. Now the field that the user sets, as well as the attribute tag that gets sent to the backend are: splunk.build_id

Also updated the method that retrieves this build ID to handle non string values more gracefully and better debug logging instead of error logging