### PR TITLE
Add extension to convert Attributes to MutableAttributes

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/AttributesExt.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/AttributesExt.kt
@@ -1,0 +1,5 @@
+package com.splunk.rum.integration.agent.api.attributes
+
+import io.opentelemetry.api.common.Attributes
+
+fun Attributes.toMutableAttributes() = MutableAttributes(this)

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/AttributesExt.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/AttributesExt.kt
@@ -1,5 +1,29 @@
+/*
+ * Copyright 2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.integration.agent.api.attributes
 
 import io.opentelemetry.api.common.Attributes
 
+/**
+ * Converts this [Attributes] instance into a [MutableAttributes].
+ *
+ * This is a convenience method for clients who need to modify attributes.
+ *
+ * @receiver The original [Attributes] to be wrapped in a mutable representation.
+ * @return A [MutableAttributes] instance that reflects the original [Attributes]' values.
+ */
 fun Attributes.toMutableAttributes() = MutableAttributes(this)

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/MutableSpanData.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/MutableSpanData.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.integration.agent.api.spaninterceptor
 
 import io.opentelemetry.api.common.Attributes

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/SpanDataExt.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/spaninterceptor/SpanDataExt.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.rum.integration.agent.api.spaninterceptor
 
 import io.opentelemetry.sdk.trace.data.SpanData


### PR DESCRIPTION
Similarly to `MutableSpanData` and `SpanDataExt`, a new `AttributesExt` extension was implemented to support easy transition from `Attributes` to `MutableAttributes`.

As part of this PR, missing license headers were also added to few files.