### PR TITLE
NO-TICKET: Add default screen.name

### DIFF
--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
@@ -38,5 +38,6 @@ object RumConstants {
     val SPLUNK_BUILD_ID: AttributeKey<String> = AttributeKey.stringKey("splunk.build_id")
 
     val SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("screen.name")
+    val LAST_SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("last.screen.name")
     const val DEFAULT_SCREEN_NAME = "unknown"
 }

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/RumConstants.kt
@@ -36,4 +36,7 @@ object RumConstants {
     val LINK_TRACE_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("link.traceId")
 
     val SPLUNK_BUILD_ID: AttributeKey<String> = AttributeKey.stringKey("splunk.build_id")
+
+    val SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("screen.name")
+    const val DEFAULT_SCREEN_NAME = "unknown"
 }

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.agent.internal.processor
 
+import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.agent.common.attributes.MutableAttributes
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.context.Context
@@ -24,6 +25,14 @@ import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
 
 class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
+
+    init {
+        /**
+         * Having a value for the screen.name attribute is mandatory for metrics to be derived on the platform.
+         * Using [RumConstants.DEFAULT_SCREEN_NAME] ensures that a screen.name is always present.
+         */
+        attributes[RumConstants.SCREEN_NAME_KEY] = RumConstants.DEFAULT_SCREEN_NAME
+    }
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
         attributes.forEach { key, value ->

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/ActiveSpan.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/ActiveSpan.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.integration.lifecycle.tracer
 
-import io.opentelemetry.api.common.AttributeKey
+import com.splunk.rum.common.otel.internal.RumConstants
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Scope
 
@@ -53,11 +53,7 @@ internal class ActiveSpan(private val lastVisibleScreenProvider: () -> String?) 
 
         val previouslyVisibleScreen = lastVisibleScreenProvider()
         if (previouslyVisibleScreen != null && screenName != previouslyVisibleScreen) {
-            span.setAttribute(LAST_SCREEN_NAME_KEY, previouslyVisibleScreen)
+            span.setAttribute(RumConstants.LAST_SCREEN_NAME_KEY, previouslyVisibleScreen)
         }
-    }
-
-    private companion object {
-        val LAST_SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("last.screen.name")
     }
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/activity/ActivityTracer.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/activity/ActivityTracer.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.lifecycle.tracer.activity
 
+import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.lifecycle.tracer.ActiveSpan
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
@@ -79,11 +80,10 @@ internal class ActivityTracer(
             .setAttribute(ACTIVITY_NAME_KEY, activityName)
 
         return spanBuilder.startSpan()
-            .setAttribute(SCREEN_NAME_KEY, screenName)
+            .setAttribute(RumConstants.SCREEN_NAME_KEY, screenName)
     }
 
     private companion object {
         val ACTIVITY_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("activityName")
-        val SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("screen.name")
     }
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/fragment/FragmentTracer.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/tracer/fragment/FragmentTracer.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.lifecycle.tracer.fragment
 
+import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.lifecycle.tracer.ActiveSpan
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
@@ -61,12 +62,11 @@ internal class FragmentTracer(
             .setAttribute(FRAGMENT_NAME_KEY, fragmentName)
             .startSpan()
 
-        span.setAttribute(SCREEN_NAME_KEY, screenName)
+        span.setAttribute(RumConstants.SCREEN_NAME_KEY, screenName)
         return span
     }
 
     private companion object {
         val FRAGMENT_NAME_KEY: AttributeKey<String?> = AttributeKey.stringKey("fragmentName")
-        val SCREEN_NAME_KEY: AttributeKey<String?> = AttributeKey.stringKey("screen.name")
     }
 }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -44,7 +44,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
 
             val provider = SplunkOpenTelemetrySdk.instance?.sdkTracerProvider ?: return
 
-            SplunkInternalGlobalAttributeSpanProcessor.attributes["screen.name"] = screenName
+            SplunkInternalGlobalAttributeSpanProcessor.attributes[RumConstants.SCREEN_NAME_KEY] = screenName
 
             provider.get(RumConstants.RUM_TRACER_NAME)
                 .spanBuilder("Created")


### PR DESCRIPTION
Having a value for the `screen.name` attribute is **mandatory** for metrics to be derived on the platform. Using `RumConstants.DEFAULT_SCREEN_NAME` ensures that a `screen.name` is always present.