### PR TITLE
NO-TICKET: Disable link checker

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,12 +54,16 @@ jobs:
           java-version: 17
       - name: Run ktlint
         run: ./gradlew ktlintCheck
-  check_links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.4.1
-        with:
-          fail: true
-          lycheeVersion: v0.19.1
+        
+  # check_links:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4.2.2
+  #     - name: Link Checker
+  #       uses: lycheeverse/lychee-action@v2.4.1
+  #       with:
+  #         fail: true
+  #         lycheeVersion: v0.19.1
+  #
+  # Temporarily disabled because Splunk Docs URLs return 403 errors to CI scanners,
+  # which causes the link checker to fail even though the links are valid.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.1.0
+        uses: lycheeverse/lychee-action@v2.4.1
         with:
           fail: true
           lycheeVersion: v0.16.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,4 +62,4 @@ jobs:
         uses: lycheeverse/lychee-action@v2.4.1
         with:
           fail: true
-          lycheeVersion: v0.16.1
+          lycheeVersion: v0.19.1


### PR DESCRIPTION
- Temporarily disabled the check_links job due to Splunk Docs URLs returning 403 errors during CI scans.
- Updated the lychee versions.
