### PR TITLE
Add check codestyle job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,17 @@ jobs:
         run: touch ./local.properties; ./gradlew check javadoc assemble
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.0.7
-      - name: Run KtLint
+  check_codestyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Set up JDK 17 for running Gradle
+        uses: actions/setup-java@v4.5.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Run ktlint
         run: ./gradlew ktlintCheck
   check_links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The ktlint check, or any other code style checks, should run in a separate job from the build.