### PR TITLE
NO-TICKET: Use Attributes consistently

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
@@ -19,7 +19,6 @@ package com.splunk.rum.integration.agent.api
 import com.splunk.rum.integration.agent.api.session.SessionConfiguration
 import com.splunk.rum.integration.agent.api.spaninterceptor.toMutableSpanData
 import com.splunk.rum.integration.agent.api.user.UserConfiguration
-import com.splunk.rum.integration.agent.common.attributes.MutableAttributes
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.trace.data.SpanData
 

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/AgentConfiguration.kt
@@ -20,6 +20,7 @@ import com.splunk.rum.integration.agent.api.session.SessionConfiguration
 import com.splunk.rum.integration.agent.api.spaninterceptor.toMutableSpanData
 import com.splunk.rum.integration.agent.api.user.UserConfiguration
 import com.splunk.rum.integration.agent.common.attributes.MutableAttributes
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.trace.data.SpanData
 
 /**
@@ -52,7 +53,7 @@ data class AgentConfiguration @JvmOverloads constructor(
     val deploymentEnvironment: String,
     val appVersion: String? = null,
     val enableDebugLogging: Boolean = false,
-    val globalAttributes: MutableAttributes = MutableAttributes(),
+    val globalAttributes: Attributes = Attributes.empty(),
     val spanInterceptor: ((SpanData) -> SpanData?)? = null,
     val user: UserConfiguration = UserConfiguration(),
     val session: SessionConfiguration = SessionConfiguration(),

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
@@ -57,7 +57,7 @@ class SplunkRum private constructor(
     val state: IState = State(agentConfiguration),
     val session: ISession = Session(SessionState(agentConfiguration.session, sessionManager)),
     val user: User = User(userManager),
-    val globalAttributes: MutableAttributes = agentConfiguration.globalAttributes
+    val globalAttributes: MutableAttributes = MutableAttributes(agentConfiguration.globalAttributes)
 ) {
 
     @Deprecated("Use property session.state.sessionId", ReplaceWith("session.state.sessionId"))


### PR DESCRIPTION
All places in the agent where the client can pass an instance of attributes should use `Attributes` and **not** `MutableAttributes`.  
We previously changed this for custom tracking ([PR #1271](https://github.com/signalfx/splunk-otel-android/pull/1271)), and now using `MutableAttributes` elsewhere would be inconsistent.

The **only** place where `MutableAttributes` is provided by the agent to the client is via:

```kotlin  
SplunkRum.instance.globalAttributes  
```

In this case, it makes perfect sense—this API prioritizes convenience, and clients cannot mutate the classic `Attributes`.