### PR TITLE
Fix duplicate crash + ANR span bug

### DIFF
--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -108,7 +108,7 @@ class RumInitializer {
         // We are installing the crash reporter ourselves in installCrashReporter.
         // Disabling this one to prevent duplicate spans
         config.disableCrashReporting();
-        config.disableAnrDetection();  // Same with ANR
+        config.disableAnrDetection(); // Same with ANR
 
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);
 

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -105,6 +105,9 @@ class RumInitializer {
         }
 
         config.disableScreenAttributes();
+        // We are installing the crash reporter ourselves in installCrashReporter.
+        // Disabling this one to prevent duplicate spans
+        config.disableCrashReporting();
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);
 
         otelRumBuilder.mergeResource(createSplunkResource());

--- a/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
+++ b/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java
@@ -108,6 +108,8 @@ class RumInitializer {
         // We are installing the crash reporter ourselves in installCrashReporter.
         // Disabling this one to prevent duplicate spans
         config.disableCrashReporting();
+        config.disableAnrDetection();  // Same with ANR
+
         OpenTelemetryRumBuilder otelRumBuilder = OpenTelemetryRum.builder(application, config);
 
         otelRumBuilder.mergeResource(createSplunkResource());

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -61,7 +61,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 @ExtendWith(MockitoExtension.class)

--- a/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
+++ b/splunk-otel-android/src/test/java/com/splunk/rum/RumInitializerTest.java
@@ -59,9 +59,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RumInitializerTest {
 
     static final String APP_NAME = "Sick test app";


### PR DESCRIPTION
**When a crash occurs in the application, the SDK was generating two almost identical spans with the same exception information:**

1) One span with basic attributes
2) Another span that also includes our custom attributes including component="crash", service.application_id, and service.version_code

**The problem was caused by having two separate crash reporters being registered:**

1) The default crash reporter from the version of OpenTelemetryRumBuilder we are using, which is enabled by default in the OtelRumConfig
2) Our custom crash reporter installed in the installCrashReporter method with the CrashComponentExtractor and other custom attributes appended

We do not want this one:
<img width="845" alt="Screenshot 2025-04-11 at 11 40 49 AM" src="https://github.com/user-attachments/assets/7739cdfb-68a0-4a71-93bf-ce57eee73f0e" />

We only want this one:
https://github.com/signalfx/splunk-otel-android/blob/main/splunk-otel-android/src/main/java/com/splunk/rum/RumInitializer.java#L316

To resolve this, we must explicitly disable the default crash reporter by adding config.disableCrashReporting() in the RumInitializer while keeping our custom crash reporter implementation. This prevents the duplicate registration and only keeps the crash reporter the splunk sdk installs with the additional attributes we require

Testing:
Tested with sample app and confirm that crashes now generate a single span with all required attributes
The span correctly includes our custom component="crash" attribute and service.version_code etc 

Did the exact same with ANR which had the same issue