### PR TITLE
Remove deprecated navigation API

### DIFF
--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/extension/SplunkRumExt.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/extension/SplunkRumExt.kt
@@ -21,12 +21,3 @@ import com.splunk.rum.integration.navigation.Navigation
 
 val SplunkRum.navigation: Navigation
     get() = Navigation
-
-@JvmOverloads
-@Deprecated("Use navigation.track(). Argument spanType is ignored.")
-fun SplunkRum.experimentalSetScreenName(screenName: String?, spanType: String = "Created") {
-    if (screenName == null)
-        return
-
-    navigation.track(screenName)
-}


### PR DESCRIPTION
The api is no longer needed because it was already marked as `@Deprecated`.