### PR TITLE
NO-TICKET: Fix event.name for interactions

### DIFF
--- a/integration/interactions/src/main/java/com/splunk/rum/integration/interactions/InteractionsModuleIntegration.kt
+++ b/integration/interactions/src/main/java/com/splunk/rum/integration/interactions/InteractionsModuleIntegration.kt
@@ -43,6 +43,7 @@ internal object InteractionsModuleIntegration : ModuleIntegration<InteractionsMo
 
     private const val TAG = "InteractionsIntegration"
 
+    private val attributeEventName = AttributeKey.stringKey("event.name")
     private val attributeKeyComponent = AttributeKey.stringKey("component")
     private val attributeKeyActionName = AttributeKey.stringKey("action.name")
     private val attributeKeyTargetType = AttributeKey.stringKey("target.type")
@@ -133,6 +134,7 @@ internal object InteractionsModuleIntegration : ModuleIntegration<InteractionsMo
             logger.get(RumConstants.RUM_TRACER_NAME)
                 .logRecordBuilder()
                 .setTimestamp(interaction.timestamp, TimeUnit.MILLISECONDS)
+                .setAttribute(attributeEventName, "action")
                 .setAttribute(attributeKeyComponent, "ui")
                 .setAttribute(attributeKeyActionName, actionName)
                 .setAttribute(attributeKeyTargetType, targetType)


### PR DESCRIPTION
Interaction log events now have `event.name`.