### PR TITLE
Add Convenience API: MutableSpanData + SpanFilter → SpanInterceptor

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
@@ -20,6 +20,19 @@ import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
 import com.splunk.rum.integration.agent.api.user.UserConfiguration
 import io.opentelemetry.sdk.trace.data.SpanData
 
+/**
+ * TODO: Fill in the documentation.
+ *
+ * @property spanInterceptor A function to intercept and optionally modify spans before they are exported.
+ * Can return `null` to drop a span. Default is `null` (no interception).
+ *
+ * If span interception and modification are required, consider using the [toMutableSpanData] extension method:
+ * ```kotlin
+ * val mutableSpanData: MutableSpanData = spanData.toMutableSpanData()
+ * ```
+ * This method allows you to convert a `SpanData` instance into a `MutableSpanData`, enabling you to modify span attributes,
+ * status, and other properties as needed during the interception process.
+ */
 data class AgentConfiguration(
     val endpoint: EndpointConfiguration,
     var appName: String,
@@ -28,7 +41,7 @@ data class AgentConfiguration(
     val enableDebugLogging: Boolean = false,
     val sessionSamplingRate: Double = 1.0, // TODO move to session
     val globalAttributes: MutableAttributes = MutableAttributes(),
-    val spanFilter: ((SpanData) -> SpanData?)? = null,
+    val spanInterceptor: ((SpanData) -> SpanData?)? = null,
     val user: UserConfiguration = UserConfiguration(),
     val session: Any? = null, // TODO,
     val instrumentedProcessName: String? = null,

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -143,7 +143,7 @@ class SplunkRumBuilder {
                 sessionSamplingRate = sessionBasedSampling,
                 globalAttributes = globalAttributes,
                 instrumentedProcessName = instrumentedProcessName,
-                spanFilter = this.spanFilter?.let {
+                spanInterceptor = this.spanFilter?.let {
                     val spanFilterBuilder = SpanFilterBuilder()
                     it.accept(spanFilterBuilder)
                     spanFilterBuilder.toSpanInterceptor()

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
@@ -87,7 +87,7 @@ internal object SplunkRumAgentCore {
         val stateManager = StateManager.obtainInstance(application)
         SessionStartEventManager.obtainInstance(agentIntegration.sessionManager)
 
-        val initializer = OpenTelemetryInitializer(application, agentConfiguration.spanFilter)
+        val initializer = OpenTelemetryInitializer(application, agentConfiguration.spanInterceptor)
             // The GlobalAttributeSpanProcessor must be registered first to ensure that global attributes
             // do not override internal agent attributes required by the backend.
             .addSpanProcessor(GlobalAttributeSpanProcessor(agentConfiguration.globalAttributes))

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/MutableSpanData.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/MutableSpanData.kt
@@ -1,0 +1,82 @@
+package com.splunk.rum.integration.agent.api.spaninterceptor
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.data.EventData
+import io.opentelemetry.sdk.trace.data.LinkData
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.data.StatusData
+
+class MutableSpanData(private val spanData: SpanData) : SpanData {
+
+    private var name: String? = null
+    private var kind: SpanKind? = null
+    private var spanContext: SpanContext? = null
+    private var parentSpanContext: SpanContext? = null
+    private var status: StatusData? = null
+    private var startEpochNanos: Long? = null
+    private var attributes: Attributes? = null
+    private var events: MutableList<EventData>? = null
+    private var links: MutableList<LinkData>? = null
+    private var endEpochNanos: Long? = null
+    private var hasEnded: Boolean? = null
+    private var totalRecordedEvents: Int? = null
+    private var totalRecordedLinks: Int? = null
+    private var totalAttributeCount: Int? = null
+    private var instrumentationLibraryInfo: InstrumentationLibraryInfo? = null
+    private var resource: Resource? = null
+
+    override fun getName(): String = name ?: spanData.name
+    fun setName(value: String) { name = value }
+
+    override fun getKind(): SpanKind = kind ?: spanData.kind
+    fun setKind(value: SpanKind) { kind = value }
+
+    override fun getSpanContext(): SpanContext = spanContext ?: spanData.spanContext
+    fun setSpanContext(value: SpanContext) { spanContext = value }
+
+    override fun getParentSpanContext(): SpanContext = parentSpanContext ?: spanData.parentSpanContext
+    fun setParentSpanContext(value: SpanContext) { parentSpanContext = value }
+
+    override fun getStatus(): StatusData = status ?: spanData.status
+    fun setStatus(value: StatusData) { status = value }
+
+    override fun getStartEpochNanos(): Long = startEpochNanos ?: spanData.startEpochNanos
+    fun setStartEpochNanos(value: Long) { startEpochNanos = value }
+
+    override fun getAttributes(): Attributes = attributes ?: spanData.attributes
+    fun setAttributes(value: Attributes) { attributes = value }
+
+    override fun getEvents(): MutableList<EventData> = events ?: spanData.events.toMutableList()
+    fun setEvents(value: List<EventData>) { events = value.toMutableList() }
+
+    override fun getLinks(): MutableList<LinkData> = links ?: spanData.links.toMutableList()
+    fun setLinks(value: List<LinkData>) { links = value.toMutableList() }
+
+    override fun getEndEpochNanos(): Long = endEpochNanos ?: spanData.endEpochNanos
+    fun setEndEpochNanos(value: Long) { endEpochNanos = value }
+
+    override fun hasEnded(): Boolean = hasEnded ?: spanData.hasEnded()
+    fun setHasEnded(value: Boolean) { hasEnded = value }
+
+    override fun getTotalRecordedEvents(): Int = totalRecordedEvents ?: spanData.totalRecordedEvents
+    fun setTotalRecordedEvents(value: Int) { totalRecordedEvents = value }
+
+    override fun getTotalRecordedLinks(): Int = totalRecordedLinks ?: spanData.totalRecordedLinks
+    fun setTotalRecordedLinks(value: Int) { totalRecordedLinks = value }
+
+    override fun getTotalAttributeCount(): Int = totalAttributeCount ?: spanData.totalAttributeCount
+    fun setTotalAttributeCount(value: Int) { totalAttributeCount = value }
+
+    override fun getInstrumentationLibraryInfo(): InstrumentationLibraryInfo =
+        instrumentationLibraryInfo ?: spanData.instrumentationLibraryInfo
+    fun setInstrumentationLibraryInfo(value: InstrumentationLibraryInfo) {
+        instrumentationLibraryInfo = value
+    }
+
+    override fun getResource(): Resource = resource ?: spanData.resource
+    fun setResource(value: Resource) { resource = value }
+}

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/SpanDataExt.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/SpanDataExt.kt
@@ -1,0 +1,15 @@
+package com.splunk.rum.integration.agent.api.spaninterceptor
+
+import io.opentelemetry.sdk.trace.data.SpanData
+
+/**
+ * Converts this [SpanData] instance into a [MutableSpanData].
+ *
+ * This is a convenience method for clients working with the Agent's
+ * span interception feature, where mutating spans may be necessary for filtering,
+ * enrichment, or transformation.
+ *
+ * @receiver The original [SpanData] to be wrapped in a mutable representation.
+ * @return A [MutableSpanData] instance that reflects the original [SpanData]'s values.
+ */
+fun SpanData.toMutableSpanData(): MutableSpanData = MutableSpanData(this)


### PR DESCRIPTION
- Added `MutableSpanData` and `SpanData.toMutableSpanData(): MutableSpanData` as a convenience API.
- Renamed SpanFilter to SpanInterceptor.