### PR TITLE
DEMRUM-2356: Add required fingerprint to enable stacktrace symbolication

### DIFF
--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
@@ -28,6 +28,7 @@ object RumConstants {
 
     val WORKFLOW_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("workflow.name")
     val COMPONENT_KEY: AttributeKey<String> = AttributeKey.stringKey("component")
+    val ERROR_KEY: AttributeKey<String> = AttributeKey.stringKey("error")
 
     val APPLICATION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("service.application_id")
     val APP_VERSION_CODE_KEY: AttributeKey<String> = AttributeKey.stringKey("service.version_code")

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
@@ -28,6 +28,8 @@ object RumConstants {
 
     val WORKFLOW_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("workflow.name")
     val COMPONENT_KEY: AttributeKey<String> = AttributeKey.stringKey("component")
+
+    // Required by backend for symbolication. Applied to crashes, ANRs and manually reported errors
     val ERROR_KEY: AttributeKey<String> = AttributeKey.stringKey("error")
 
     val APPLICATION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("service.application_id")

--- a/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrAttributesExtractor.kt
+++ b/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrAttributesExtractor.kt
@@ -14,7 +14,6 @@ internal class AnrAttributesExtractor : AttributesExtractor<Array<StackTraceElem
     ) {
         attributes.put(RumConstants.COMPONENT_KEY, RumConstants.COMPONENT_ERROR)
         attributes.put(RumConstants.ERROR_KEY, "true")
-
     }
 
     override fun onEnd(

--- a/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrAttributesExtractor.kt
+++ b/integration/anr/src/main/java/com/splunk/rum/integration/anr/AnrAttributesExtractor.kt
@@ -13,6 +13,8 @@ internal class AnrAttributesExtractor : AttributesExtractor<Array<StackTraceElem
         stackTrace: Array<StackTraceElement>
     ) {
         attributes.put(RumConstants.COMPONENT_KEY, RumConstants.COMPONENT_ERROR)
+        attributes.put(RumConstants.ERROR_KEY, "true")
+
     }
 
     override fun onEnd(

--- a/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashAttributesExtractor.kt
+++ b/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashAttributesExtractor.kt
@@ -24,7 +24,6 @@ internal class CrashAttributesExtractor : AttributesExtractor<CrashDetails, Void
         }
         attributes.put(RumConstants.COMPONENT_KEY, component)
         attributes.put(RumConstants.ERROR_KEY, "true")
-
     }
 
     override fun onEnd(

--- a/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashAttributesExtractor.kt
+++ b/integration/crash/src/main/java/com/splunk/rum/integration/crash/CrashAttributesExtractor.kt
@@ -23,6 +23,8 @@ internal class CrashAttributesExtractor : AttributesExtractor<CrashDetails, Void
             RumConstants.COMPONENT_ERROR
         }
         attributes.put(RumConstants.COMPONENT_KEY, component)
+        attributes.put(RumConstants.ERROR_KEY, "true")
+
     }
 
     override fun onEnd(

--- a/integration/customtracking/src/main/java/com/splunk/rum/integration/customtracking/CustomTracking.kt
+++ b/integration/customtracking/src/main/java/com/splunk/rum/integration/customtracking/CustomTracking.kt
@@ -87,6 +87,7 @@ class CustomTracking internal constructor() {
         }
         val timestamp = Instant.now()
         spanBuilder.setAttribute(RumConstants.COMPONENT_KEY, RumConstants.COMPONENT_ERROR)
+            .setAttribute(RumConstants.ERROR_KEY, "true")
             .setStartTimestamp(timestamp)
             .startSpan()
             .recordException(throwable)


### PR DESCRIPTION
The backend needs either one of the following conditions to be met:
- otel.status_code tag has value ERROR
- error tag exists
- http.response.status_code tag has a value greater or equal than 400

in order to enable symbolication.

In this PR, `error` = `true` attribute has been added to all ANR and crash spans, as well as manually reported errors