### PR TITLE
DEMRUM-2430: Update timestamp selection logic in log to span conversion

### DIFF
--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
@@ -68,11 +68,8 @@ internal class AndroidLogRecordExporter : LogRecordExporter {
                     }
                 }
             } finally {
-                val effectiveTimestamp = if (log.timestampEpochNanos != 0L) {
-                    log.timestampEpochNanos
-                } else {
-                    log.observedTimestampEpochNanos
-                }
+                val effectiveTimestamp = log.timestampEpochNanos.takeIf { it != 0L }
+                    ?: log.observedTimestampEpochNanos
                 spanBuilder.createZeroLengthSpan(effectiveTimestamp, TimeUnit.NANOSECONDS)
 
                 if (log.instrumentationScopeInfo.name == RumConstants.CRASH_INSTRUMENTATION_SCOPE_NAME) {

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
@@ -68,7 +68,12 @@ internal class AndroidLogRecordExporter : LogRecordExporter {
                     }
                 }
             } finally {
-                spanBuilder.createZeroLengthSpan(log.timestampEpochNanos, TimeUnit.NANOSECONDS)
+                val effectiveTimestamp = if (log.timestampEpochNanos != 0L) {
+                    log.timestampEpochNanos
+                } else {
+                    log.observedTimestampEpochNanos
+                }
+                spanBuilder.createZeroLengthSpan(effectiveTimestamp, TimeUnit.NANOSECONDS)
 
                 if (log.instrumentationScopeInfo.name == RumConstants.CRASH_INSTRUMENTATION_SCOPE_NAME) {
                     SplunkOpenTelemetrySdk.instance?.sdkTracerProvider?.forceFlush()


### PR DESCRIPTION
Crashes were not being generated as zero length spans

In the log to span conversion logic we call:
`spanBuilder.createZeroLengthSpan(log.timestampEpochNanos, TimeUnit.NANOSECONDS)`

with 

`log.timestampEpochNanos`

However, crash instrumentation generates log records with timestampEpochNanos = 0 (no explicit timestamp). 

So the following logic will resort to passing the current timestamp when start and end to the span are called.
Only `observedTimestampEpochNanos` contains the actual timestamp in crash logs, which makes sense for a crash event

We are now falling back on `observedTimestampEpochNanos` if the timestamp is 0