### PR TITLE
Update ANR legacy mapping method name 

### DIFF
--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -57,7 +57,7 @@ class App : Application() {
           .setDeploymentEnvironment("test")
           .setGlobalAttributes(Attributes.of(AttributeKey.stringKey("legacyGlobalAttributesKey"), "legacyGlobalAttributesVal"))
           .enableDebug(true)
-          .disableANRReporting()
+          .disableAnrDetection()
           .disableCrashReporting()
           .disableSlowRenderingDetection()
           .setSlowRenderingDetectionPollInterval(Duration.ofMillis(500))

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -205,7 +205,7 @@ class SplunkRumBuilder {
      * This feature is enabled by default. You can disable it by calling this method.
      */
     @Deprecated("ANRReporting is now controlled by the ANRModuleConfiguration")
-    fun disableANRReporting(): SplunkRumBuilder {
+    fun disableAnrDetection(): SplunkRumBuilder {
         anrReportingEnabled = false
         return this
     }


### PR DESCRIPTION
Corrected mapping method name from `disableANRReporting` to `disableAnrDetection` as it should be here:
https://github.com/signalfx/splunk-otel-android/blob/main/splunk-otel-android/src/main/java/com/splunk/rum/SplunkRumBuilder.java#L219