### PR TITLE
(WIP) DEMRUM-2067: Mapping file gradle plugin POC

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     // Uncomment this to test HttpURLConnection instrumentation
     //id("com.splunk.android.rum-okhttp3-auto-plugin") version "24.4.1"
     //id("com.splunk.android.rum-httpurlconnection-auto-plugin") version "24.4.1"
+    // Uncomment this to test mapping file plugin
+    //id("com.splunk.rum-mapping-file-plugin") version "2.0.0-beta"
 }
 
 apply<ConfigAndroidApp>()

--- a/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
@@ -1,0 +1,93 @@
+import utils.artifactPrefix
+import utils.defaultGroupId
+
+plugins {
+    id("java-gradle-plugin")
+    kotlin("jvm")
+    id("maven-publish")
+    id("signing")
+}
+
+group = defaultGroupId
+version = Configurations.sdkVersionName
+
+val javadocJar by tasks.creating(Jar::class) {
+    archiveClassifier.set("javadoc")
+    from(tasks.named("javadoc"))
+    metaInf {
+        from("$projectDir/src/main/assets/LICENSE.txt")
+    }
+}
+
+val sourcesJar by tasks.creating(Jar::class) {
+    archiveClassifier.set("sources")
+    from(sourceSets["main"].allSource)
+    metaInf {
+        from("$projectDir/src/main/assets/LICENSE.txt")
+    }
+}
+
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
+        )
+    }
+    metaInf {
+        from("$projectDir/src/main/assets/LICENSE.txt")
+    }
+}
+
+gradlePlugin {
+    plugins {
+        create("androidInstrumentationPlugin") {
+            id = "$defaultGroupId.${artifactPrefix}mapping-file-plugin"
+            implementationClass = "com.splunk.rum.mappingfile.plugin.MappingFilePlugin"
+            displayName = "Splunk Android Mapping File Plugin"
+        }
+    }
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(Dependencies.gradle)
+}
+
+signing {
+    val secretKey: String? = System.getenv("SECRET_KEY")
+    val signingPassword: String? = System.getenv("SIGNING_PASSWORD")
+
+    if (secretKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(secretKey, signingPassword)
+        sign(publishing.publications)
+    } else {
+        println("WARNING: Environment variables SECRET_KEY and/or SIGNING_PASSWORD not set. Skipping signing of artifacts.")
+    }
+}
+
+publishing {
+    publications {
+        withType(MavenPublication::class.java) {
+            pom.withXml { asNode().addCiscoInfo() }
+
+            artifactId = "${artifactPrefix}mapping-file-plugin"
+
+            artifact(javadocJar)
+            artifact(sourcesJar)
+        }
+        repositories {
+            maven {
+                name = "maven"
+                url = uri(Configurations.Artifactory.bareRepositoryURL)
+                credentials {
+                    username = System.getenv("ARTIFACT_REPO_USERNAME")
+                    password = System.getenv("ARTIFACT_REPO_PASSWORD")
+                }
+            }
+            maven {
+                name = "local"
+                url = uri("$projectDir/repo")
+            }
+        }
+    }
+}

