### PR TITLE
Add tests for legacy custom tracking APIs + some necessary cleanup

### DIFF
--- a/app/src/main/java/com/splunk/app/ui/customtracking/CustomTrackingFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/customtracking/CustomTrackingFragment.kt
@@ -116,9 +116,9 @@ class CustomTrackingFragment : BaseFragment<FragmentCustomTrackingBinding>() {
         }
 
         workflowSpan?.apply {
-            setAttribute("workflow.start.time", System.currentTimeMillis())
-            Thread.sleep(125) // Simulate processing time
-            setAttribute("workflow.end.time", System.currentTimeMillis())
+            val startTime = System.currentTimeMillis()
+            setAttribute("workflow.start.time", startTime)
+            setAttribute("workflow.end.time", startTime + 125) // Added 125ms processing time in end time.
             end()
         }
     }

--- a/app/src/main/java/com/splunk/app/ui/customtracking/CustomTrackingFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/customtracking/CustomTrackingFragment.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.app.ui.customtracking
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.splunk.app.R
+import com.splunk.app.databinding.FragmentCustomTrackingBinding
+import com.splunk.app.ui.BaseFragment
+import com.splunk.app.util.ApiVariant
+import com.splunk.app.util.CommonUtils
+import com.splunk.rum.integration.agent.api.SplunkRum
+import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
+import com.splunk.rum.integration.customtracking.extension.addRumEvent
+import com.splunk.rum.integration.customtracking.extension.addRumException
+import com.splunk.rum.integration.customtracking.extension.customTracking
+import com.splunk.rum.integration.customtracking.extension.startWorkflow
+import com.splunk.rum.integration.navigation.extension.navigation
+
+class CustomTrackingFragment : BaseFragment<FragmentCustomTrackingBinding>() {
+
+    override val titleRes: Int = R.string.customtracking_title
+    override val viewBindingCreator: (LayoutInflater, ViewGroup?, Boolean) -> FragmentCustomTrackingBinding
+        get() = FragmentCustomTrackingBinding::inflate
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Latest APIs
+        viewBinding.trackCustomEvent.setOnClickListener(onClickListener)
+        viewBinding.trackWorkflow.setOnClickListener(onClickListener)
+        viewBinding.trackException.setOnClickListener(onClickListener)
+        viewBinding.trackExceptionWithAttributes.setOnClickListener(onClickListener)
+
+        // Legacy APIs
+        viewBinding.trackCustomEventLegacy.setOnClickListener(onClickListener)
+        viewBinding.trackWorkflowLegacy.setOnClickListener(onClickListener)
+        viewBinding.trackExceptionLegacy.setOnClickListener(onClickListener)
+        viewBinding.trackExceptionWithAttributesLegacy.setOnClickListener(onClickListener)
+
+        SplunkRum.instance.navigation.track("CustomTracking")
+    }
+
+    private val onClickListener = View.OnClickListener {
+        when (it.id) {
+            // Latest APIs
+            viewBinding.trackCustomEvent.id -> {
+                SplunkRum.instance.customTracking.trackCustomEvent("TestEvent", getTestAttributes())
+                CommonUtils.showDoneToast(context, "Track Custom Event")
+            }
+
+            viewBinding.trackWorkflow.id -> {
+                simulateWorkflow(ApiVariant.NEXTGEN)
+                CommonUtils.showDoneToast(context, "Track Workflow")
+            }
+
+            viewBinding.trackException.id -> {
+                SplunkRum.instance.customTracking.trackException(getTestException("Custom Exception To Be Tracked"))
+                CommonUtils.showDoneToast(context, "Track Exception")
+            }
+
+            viewBinding.trackExceptionWithAttributes.id -> {
+                SplunkRum.instance.customTracking.trackException(
+                    getTestException("Custom Exception (with attributes) To Be Tracked"),
+                    getTestAttributes())
+
+                CommonUtils.showDoneToast(context, "Track Exception with Attributes")
+            }
+
+            // Legacy APIs
+            viewBinding.trackCustomEventLegacy.id -> {
+                SplunkRum.instance.addRumEvent("TestEvent", getTestAttributes())
+                CommonUtils.showDoneToast(context, "Track Custom Event (Legacy)")
+            }
+
+            viewBinding.trackWorkflowLegacy.id -> {
+                simulateWorkflow(ApiVariant.LEGACY)
+                CommonUtils.showDoneToast(context, "Track Workflow (Legacy)")
+            }
+
+            viewBinding.trackExceptionLegacy.id -> {
+                SplunkRum.instance.addRumException(getTestException("Custom Exception To Be Tracked"))
+                CommonUtils.showDoneToast(context, "Track Exception (Legacy)")
+            }
+
+            viewBinding.trackExceptionWithAttributesLegacy.id -> {
+                SplunkRum.instance.addRumException(
+                    getTestException("Custom Exception (with attributes) To Be Tracked"),
+                    getTestAttributes())
+
+                CommonUtils.showDoneToast(context, "Track Exception with Attributes (Legacy)")
+            }
+        }
+    }
+
+    private fun simulateWorkflow(implementationType: ApiVariant) {
+        val workflowSpan = when (implementationType) {
+            ApiVariant.NEXTGEN -> SplunkRum.instance.customTracking.trackWorkflow("Test Workflow")
+            ApiVariant.LEGACY -> SplunkRum.instance.startWorkflow("Test Workflow")
+        }
+
+        workflowSpan?.apply {
+            setAttribute("workflow.start.time", System.currentTimeMillis())
+            Thread.sleep(125) // Simulate processing time
+            setAttribute("workflow.end.time", System.currentTimeMillis())
+            end()
+        }
+    }
+
+    private fun getTestAttributes(): MutableAttributes = MutableAttributes().also { attributes ->
+        attributes["attribute.one"] = "value1"
+        attributes["attribute.two"] = "12345"
+    }
+
+    private fun getTestException(message: String): Exception {
+        val e = Exception(message)
+        e.stackTrace = arrayOf(
+            StackTraceElement("android.fake.Crash", "crashMe", "NotARealFile.kt", 12),
+            StackTraceElement("android.fake.Class", "foo", "NotARealFile.kt", 34),
+            StackTraceElement("android.fake.Main", "main", "NotARealFile.kt", 56)
+        )
+        return e
+    }
+}

