### PR TITLE
Add attributes before creating a span

### DIFF
--- a/common/otel/src/main/java/com/splunk/sdk/common/otel/logRecord/AndroidLogRecordExporter.kt
+++ b/common/otel/src/main/java/com/splunk/sdk/common/otel/logRecord/AndroidLogRecordExporter.kt
@@ -45,29 +45,30 @@ internal class AndroidLogRecordExporter : LogRecordExporter {
                 .setStartTimestamp(log.timestampEpochNanos, TimeUnit.NANOSECONDS)
 
 
-            if(activeSpan !=null && activeSpan.spanContext.isValid){
+            if(activeSpan != null && activeSpan.spanContext.isValid){
                 spanBuilder.setParent(parentContext)
             }
 
-            val span = spanBuilder.startSpan()
-
             try {
-                span.setAttribute("log.body", log.body.asString())
+                spanBuilder.setAttribute("log.body", log.body.asString())
                 log.attributes.asMap().forEach { (key, value) ->
                     when (value) {
-                        is String -> span.setAttribute(key.key, value)
-                        is Long -> span.setAttribute(key.key, value)
-                        is Double -> span.setAttribute(key.key, value)
-                        is Boolean -> span.setAttribute(key.key, value)
+                        is String -> spanBuilder.setAttribute(key.key, value)
+                        is Long -> spanBuilder.setAttribute(key.key, value)
+                        is Double -> spanBuilder.setAttribute(key.key, value)
+                        is Boolean -> spanBuilder.setAttribute(key.key, value)
                         is List<*> -> {
                             val listValue = value.joinToString(",") { it.toString() }
-                            span.setAttribute(key.key, listValue)
+                            spanBuilder.setAttribute(key.key, listValue)
                         }
-                        else -> span.setAttribute(key.key, value.toString())
+                        else -> spanBuilder.setAttribute(key.key, value.toString())
                     }
                 }
             } finally {
-                span.end(log.timestampEpochNanos, TimeUnit.NANOSECONDS)
+                spanBuilder
+                    .setStartTimestamp(log.timestampEpochNanos, TimeUnit.NANOSECONDS)
+                    .startSpan()
+                    .end(log.timestampEpochNanos, TimeUnit.NANOSECONDS)
             }
         }
 


### PR DESCRIPTION
The log2span translation logic had a bug where it added attributes **after** the span had been started. This caused issues in the `SpanProcessor`, where the `onStart()` callback would receive the span **without** those attributes.