### PR TITLE
NO-TICKET: Remove limitDiskUsageMegabytes todo and maxUsageMegabytes variable

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -49,7 +49,6 @@ class SplunkRumBuilder {
     private var spanFilter: Consumer<SpanFilterBuilder>? = null
     private var instrumentedProcessName: String? = null
     private var deferredUntilForeground: Boolean = false
-    private var maxUsageMegabytes: Int = 25
     private var crashReportingEnabled: Boolean = true
     private var anrReportingEnabled: Boolean = true
     private var slowRenderingDetectionEnabled: Boolean = true
@@ -300,8 +299,6 @@ class SplunkRumBuilder {
                 )
             )
         )
-
-        // TODO limitDiskUsageMegabytes
 
         return agent
     }


### PR DESCRIPTION
We have deprecated the `limitDiskUsageMegabytes` function, making both `maxUsageMegabytes` and the `// TODO limitDiskUsageMegabytes` comment redundant.