--- a/app/src/main/java/com/splunk/app/ui/httpurlconnection/HttpURLConnectionFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/httpurlconnection/HttpURLConnectionFragment.kt
@@ -21,18 +21,16 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import com.cisco.android.common.utils.runOnBackgroundThread
-import com.cisco.android.common.utils.runOnUiThread
 import com.splunk.app.R
 import com.splunk.app.databinding.FragmentHttpUrlConnectionBinding
 import com.splunk.app.ui.BaseFragment
+import com.splunk.app.util.CommonUtils
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.navigation.extension.navigation
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.concurrent.Executors
 
 class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>() {
 
@@ -42,10 +40,8 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // Schedule thread that closes un-ended spans for edge cases
-        val executor = Executors.newSingleThreadScheduledExecutor()
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewBinding.customUrlGet.setOnClickListener { customUrlGet() }
@@ -66,7 +62,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
      */
     fun customUrlGet() {
         executeGet(viewBinding.customUrl.text.toString())
-        showDoneToast("customUrlGet")
+        CommonUtils.showDoneToast(context, "Custom Url Get")
     }
 
     /**
@@ -74,7 +70,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
      */
     fun successfulGet() {
         executeGet("https://httpbin.org/get")
-        showDoneToast("successfulGet")
+        CommonUtils.showDoneToast(context, "Successful Get")
     }
 
     /**
@@ -84,7 +80,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
      */
     fun getWithoutInputStream() {
         executeGet("https://httpbin.org/get", false)
-        showDoneToast("getWithoutInputStream")
+        CommonUtils.showDoneToast(context, "Get Without InputStream")
     }
 
     /**
@@ -96,7 +92,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
         executeGet("https://google.com")
         executeGet("https://android.com")
         executeGet("https://httpbin.org/headers")
-        showDoneToast("fourConcurrentGetRequests")
+        CommonUtils.showDoneToast(context, "Four Concurrent Get Requests")
     }
 
     /**
@@ -105,7 +101,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
      */
     fun sustainedConnection() {
         executeGet("https://httpbin.org/get", false, false)
-        showDoneToast("sustainedConnection")
+        CommonUtils.showDoneToast(context, "Sustained Connection")
     }
 
     /**
@@ -114,7 +110,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
      */
     fun stalledRequest() {
         executeGet("https://httpbin.org/get", false, true, true)
-        showDoneToast("stalledRequest")
+        CommonUtils.showDoneToast(context, "Stalled Request")
     }
 
     /**
@@ -134,7 +130,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
                 "?Server-Timing=traceparent;desc=\"00-00000000000000000000000000000001-0000000000000001-01\"" +
                 "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-01\"")
 
-        showDoneToast("serverTimingHeaderInResponse")
+        CommonUtils.showDoneToast(context, "Server-Timing Header In Response")
     }
 
     private fun executeGet(inputUrl: String, getInputStream: Boolean = true, disconnect: Boolean = true, stallRequest: Boolean = false) {
@@ -173,7 +169,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
                 val readError = errorStream.bufferedReader().use { it.readText() }
                 Log.v(TAG, "response code: " + responseCode + " response message: " + responseMessage +
                     " ErrorStream: " + readError)
-                showDoneToast("unSuccessfulGet")
+                CommonUtils.showDoneToast(context, "UnSuccessful Get")
             } catch (e: IOException) {
                 e.printStackTrace()
             } finally {
@@ -200,18 +196,12 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
                 val readInput = inputStream.bufferedReader().use { it.readText() }
                 Log.v(TAG, "response code: " + responseCode + " response message: " + responseMessage +
                     " InputStream: " + readInput)
-                showDoneToast("post")
+                CommonUtils.showDoneToast(context, "Post")
             } catch (e: IOException) {
                 e.printStackTrace()
             } finally {
                 connection.disconnect()
             }
-        }
-    }
-
-    private fun showDoneToast(methodName: String) {
-        runOnUiThread {
-            Toast.makeText(context, getString(R.string.http_toast, methodName), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
@@ -21,19 +21,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
-import com.cisco.android.common.utils.runOnUiThread
 import com.splunk.app.R
 import com.splunk.app.databinding.FragmentMenuBinding
 import com.splunk.app.ui.BaseFragment
+import com.splunk.app.ui.customtracking.CustomTrackingFragment
 import com.splunk.app.ui.httpurlconnection.HttpURLConnectionFragment
 import com.splunk.app.ui.okhttp.OkHttpFragment
 import com.splunk.app.ui.webview.WebViewFragment
+import com.splunk.app.util.ApiVariant
+import com.splunk.app.util.CommonUtils
 import com.splunk.app.util.FragmentAnimation
 import com.splunk.rum.integration.agent.api.SplunkRum
-import com.splunk.rum.integration.agent.api.attributes.MutableAttributes
 import com.splunk.rum.integration.agent.api.extension.splunkRumId
-import com.splunk.rum.integration.customtracking.extension.customTracking
 import com.splunk.rum.integration.navigation.extension.navigation
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -61,10 +60,7 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
         viewBinding.httpurlconnection.setOnClickListener(onClickListener)
         viewBinding.webViewNextgen.setOnClickListener(onClickListener)
         viewBinding.webViewLegacy.setOnClickListener(onClickListener)
-        viewBinding.trackCustomEvent.setOnClickListener(onClickListener)
-        viewBinding.trackWorkflow.setOnClickListener(onClickListener)
-        viewBinding.trackException.setOnClickListener(onClickListener)
-        viewBinding.trackExceptionWithAttributes.setOnClickListener(onClickListener)
+        viewBinding.menuCustomTrackingButton.setOnClickListener(onClickListener)
 
         viewBinding.setStringAttribute.setOnClickListener(onClickListener)
         viewBinding.setLongAttribute.setOnClickListener(onClickListener)
@@ -135,88 +131,48 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                 navigateTo(HttpURLConnectionFragment(), FragmentAnimation.FADE)
             viewBinding.webViewNextgen.id -> {
                 val args = Bundle().apply {
-                    putString("IMPLEMENTATION_TYPE", "nextgen")
+                    putString("API_VARIANT", ApiVariant.NEXTGEN.name)
                 }
                 navigateTo(WebViewFragment(), FragmentAnimation.FADE, args)
             }
             viewBinding.webViewLegacy.id -> {
                 val args = Bundle().apply {
-                    putString("IMPLEMENTATION_TYPE", "legacy")
+                    putString("API_VARIANT", ApiVariant.LEGACY.name)
                 }
                 navigateTo(WebViewFragment(), FragmentAnimation.FADE, args)
             }
-            viewBinding.trackCustomEvent.id -> {
-                val testAttributes = MutableAttributes().also { attributes ->
-                    attributes["attribute.one"] = "value1"
-                    attributes["attribute.two"] = "12345"
-                }
-
-                SplunkRum.instance.customTracking.trackCustomEvent("TestEvent", testAttributes)
-                showDoneToast("Track Custom Event, Done!")
-            }
-            viewBinding.trackWorkflow.id -> {
-                val workflowSpan = SplunkRum.instance.customTracking.trackWorkflow("Test Workflow")
-                workflowSpan?.setAttribute("workflow.start.time", System.currentTimeMillis())
-                // Simulate some processing time
-                Thread.sleep(125)
-                workflowSpan?.setAttribute("workflow.end.time", System.currentTimeMillis())
-                workflowSpan?.end()
-                showDoneToast("Track Workflow, Done!")
-            }
-            viewBinding.trackException.id -> {
-                val e = Exception("Custom Exception To Be Tracked")
-                e.stackTrace = arrayOf(
-                    StackTraceElement("android.fake.Crash", "crashMe", "NotARealFile.kt", 12),
-                    StackTraceElement("android.fake.Class", "foo", "NotARealFile.kt", 34),
-                    StackTraceElement("android.fake.Main", "main", "NotARealFile.kt", 56)
-                )
-                SplunkRum.instance.customTracking.trackException(e)
-                showDoneToast("Track Exception, Done!")
-            }
-            viewBinding.trackExceptionWithAttributes.id -> {
-                val e = Exception("Custom Exception (with attributes) To Be Tracked")
-                e.stackTrace = arrayOf(
-                    StackTraceElement("android.fake.Crash", "crashMe", "NotARealFile.kt", 12),
-                    StackTraceElement("android.fake.Class", "foo", "NotARealFile.kt", 34),
-                    StackTraceElement("android.fake.Main", "main", "NotARealFile.kt", 56)
-                )
-                val testAttributes = MutableAttributes().also { attributes ->
-                    attributes["attribute.one"] = "value1"
-                    attributes["attribute.two"] = "12345"
-                }
-
-                SplunkRum.instance.customTracking.trackException(e, testAttributes)
-                showDoneToast("Track Exception with Attributes")
+            viewBinding.menuCustomTrackingButton.id -> {
+                navigateTo(CustomTrackingFragment(), FragmentAnimation.FADE)
             }
             viewBinding.setStringAttribute.id -> {
                 SplunkRum.instance.globalAttributes["stringKey"] = "String Value"
-                showDoneToast("Set String Global Attribute")
+                CommonUtils.showDoneToast(context, "Set String Global Attribute")
             }
             viewBinding.setLongAttribute.id -> {
                 SplunkRum.instance.globalAttributes["longKey"] = 12345L
-                showDoneToast("Set Long Global Attribute")
+                CommonUtils.showDoneToast(context, "Set Long Global Attribute")
             }
             viewBinding.setDoubleAttribute.id -> {
                 SplunkRum.instance.globalAttributes["doubleKey"] = 123.45
-                showDoneToast("Set Double Global Attribute")
+                CommonUtils.showDoneToast(context, "Set Double Global Attribute")
             }
             viewBinding.setBooleanAttribute.id -> {
                 SplunkRum.instance.globalAttributes["booleanKey"] = true
-                showDoneToast("Set Boolean Global Attribute")
+                CommonUtils.showDoneToast(context, "Set Boolean Global Attribute")
             }
             viewBinding.setGenericAttribute.id -> {
                 val key = AttributeKey.stringKey("genericKey")
                 SplunkRum.instance.globalAttributes[key] = "Generic Value"
-                showDoneToast("Set Generic Global Attribute")
+                CommonUtils.showDoneToast(context, "Set Generic Global Attribute")
             }
             viewBinding.removeStringAttribute.id -> {
                 SplunkRum.instance.globalAttributes.remove("stringKey")
-                showDoneToast("Remove String Global Attribute")
+                CommonUtils.showDoneToast(context, "Remove String Global Attribute")
             }
             viewBinding.removeGenericAttribute.id -> {
                 val key = AttributeKey.stringKey("genericKey")
                 SplunkRum.instance.globalAttributes.remove(key)
-                showDoneToast("Remove Generic Global Attribute")
+                CommonUtils.showDoneToast(context, "Remove Generic Global Attribute")
             }
             viewBinding.getStringAttribute.id -> {
                 val value: String? = SplunkRum.instance.globalAttributes["stringKey"]
@@ -243,11 +199,11 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                     AttributeKey.longKey("setAllLong"), 9876L
                 )
                 SplunkRum.instance.globalAttributes.setAll(globalAttributes)
-                showDoneToast("Set All Global Attributes")
+                CommonUtils.showDoneToast(context, "Set All Global Attributes")
             }
             viewBinding.removeAllGlobalAttributes.id -> {
                 SplunkRum.instance.globalAttributes.removeAll()
-                showDoneToast("Remove All Global Attributes")
+                CommonUtils.showDoneToast(context, "Remove All Global Attributes")
             }
             viewBinding.getAllGlobalAttributes.id -> {
                 val allAttributes = SplunkRum.instance.globalAttributes
@@ -266,7 +222,7 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
             viewBinding.legacySetGlobalAttribute.id -> {
                 val key = AttributeKey.stringKey("legacyKey")
                 SplunkRum.instance.setGlobalAttribute(key, "LegacyVal")
-                showDoneToast("Set Global Attribute using legacy API")
+                CommonUtils.showDoneToast(context, "Set Global Attribute using legacy API")
             }
 
             viewBinding.legacyUpdateGlobalAttributes.id -> {
@@ -275,14 +231,8 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
                         .put(AttributeKey.longKey("legacyUpdate2"), 54321L)
                         .put(AttributeKey.booleanKey("legacyUpdate3"), false)
                 }
-                showDoneToast("Updated Global Attributes using legacy API")
+                CommonUtils.showDoneToast(context, "Updated Global Attributes using legacy API")
             }
-        }
-    }
-
-    private fun showDoneToast(message: String) {
-        runOnUiThread {
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/com/splunk/app/ui/okhttp/OkHttpFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/okhttp/OkHttpFragment.kt
@@ -22,13 +22,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import com.cisco.android.common.utils.extensions.safeSchedule
 import com.cisco.android.common.utils.runOnBackgroundThread
-import com.cisco.android.common.utils.runOnUiThread
 import com.splunk.app.R
 import com.splunk.app.databinding.FragmentOkhttpBinding
 import com.splunk.app.ui.BaseFragment
+import com.splunk.app.util.CommonUtils
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.navigation.extension.navigation
 import io.opentelemetry.api.trace.Span
@@ -123,7 +122,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
      */
     fun synchronousGet() {
         executeGetRequest("https://publicobject.com/helloworld.txt")
-        showDoneToast("synchronousGet")
+        CommonUtils.showDoneToast(context, "Synchronous Get")
     }
 
     /**
@@ -133,7 +132,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
      */
     fun asynchronousGet() {
         executeAsynchronousGet("https://httpbin.org/robots.txt")
-        showDoneToast("asynchronousGet")
+        CommonUtils.showDoneToast(context, "Asynchronous Get")
     }
 
     /**
@@ -143,7 +142,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         val url = "https://httpbin.org/headers"
         executeAsynchronousGet(url)
         executeAsynchronousGet(url)
-        showDoneToast("concurrentAsynchronousGet")
+        CommonUtils.showDoneToast(context, "Concurrent Asynchronous Get")
     }
 
     /**
@@ -200,7 +199,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         }
         lock.await()
         span.end()
-        showDoneToast("parentContextPropagationInAsyncGet")
+        CommonUtils.showDoneToast(context, "Parent Context Propagation In Async Get")
     }
 
     /**
@@ -208,7 +207,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
      */
     fun unsuccessfulGet() {
         executeGetRequest("https://httpbin.org/status/404")
-        showDoneToast("unsuccessfulGet")
+        CommonUtils.showDoneToast(context, "Unsuccessful Get")
     }
 
     /**
@@ -217,7 +216,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
      */
     fun retryRequest() {
         executeGetRequest("https://httpbin.org/status/503", true)
-        showDoneToast("retryRequest")
+        CommonUtils.showDoneToast(context, "Retry Request")
     }
 
     /**
@@ -243,7 +242,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
             }
         }
 
-        showDoneToast("multipleHeaders")
+        CommonUtils.showDoneToast(context, "Multiple Headers")
     }
 
     /**
@@ -270,7 +269,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
                     "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-01\""
         )
 
-        showDoneToast("serverTimingHeaderInResponse")
+        CommonUtils.showDoneToast(context, "Server-Timing Header In Response")
     }
 
     /**
@@ -288,7 +287,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         |""".trimMargin()
 
         executePostRequest("https://api.github.com/markdown/raw", postBody.toRequestBody(MEDIA_TYPE_MARKDOWN))
-        showDoneToast("postMarkdown")
+        CommonUtils.showDoneToast(context, "Post Markdown")
     }
 
     /**
@@ -317,7 +316,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         }
 
         executePostRequest("https://api.github.com/markdown/raw", requestBody)
-        showDoneToast("postStreaming")
+        CommonUtils.showDoneToast(context, "Post Streaming")
     }
 
     /**
@@ -338,7 +337,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         )
 
         executePostRequest("https://api.github.com/markdown/raw", file.asRequestBody(MEDIA_TYPE_MARKDOWN))
-        showDoneToast("postFile")
+        CommonUtils.showDoneToast(context, "Post File")
     }
 
     /**
@@ -351,7 +350,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
             .build()
 
         executePostRequest("https://en.wikipedia.org/w/index.php", formBody)
-        showDoneToast("postFormParameters")
+        CommonUtils.showDoneToast(context, "Post Form Parameters")
     }
 
     /**
@@ -373,7 +372,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
 
         val headers = mapOf("Authorization" to "Client-ID $IMGUR_CLIENT_ID")
         executePostRequest("https://api.imgur.com/3/image", requestBody, headers)
-        showDoneToast("postMutlipartRequest")
+        CommonUtils.showDoneToast(context, "Post Mutlipart Request")
     }
 
     /**
@@ -387,7 +386,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         runOnBackgroundThread {
             try {
                 client.newCall(request).execute()
-                showDoneToast("networkError")
+                CommonUtils.showDoneToast(context, "Network Error")
             } catch (e: IOException) {
                 e.printStackTrace()
             }
@@ -434,7 +433,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
             }
 
             Log.v(TAG, "Response 2 equals Response 1? " + (response1Body == response2Body))
-            showDoneToast("responseCaching")
+            CommonUtils.showDoneToast(context, "Response Caching")
         }
     }
 
@@ -479,7 +478,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
                         (System.nanoTime() - startNanos) / 1e9f, e
                     )
                 )
-                showDoneToast("canceledCall")
+                CommonUtils.showDoneToast(context, "Canceled Call")
             }
         }
     }
@@ -561,12 +560,6 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
 
                 Log.v(TAG, (response.body?.string() ?: "null"))
             }
-        }
-    }
-
-    private fun showDoneToast(methodName: String) {
-        runOnUiThread {
-            Toast.makeText(context, getString(R.string.http_toast, methodName), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/splunk/app/ui/webview/WebViewFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/webview/WebViewFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import com.splunk.app.R
 import com.splunk.app.databinding.FragmentWebViewBinding
 import com.splunk.app.ui.BaseFragment
+import com.splunk.app.util.ApiVariant
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.navigation.extension.navigation
 import com.splunk.rum.integration.webview.extension.integrateWithBrowserRum
@@ -40,17 +41,20 @@ class WebViewFragment : BaseFragment<FragmentWebViewBinding>() {
 
         viewBinding.webView.settings.javaScriptEnabled = true
 
-        val implementationType = arguments?.getString("IMPLEMENTATION_TYPE")
+        val apiVariant = arguments?.getString("API_VARIANT")?.let { ApiVariant.valueOf(it) }
 
-        when (implementationType) {
-            "nextgen" -> {
+        when (apiVariant) {
+            ApiVariant.NEXTGEN -> {
                 SplunkRum.instance.webViewNativeBridge.integrateWithBrowserRum(viewBinding.webView)
                 Log.d(TAG, "Nextgen integrateWithBrowserRum API called")
             }
-            "legacy" -> {
+
+             ApiVariant.LEGACY -> {
                 SplunkRum.instance.integrateWithBrowserRum(viewBinding.webView)
                 Log.d(TAG, "Legacy integrateWithBrowserRum API called")
             }
+
+            null -> Log.e(TAG, "WebView not integrated with Browser RUM due to missing API_VARIANT argument.")
         }
 
         viewBinding.webView.loadUrl("file:///android_asset/webview_content.html")

--- a/app/src/main/java/com/splunk/app/util/ApiVariant.kt
+++ b/app/src/main/java/com/splunk/app/util/ApiVariant.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.app.util
 
 enum class ApiVariant {

--- a/app/src/main/java/com/splunk/app/util/ApiVariant.kt
+++ b/app/src/main/java/com/splunk/app/util/ApiVariant.kt
@@ -1,0 +1,6 @@
+package com.splunk.app.util
+
+enum class ApiVariant {
+    NEXTGEN,
+    LEGACY
+}

--- a/app/src/main/java/com/splunk/app/util/CommonUtils.kt
+++ b/app/src/main/java/com/splunk/app/util/CommonUtils.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.app.util
 
 import android.content.Context

--- a/app/src/main/java/com/splunk/app/util/CommonUtils.kt
+++ b/app/src/main/java/com/splunk/app/util/CommonUtils.kt
@@ -1,0 +1,19 @@
+package com.splunk.app.util
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import com.cisco.android.common.utils.runOnUiThread
+import com.splunk.app.R
+
+object CommonUtils {
+    fun showDoneToast(context: Context?, message: String) {
+        if (context == null) {
+            Log.e("CommonUtils", "Context is null while attempting to show a toast.")
+            return
+        }
+        runOnUiThread {
+            Toast.makeText(context, context.getString(R.string.http_toast, message), Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_custom_tracking.xml
+++ b/app/src/main/res/layout/fragment_custom_tracking.xml
@@ -1,0 +1,136 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/scroller"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/custom_tracking_title"
+            style="@style/Header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_tracking_title"
+            android:textSize="25sp"
+            android:textStyle="bold"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/custom_tracking_latest_api_title"
+            style="@style/Header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/custom_tracking_latest_api_title"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintTop_toBottomOf="@id/custom_tracking_title"/>
+
+
+        <TextView
+            android:id="@+id/track_custom_event"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_custom_event"
+            app:layout_constraintTop_toBottomOf="@id/custom_tracking_latest_api_title" />
+
+        <TextView
+            android:id="@+id/track_workflow"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_workflow"
+            app:layout_constraintTop_toBottomOf="@id/track_custom_event" />
+
+        <TextView
+            android:id="@+id/track_exception"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_exception"
+            app:layout_constraintTop_toBottomOf="@id/track_workflow" />
+
+        <TextView
+            android:id="@+id/track_exception_with_attributes"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_exception_with_attributes"
+            app:layout_constraintTop_toBottomOf="@id/track_exception" />
+
+        <TextView
+            android:id="@+id/custom_tracking_legacy_api_title"
+            style="@style/Header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/custom_tracking_legacy_api_title"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintTop_toBottomOf="@id/track_exception_with_attributes"/>
+
+
+        <TextView
+            android:id="@+id/track_custom_event_legacy"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_custom_event"
+            app:layout_constraintTop_toBottomOf="@id/custom_tracking_legacy_api_title" />
+
+        <TextView
+            android:id="@+id/track_workflow_legacy"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_workflow"
+            app:layout_constraintTop_toBottomOf="@id/track_custom_event_legacy" />
+
+        <TextView
+            android:id="@+id/track_exception_legacy"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_exception"
+            app:layout_constraintTop_toBottomOf="@id/track_workflow_legacy" />
+
+        <TextView
+            android:id="@+id/track_exception_with_attributes_legacy"
+            style="@style/Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/track_exception_with_attributes"
+            app:layout_constraintTop_toBottomOf="@id/track_exception_legacy"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -185,60 +185,28 @@
 			app:layout_constraintTop_toBottomOf="@id/web_view_nextgen" />
 
 		<TextView
-			android:id="@+id/custom_tracking_title"
+			android:id="@+id/menu_custom_tracking_title"
 			style="@style/Header"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
-			android:text="@string/menu_custom_tracking_title"
+			android:text="@string/custom_tracking_title"
 			android:textSize="18sp"
 			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@+id/web_view_legacy" />
 
 
 		<TextView
-			android:id="@+id/track_custom_event"
+			android:id="@+id/menu_custom_tracking_button"
 			style="@style/Button"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginLeft="20dp"
 			android:layout_marginTop="20dp"
 			android:layout_marginRight="20dp"
-			android:text="@string/menu_custom_event"
-			app:layout_constraintTop_toBottomOf="@id/custom_tracking_title" />
+			android:text="@string/custom_tracking_title"
+			app:layout_constraintTop_toBottomOf="@id/menu_custom_tracking_title" />
 
-		<TextView
-			android:id="@+id/track_workflow"
-			style="@style/Button"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginLeft="20dp"
-			android:layout_marginTop="5dp"
-			android:layout_marginRight="20dp"
-			android:text="@string/menu_workflow"
-			app:layout_constraintTop_toBottomOf="@id/track_custom_event" />
-
-		<TextView
-			android:id="@+id/track_exception"
-			style="@style/Button"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginLeft="20dp"
-			android:layout_marginTop="5dp"
-			android:layout_marginRight="20dp"
-			android:text="@string/menu_track_exception"
-			app:layout_constraintTop_toBottomOf="@id/track_workflow" />
-
-		<TextView
-			android:id="@+id/track_exception_with_attributes"
-			style="@style/Button"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginLeft="20dp"
-			android:layout_marginTop="5dp"
-			android:layout_marginRight="20dp"
-			android:text="@string/menu_track_exception_with_attributes"
-			app:layout_constraintTop_toBottomOf="@id/track_exception" />
 
 		<TextView
 			android:id="@+id/global_attributes_title"
@@ -249,7 +217,7 @@
 			android:text="@string/menu_global_attributes_title"
 			android:textSize="18sp"
 			android:textStyle="bold"
-			app:layout_constraintTop_toBottomOf="@+id/track_exception_with_attributes" />
+			app:layout_constraintTop_toBottomOf="@+id/menu_custom_tracking_button" />
 
 		<TextView
 			android:id="@+id/set_string_attribute"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,11 +18,13 @@
     <string name="menu_web_view_native_bridge_title">Web View Native Bridge</string>
     <string name="menu_web_view_nextgen">Get Session ID (Nextgen)</string>
     <string name="menu_web_view_legacy">Get Session ID (Legacy)</string>
-    <string name="menu_custom_tracking_title">Custom Tracking</string>
-    <string name="menu_custom_event">Track Custom Event</string>
-    <string name="menu_workflow">Track Workflow</string>
-    <string name="menu_track_exception">Track Exception</string>
-    <string name="menu_track_exception_with_attributes">Track Exception With Attributes</string>
+    <string name="custom_tracking_title">Custom Tracking</string>
+    <string name="custom_tracking_latest_api_title">Latest APIs</string>
+    <string name="custom_tracking_legacy_api_title">Legacy APIs</string>
+    <string name="track_custom_event">Track Custom Event</string>
+    <string name="track_workflow">Track Workflow</string>
+    <string name="track_exception">Track Exception</string>
+    <string name="track_exception_with_attributes">Track Exception With Attributes</string>
 
     <!-- Global Attributes -->
     <string name="menu_global_attributes_title">Global Attributes</string>
@@ -44,6 +46,7 @@
     <string name="okhttp_title">OkHttp</string>
     <string name="httpurlconnection_title">HttpURLConnection</string>
     <string name="webview_title">WebView</string>
+    <string name="customtracking_title">CustomTracking</string>
 
     <!-- Fragment Okhttp -->
     <string name="synchronous_get">Synchronous GET</string>
@@ -60,7 +63,7 @@
     <string name="network_error">Network Error</string>
     <string name="response_caching">Response caching</string>
     <string name="canceled_call">Canceled call</string>
-    <string name="http_toast">%s(): Done!</string>
+    <string name="http_toast">%s, Done!</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 


### PR DESCRIPTION
- Moved Custom Tracking tests to its own screen. Will cleanup remaining in upcoming task for decluttering menu fragment. 
- Added tests for legacy custom tracking APIs + some necessary cleanup

This is how the custom tracking screen looks:
[
<img width="304" alt="Screenshot 2025-05-14 at 2 44 35 PM" src="https://github.com/user-attachments/assets/4e920eb0-dbbe-4930-91c2-8991ac444db4" />
](url)