### PR TITLE
NO-TICKET: Change session.state.sessionId to session.state.id

### DIFF
--- a/app/src/androidTest/java/com/splunk/app/JavaIntegration.java
+++ b/app/src/androidTest/java/com/splunk/app/JavaIntegration.java
@@ -76,7 +76,7 @@ public class JavaIntegration extends Application {
         userState.getTrackingMode();
 
         ISession session = agent.getSession();
-        session.getState().getSessionId();
+        session.getState().getId();
         session.getState().getSamplingRate();
 
         agent.getOpenTelemetry();

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
@@ -61,7 +61,7 @@ class SplunkRum private constructor(
 ) {
 
     @Deprecated("Use property session.state.sessionId", ReplaceWith("session.state.sessionId"))
-    fun getRumSessionId(): String = session.state.sessionId
+    fun getRumSessionId(): String = session.state.id
 
     /**
      * Set an attribute in the global attributes that will be appended to every span and event.

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/session/SessionState.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/session/SessionState.kt
@@ -22,7 +22,7 @@ class SessionState internal constructor(
     private val sessionConfiguration: SessionConfiguration,
     private val sessionManager: ISplunkSessionManager
 ) {
-    val sessionId: String
+    val id: String
         get() = sessionManager.sessionId
     val samplingRate: Double
         get() = sessionConfiguration.samplingRate

--- a/integration/webview/src/main/java/com/splunk/rum/integration/webview/NativeRumSessionId.kt
+++ b/integration/webview/src/main/java/com/splunk/rum/integration/webview/NativeRumSessionId.kt
@@ -25,5 +25,5 @@ import com.splunk.rum.integration.agent.api.SplunkRum
 internal class NativeRumSessionId {
     @get:JavascriptInterface
     val nativeSessionId: String
-        get() = SplunkRum.instance.session.state.sessionId
+        get() = SplunkRum.instance.session.state.id
 }


### PR DESCRIPTION
As per the documentation, the session state should expose the property `id`, but previously it was named `sessionId`, resulting in a redundant-looking API call:

```kotlin
SplunkRum.instance.session.state.sessionId
```

This has been updated to:

```kotlin
SplunkRum.instance.session.state.id
```

which is simpler and aligns with the documented API.