### PR TITLE
POC Legacy module configurations

### DIFF
--- a/integration/agent/api/build.gradle.kts
+++ b/integration/agent/api/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
     implementation(Dependencies.SessionReplay.commonStorage)
     implementation(Dependencies.SessionReplay.commonUtils)
     implementation(project(":common:utils"))
-    implementation(project(":integration:crash"))
-    implementation(project(":integration:anr"))
 
     compileOnly(Dependencies.Android.Compose.ui)
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -20,8 +20,8 @@ import android.app.Application
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.api.SplunkRum.Companion.install
 import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
-import com.splunk.rum.integration.anr.AnrModuleConfiguration
-import com.splunk.rum.integration.crash.CrashModuleConfiguration
+import com.splunk.rum.integration.agent.internal.legacy.LegacyAnrModuleConfiguration
+import com.splunk.rum.integration.agent.internal.legacy.LegacyCrashModuleConfiguration
 import io.opentelemetry.api.common.Attributes
 import java.net.URL
 import java.util.function.Consumer
@@ -170,10 +170,10 @@ class SplunkRumBuilder {
                 },
             ),
             moduleConfigurations = arrayOf(
-                CrashModuleConfiguration(
+                LegacyCrashModuleConfiguration(
                     isEnabled = crashReportingEnabled
                 ),
-                AnrModuleConfiguration(
+                LegacyAnrModuleConfiguration(
                     isEnabled = anrReportingEnabled
                 )
             )

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyAnrModuleConfiguration.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyAnrModuleConfiguration.kt
@@ -1,0 +1,13 @@
+package com.splunk.rum.integration.agent.internal.legacy
+
+import com.splunk.rum.integration.agent.module.ModuleConfiguration
+
+@Deprecated("Only to support legacy API, can be removed with legacy API.")
+class LegacyAnrModuleConfiguration(val isEnabled: Boolean = true)  : ModuleConfiguration {
+
+    override val name: String = "anr"
+
+    override val attributes: List<Pair<String, String>> = listOf(
+        "enabled" to isEnabled.toString()
+    )
+}

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyCrashModuleConfiguration.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyCrashModuleConfiguration.kt
@@ -5,7 +5,7 @@ import com.splunk.rum.integration.agent.module.ModuleConfiguration
 @Deprecated("Only to support legacy API, can be removed with legacy API.")
 class LegacyCrashModuleConfiguration(val isEnabled: Boolean = true) : ModuleConfiguration {
 
-    override val name: String = "crash_legacy"
+    override val name: String = "crash"
 
     override val attributes: List<Pair<String, String>> = listOf(
         "enabled" to isEnabled.toString()

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyCrashModuleConfiguration.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/legacy/LegacyCrashModuleConfiguration.kt
@@ -1,0 +1,13 @@
+package com.splunk.rum.integration.agent.internal.legacy
+
+import com.splunk.rum.integration.agent.module.ModuleConfiguration
+
+@Deprecated("Only to support legacy API, can be removed with legacy API.")
+class LegacyCrashModuleConfiguration(val isEnabled: Boolean = true) : ModuleConfiguration {
+
+    override val name: String = "crash_legacy"
+
+    override val attributes: List<Pair<String, String>> = listOf(
+        "enabled" to isEnabled.toString()
+    )
+}

--- a/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrIntegration.kt
+++ b/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrIntegration.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.extension.find
+import com.splunk.rum.integration.agent.internal.legacy.LegacyAnrModuleConfiguration
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.anr.AnrInstrumentation
@@ -32,7 +33,6 @@ internal object AnrIntegration {
     private const val MODULE_NAME = "anr"
 
     private val defaultModuleConfiguration = AnrModuleConfiguration()
-    private var moduleConfiguration = defaultModuleConfiguration
 
     init {
         Logger.d(TAG, "init()")
@@ -51,11 +51,13 @@ internal object AnrIntegration {
             moduleConfigurations: List<ModuleConfiguration>
         ) {
             Logger.d(TAG, "onInstall()")
-            moduleConfiguration = moduleConfigurations.find<AnrModuleConfiguration>() ?: defaultModuleConfiguration
+            val isEnabled = moduleConfigurations.find<LegacyAnrModuleConfiguration>()?.isEnabled
+                ?: moduleConfigurations.find<AnrModuleConfiguration>()?.isEnabled
+                ?: defaultModuleConfiguration.isEnabled
 
             AgentIntegration.registerModuleInitializationEnd(MODULE_NAME)
 
-            if (moduleConfiguration.isEnabled) {
+            if (isEnabled) {
                 Logger.d(TAG, "Installing ANR reporter")
                 val anrDetectorInstrumentation = AnrInstrumentation()
                 anrDetectorInstrumentation.addAttributesExtractor(AnrAttributesExtractor())

--- a/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashIntegration.kt
+++ b/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashIntegration.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.extension.find
+import com.splunk.rum.integration.agent.internal.legacy.LegacyCrashModuleConfiguration
 import com.splunk.rum.integration.agent.module.ModuleConfiguration
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation
@@ -32,7 +33,6 @@ internal object CrashIntegration {
     private const val MODULE_NAME = "crash"
 
     private val defaultModuleConfiguration = CrashModuleConfiguration()
-    private var moduleConfiguration = defaultModuleConfiguration
 
     init {
         Logger.d(TAG, "init()")
@@ -51,11 +51,14 @@ internal object CrashIntegration {
             moduleConfigurations: List<ModuleConfiguration>
         ) {
             Logger.d(TAG, "onInstall()")
-            moduleConfiguration = moduleConfigurations.find<CrashModuleConfiguration>() ?: defaultModuleConfiguration
+
+            val isEnabled = moduleConfigurations.find<LegacyCrashModuleConfiguration>()?.isEnabled
+                ?: moduleConfigurations.find<CrashModuleConfiguration>()?.isEnabled
+                ?: defaultModuleConfiguration.isEnabled
 
             AgentIntegration.registerModuleInitializationEnd(MODULE_NAME)
 
-            if (moduleConfiguration.isEnabled){
+            if (isEnabled) {
                 Logger.d(TAG, "Installing crash reporter")
                 val crashReporterInstrumentation = CrashReporterInstrumentation()
                 crashReporterInstrumentation.addAttributesExtractor(CrashAttributesExtractor())


### PR DESCRIPTION
We can not have agent modules depending on instrumentation modules. This is a PR addressing the legacy crash and anr mapping APIs without having those dependencies