### PR TITLE
Deprecate disk usage limit

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -84,11 +84,6 @@ class SplunkRumBuilder {
         return this
     }
 
-    fun limitDiskUsageMegabytes(maxUsageMegabytes: Int): SplunkRumBuilder {
-        this.maxUsageMegabytes = maxUsageMegabytes
-        return this
-    }
-
     fun enableSessionBasedSampling(ratio: Double): SplunkRumBuilder {
         if (ratio < 0)
             Logger.w(TAG, "enableSessionBasedSampling(ratio: $ratio) - ratio can not be lower then 0")
@@ -111,6 +106,11 @@ class SplunkRumBuilder {
 
     @Deprecated("This is no longer supported")
     fun enableDiskBuffering(enable: Boolean): SplunkRumBuilder {
+        return this
+    }
+
+    @Deprecated("This is no longer supported")
+    fun limitDiskUsageMegabytes(maxUsageMegabytes: Int): SplunkRumBuilder {
         return this
     }
 


### PR DESCRIPTION
The legacy `limitDiskUsageMegabytes` has been marked as `@Deprecated` and is non-operational, as there is no equivalent in the next generation.