### PR TITLE
MutableAttributes more aligned with OTel

### DIFF
--- a/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
@@ -22,7 +22,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import com.cisco.android.common.utils.extensions.get
 import com.cisco.android.common.utils.runOnUiThread
 import com.splunk.app.R
 import com.splunk.app.databinding.FragmentMenuBinding
@@ -30,10 +29,10 @@ import com.splunk.app.ui.BaseFragment
 import com.splunk.app.ui.httpurlconnection.HttpURLConnectionFragment
 import com.splunk.app.ui.okhttp.OkHttpFragment
 import com.splunk.app.util.FragmentAnimation
-import com.splunk.rum.integration.customtracking.extension.customTracking
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
 import com.splunk.rum.integration.agent.api.extension.splunkRumId
+import com.splunk.rum.integration.customtracking.extension.customTracking
 import com.splunk.rum.integration.navigation.extension.navigation
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -234,7 +233,7 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                 showDoneToast("Remove All Global Attributes")
             }
             viewBinding.getAllGlobalAttributes.id -> {
-                val allAttributes = SplunkRum.instance.globalAttributes.getAll()
+                val allAttributes = SplunkRum.instance.globalAttributes
                 AlertDialog.Builder(context)
                     .setTitle("All Global Attributes")
                     .setMessage(allAttributes.toString())

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/MutableAttributes.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/MutableAttributes.kt
@@ -3,6 +3,7 @@ package com.splunk.rum.integration.agent.api.attributes
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
+import java.util.function.BiConsumer
 
 /**
  * A utility class for managing custom RUM attributes.
@@ -10,7 +11,7 @@ import io.opentelemetry.api.common.AttributesBuilder
 class MutableAttributes(
     @Volatile
     private var attributes: Attributes = Attributes.empty()
-) {
+): Attributes {
 
     /**
      * Retrieves the value associated with the given [AttributeKey].
@@ -18,7 +19,7 @@ class MutableAttributes(
      * @param key the attribute key to retrieve
      * @return the value if present, or null
      */
-    operator fun <T> get(key: AttributeKey<T>): T? = key.let { attributes.get(it) }
+    override operator fun <T> get(key: AttributeKey<T>): T? = key.let { attributes.get(it) }
 
     /**
      * Retrieves the value associated with the given key string.
@@ -131,6 +132,17 @@ class MutableAttributes(
     fun update(updateAttributes: AttributesBuilder.() -> Unit) {
         attributes = attributes.edit(updateAttributes)
     }
+
+    override fun forEach(consumer: BiConsumer<in AttributeKey<*>, in Any>) =
+        attributes.forEach(consumer)
+
+    override fun size(): Int = attributes.size()
+
+    override fun isEmpty(): Boolean = attributes.isEmpty
+
+    override fun asMap(): MutableMap<AttributeKey<*>, Any> = attributes.asMap()
+
+    override fun toBuilder(): AttributesBuilder = attributes.toBuilder()
 
     private inline fun Attributes.edit(block: AttributesBuilder.() -> Unit): Attributes {
         return toBuilder().apply(block).build()

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/processors/GlobalAttributeSpanProcessor.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/processors/GlobalAttributeSpanProcessor.kt
@@ -1,15 +1,15 @@
 package com.splunk.rum.integration.agent.api.internal.processors
 
-import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
 
-class GlobalAttributeSpanProcessor(private val globalAttributes: MutableAttributes) : SpanProcessor {
+class GlobalAttributeSpanProcessor(private val globalAttributes: Attributes) : SpanProcessor {
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
-        span.setAllAttributes(globalAttributes.getAll())
+        span.setAllAttributes(globalAttributes)
     }
 
     override fun isStartRequired(): Boolean {

--- a/integration/customtracking/src/main/java/com/splunk/rum/integration/customtracking/CustomTracking.kt
+++ b/integration/customtracking/src/main/java/com/splunk/rum/integration/customtracking/CustomTracking.kt
@@ -37,7 +37,7 @@ class CustomTracking internal constructor() {
      */
     fun trackCustomEvent(name: String, attributes: MutableAttributes) {
         val tracer = getTracer() ?: return
-        tracer.spanBuilder(name).setAllAttributes(attributes.getAll()).startSpan().end()
+        tracer.spanBuilder(name).setAllAttributes(attributes).startSpan().end()
     }
 
     /**
@@ -82,7 +82,7 @@ class CustomTracking internal constructor() {
         val tracer = getTracer() ?: return
         val spanBuilder = tracer.spanBuilder(throwable.javaClass.simpleName)
         attributes?.let {
-            spanBuilder.setAllAttributes(it.getAll())
+            spanBuilder.setAllAttributes(it)
         }
         spanBuilder.setAttribute(RumConstants.COMPONENT_KEY, RumConstants.COMPONENT_ERROR)
             .startSpan()


### PR DESCRIPTION
Previously, it was not possible to pass `MutableAttributes` to methods expecting an `Attributes` instance.