--- a/instrumentation/buildtime/mapping-file/plugin/src/main/java/com/splunk/rum/mappingfile/plugin/MappingFilePlugin.kt
+++ b/instrumentation/buildtime/mapping-file/plugin/src/main/java/com/splunk/rum/mappingfile/plugin/MappingFilePlugin.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.mappingfile.plugin
+
+import com.android.build.gradle.AppExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import java.io.File
+import java.util.*
+
+class MappingFilePlugin : Plugin<Project> {
+
+    private lateinit var project: Project
+
+    override fun apply(project: Project) {
+        this.project = project
+        // TODO: replace all println with more proper logging
+        println("Splunk RUM: Mapping File Plugin applied!")
+
+        project.afterEvaluate {
+            setupBuildIdInjection()
+        }
+    }
+
+    private fun setupBuildIdInjection() {
+        val android = project.extensions.findByType(AppExtension::class.java)
+        if (android == null) {
+            println("Splunk RUM: Android application plugin not found, skipping setup")
+            return
+        }
+
+        android.applicationVariants.configureEach { variant ->
+            if (variant.buildType.isMinifyEnabled) {
+                injectBuildIdForVariant(variant)
+            } else {
+                println("Splunk RUM: Skipping variant '${variant.name}' as minification not enabled")
+            }
+        }
+    }
+
+    private fun injectBuildIdForVariant(variant: com.android.build.gradle.api.ApplicationVariant) {
+        // TODO: check that customer does not have existing manual setup, if so, skip this process and log notice
+
+        val buildId = UUID.randomUUID().toString()
+        println("Splunk RUM: Generated build ID for variant '${variant.name}': $buildId")
+
+        injectViaManifestModification(variant, buildId)
+        setupUploadTask(variant, buildId)
+    }
+
+    private fun setupUploadTask(
+        variant: com.android.build.gradle.api.ApplicationVariant,
+        buildId: String
+    ) {
+        // Hook into the assemble task to upload after build completes
+        val assembleTaskName = "assemble${variant.name.capitalize(Locale.ROOT)}"
+        project.tasks.named(assembleTaskName).configure { assembleTask ->
+            assembleTask.doLast {
+                uploadMappingFileAfterBuild(variant, buildId)
+            }
+        }
+    }
+
+    private fun uploadMappingFileAfterBuild(
+        variant: com.android.build.gradle.api.ApplicationVariant,
+        buildId: String
+    ) {
+        // TODO: create gradle plugin extension for customer to put in these values instead
+        val accessToken = project.findProperty("splunk.accessToken") as String?
+            ?: System.getenv("SPLUNK_ACCESS_TOKEN")
+            ?: ""
+        val realm = project.findProperty("splunk.realm") as String?
+            ?: System.getenv("SPLUNK_REALM")
+            ?: "lab0"
+
+        // TODO: potentially recursively search for mapping file in case it isnt in this location
+        val buildDir = project.layout.buildDirectory.get().asFile
+        val mappingFile = File(buildDir, "outputs/mapping/${variant.name}/mapping.txt")
+
+        if (!mappingFile.exists()) {
+            println("Splunk RUM: Mapping file not found at ${mappingFile.absolutePath}, skipping upload")
+            return
+        }
+
+        if (accessToken.isBlank() || realm.isBlank()) {
+            println("Splunk RUM: Access token or realm not configured, skipping upload")
+            return
+        }
+
+        println("Splunk RUM: Uploading mapping file for variant ${variant.name}")
+        println("  File: ${mappingFile.absolutePath}")
+        println("  App ID: ${variant.applicationId}")
+        println("  Version Code: ${variant.versionCode}")
+        println("  Build ID: $buildId")
+
+        try {
+            uploadMappingFile(
+                mappingFile = mappingFile,
+                buildId = buildId,
+                applicationId = variant.applicationId,
+                versionCode = variant.versionCode,
+                accessToken = accessToken,
+                realm = realm
+            )
+            println("Splunk RUM: Successfully uploaded mapping file")
+        } catch (e: Exception) {
+            println("Splunk RUM: Upload failed: ${e.message}")
+            // Don't fail the build, let app build finish
+        }
+    }
+
+    private fun injectViaManifestModification(variant: com.android.build.gradle.api.ApplicationVariant, buildId: String) {
+        variant.outputs.forEach { output ->
+            try {
+                val processManifestTask = output.processManifest
+                processManifestTask.doLast {
+                    println("Splunk RUM: Executing injection after processManifest")
+                    injectMetadataIntoMergedManifest(variant, buildId)
+                }
+                println("Splunk RUM: Hooked into ${processManifestTask.name}")
+            } catch (e: Exception) {
+                println("Splunk RUM: Could not hook processManifest: ${e.message}")
+                val packageTaskName = "package${variant.name.capitalize(Locale.ROOT)}"
+                project.tasks.named(packageTaskName).configure { task ->
+                    task.doFirst {
+                        injectMetadataIntoMergedManifest(variant, buildId)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun injectMetadataIntoMergedManifest(variant: com.android.build.gradle.api.ApplicationVariant, buildId: String) {
+        println("Splunk RUM: Searching for manifest files")
+
+        val buildDir = project.layout.buildDirectory.get().asFile
+        val manifestFiles = buildDir.walkTopDown()
+            .filter { it.name == "AndroidManifest.xml" && it.absolutePath.contains(variant.name) }
+            .filter { it.exists() }
+            .toList()
+
+        if (manifestFiles.isNotEmpty()) {
+            println("Splunk RUM: Found ${manifestFiles.size} manifest files:")
+            manifestFiles.forEach { file ->
+                println("  - ${file.absolutePath}")
+            }
+
+            var successCount = 0
+            manifestFiles.forEach { manifestFile ->
+                try {
+                    val wasModified = addMetadataToManifest(manifestFile, buildId)
+                    if (wasModified) {
+                        successCount++
+                        println("Splunk RUM: Modified: ${manifestFile.name}")
+                    }
+                } catch (e: Exception) {
+                    println("Splunk RUM: Failed: ${manifestFile.name} - ${e.message}")
+                }
+            }
+
+            println("Splunk RUM: Successfully modified $successCount/${manifestFiles.size} files")
+        } else {
+            println("Splunk RUM: No manifest files found for variant ${variant.name}")
+        }
+    }
+
+    private fun addMetadataToManifest(manifestFile: java.io.File, buildId: String): Boolean {
+        try {
+            var content = manifestFile.readText()
+
+            // Find <application> tag and inject metadata after it
+            val applicationPattern = Regex("<application([^>]*)>")
+            val match = applicationPattern.find(content)
+
+            if (match != null) {
+                val metadataTag = "\n        <meta-data android:name=\"splunk.build_id\" android:value=\"$buildId\" />"
+                val replacement = "${match.value}$metadataTag"
+                content = content.replace(match.value, replacement)
+
+                manifestFile.writeText(content)
+                println("Splunk RUM: Successfully injected build ID metadata into: ${manifestFile.name}")
+                return true
+            } else {
+                println("Splunk RUM: Could not find <application> tag in: ${manifestFile.name}")
+                return false
+            }
+
+        } catch (e: Exception) {
+            println("Splunk RUM: Error modifying ${manifestFile.name}: ${e.message}")
+            return false
+        }
+    }
+
+    private fun uploadMappingFile(
+        mappingFile: File,
+        buildId: String,
+        applicationId: String,
+        versionCode: Int,
+        accessToken: String,
+        realm: String
+    ) {
+        // Build URL
+        val url = "https://api.$realm.signalfx.com/v2/rum-mfm/proguard/$applicationId/$versionCode/$buildId"
+        println("Splunk RUM: Upload URL: $url")
+        println("Splunk RUM: Using PUT method")
+        println("Splunk RUM: File size: ${mappingFile.length()} bytes")
+
+        val connection = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+
+        try {
+            // Setup connection, PUT request
+            connection.requestMethod = "PUT"
+            connection.doOutput = true
+            connection.doInput = true
+            connection.setRequestProperty("X-SF-Token", accessToken)
+
+            // Create multipart formdata
+            val boundary = "----Boundary${System.currentTimeMillis()}"
+            connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+
+            connection.outputStream.use { outputStream ->
+                val writer = java.io.PrintWriter(java.io.OutputStreamWriter(outputStream, "UTF-8"), true)
+
+                // Add filename parameter
+                writer.append("--$boundary").append("\r\n")
+                writer.append("Content-Disposition: form-data; name=\"filename\"").append("\r\n")
+                writer.append("\r\n")
+                writer.append(mappingFile.name).append("\r\n")
+                writer.flush()
+
+                // Add file
+                writer.append("--$boundary").append("\r\n")
+                writer.append("Content-Disposition: form-data; name=\"file\"; filename=\"${mappingFile.name}\"").append("\r\n")
+                writer.append("Content-Type: application/octet-stream").append("\r\n")
+                writer.append("\r\n")
+                writer.flush()
+
+                mappingFile.inputStream().use { it.copyTo(outputStream) }
+                outputStream.flush()
+
+                writer.append("\r\n--$boundary--\r\n")
+                writer.close()
+            }
+
+            // Response handling
+            val responseCode = connection.responseCode
+            println("Splunk RUM: Response code: $responseCode")
+            println("Splunk RUM: Response message: ${connection.responseMessage}")
+
+            if (responseCode in 200..299) {
+                val response = connection.inputStream?.bufferedReader()?.use { it.readText() } ?: ""
+                println("Splunk RUM: Upload successful (HTTP $responseCode)")
+                if (response.isNotEmpty()) {
+                    println("Splunk RUM: Response body: $response")
+                }
+            } else {
+                val errorResponse = connection.errorStream?.bufferedReader()?.use { it.readText() } ?: "No error details"
+                println("Splunk RUM: Error response body: $errorResponse")
+
+                // Printing response headers for debugging
+                connection.headerFields.forEach { (key, values) ->
+                    println("Splunk RUM: Response header $key: ${values.joinToString(", ")}")
+                }
+
+                throw Exception("HTTP $responseCode: $errorResponse")
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,8 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         //uncomment to look for plugins in local maven (.m2) folder
-        //mavenLocal()
+        mavenLocal()
+        google()
     }
 }
 
@@ -15,7 +16,8 @@ include ':common:otel',
 // Instrumentation modules
 include ':instrumentation:runtime:startup',
         ':instrumentation:buildtime:httpurlconnection-auto:plugin',
-        ':instrumentation:buildtime:okhttp3-auto:plugin'
+        ':instrumentation:buildtime:okhttp3-auto:plugin',
+        ':instrumentation:buildtime:mapping-file:plugin'
 
 // Integration
 include ':integration:agent:api',


### PR DESCRIPTION
Work in progress.

Gradle plugin that:
- automatically generates a `splunk build id` for all app build variants with minification enabled
- injects that id into the app's final AndroidManifest.XML file so the id is accessible by the sdk at runtime
- and then uploads the generated mapping files to splunk o11y cloud

To test:

- add access token and realm variables to `uploadMappingFileAfterBuild ` method in `MappingFilePlugin.kt`
- build sdk and publish to maven local
- uncomment `id("com.splunk.rum-mapping-file-plugin") version "2.0.0-beta"` in `app/build.gradle.kts`
- build app and verify successful build id generation and mapping file upload in logs

To do:

- split up code into separate files, clean up
- optimizations highlighted in `TODO` comments