### PR TITLE
Fixed the asMap() retun type

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/MutableAttributes.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/attributes/MutableAttributes.kt
@@ -154,7 +154,7 @@ class MutableAttributes(
 
     override fun isEmpty(): Boolean = attributes.isEmpty
 
-    override fun asMap(): MutableMap<AttributeKey<*>, Any> = attributes.asMap()
+    override fun asMap(): Map<AttributeKey<*>, Any> = attributes.asMap()
 
     override fun toBuilder(): AttributesBuilder = attributes.toBuilder()
 


### PR DESCRIPTION
The function `asMap` should return a `Map`, not a `MutableMap`.  Thanks to @TomasChladekSL for the report!