### PR TITLE
NO-TICKET: Fix last screen name logic

### DIFF
--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -26,6 +26,7 @@ import com.splunk.rum.integration.agent.api.user.UserConfiguration
 import com.splunk.rum.integration.agent.api.user.UserTrackingMode
 import com.splunk.rum.integration.agent.common.attributes.MutableAttributes
 import com.splunk.rum.integration.httpurlconnection.auto.HttpURLModuleConfiguration
+import com.splunk.rum.integration.navigation.NavigationModuleConfiguration
 import com.splunk.rum.integration.okhttp3.auto.OkHttp3AutoModuleConfiguration
 import com.splunk.rum.integration.okhttp3.manual.OkHttp3ManualModuleConfiguration
 import com.splunk.rum.integration.sessionreplay.api.RenderingMode
@@ -125,6 +126,11 @@ class App : Application() {
         interval = Duration.ofMillis(500)
     )
 
+    private val navigationModuleConfiguration =  NavigationModuleConfiguration(
+        isEnabled = true,
+        isAutomatedTrackingEnabled = false
+    )
+
     override fun onCreate() {
         super.onCreate()
 
@@ -132,7 +138,8 @@ class App : Application() {
             httpURLModuleConfiguration,
             okHttp3AutoModuleConfiguration,
             okHttp3ManualModuleConfiguration,
-            slowRenderingModuleConfiguration
+            slowRenderingModuleConfiguration,
+            navigationModuleConfiguration,
         )
 
         val agentConfiguration = AgentConfiguration(

--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -126,7 +126,7 @@ class App : Application() {
         interval = Duration.ofMillis(500)
     )
 
-    private val navigationModuleConfiguration =  NavigationModuleConfiguration(
+    private val navigationModuleConfiguration = NavigationModuleConfiguration(
         isEnabled = true,
         isAutomatedTrackingEnabled = false
     )
@@ -139,7 +139,7 @@ class App : Application() {
             okHttp3AutoModuleConfiguration,
             okHttp3ManualModuleConfiguration,
             slowRenderingModuleConfiguration,
-            navigationModuleConfiguration,
+            navigationModuleConfiguration
         )
 
         val agentConfiguration = AgentConfiguration(

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/AppStartSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/AppStartSpanProcessor.kt
@@ -18,7 +18,6 @@ package com.splunk.rum.integration.agent.internal.processor
 
 import android.os.SystemClock
 import com.splunk.rum.common.otel.SplunkOpenTelemetrySdk
-import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.agent.common.module.toSplunkString
 import com.splunk.rum.integration.agent.internal.AgentIntegration.Companion.modules
 import io.opentelemetry.api.trace.Span
@@ -50,7 +49,7 @@ class AppStartSpanProcessor : SpanProcessor {
         val tracer = SplunkOpenTelemetrySdk.instance
             ?.sdkTracerProvider
             ?.get("splunk-app-start")
-                ?: throw IllegalStateException("unable to report initialization")
+            ?: throw IllegalStateException("unable to report initialization")
         val modules = modules.values
 
         val firstInitialization =
@@ -66,7 +65,7 @@ class AppStartSpanProcessor : SpanProcessor {
             .startSpan()
 
         span.setAttribute("component", "appstart")
-            .setAttribute("screen.name","unknown")
+            .setAttribute("screen.name", "unknown")
 
         val resources = modules.joinToString(",", "[", "]") {
             it.configuration?.toSplunkString()

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -19,7 +19,6 @@ package com.splunk.rum.integration.navigation
 import android.content.Context
 import com.cisco.android.common.logger.Logger
 import com.splunk.rum.common.otel.SplunkOpenTelemetrySdk
-import com.splunk.rum.common.otel.extensions.createZeroLengthSpan
 import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration

--- a/integration/startup/src/main/java/com/splunk/rum/integration/startup/StartupModuleIntegration.kt
+++ b/integration/startup/src/main/java/com/splunk/rum/integration/startup/StartupModuleIntegration.kt
@@ -21,13 +21,11 @@ import com.cisco.android.common.logger.Logger
 import com.cisco.android.common.utils.extensions.forEachFast
 import com.splunk.rum.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.rum.common.otel.extensions.toInstant
-import com.splunk.rum.common.otel.internal.RumConstants
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
 import com.splunk.rum.integration.startup.model.StartupData
 import com.splunk.rum.startup.ApplicationStartupTimekeeper
 import io.opentelemetry.android.instrumentation.InstallationContext
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 internal object StartupModuleIntegration : ModuleIntegration<StartupModuleConfiguration>(
@@ -80,7 +78,6 @@ internal object StartupModuleIntegration : ModuleIntegration<StartupModuleConfig
     }
 
     private fun reportEvent(startTimestamp: Long, endTimestamp: Long, name: String) {
-
         val tracer = SplunkOpenTelemetrySdk.instance
             ?.sdkTracerProvider
             ?.get("splunk-app-start")


### PR DESCRIPTION
This PR solves wrong displaying in the Web player of different screens. Also it aligns more with iOS agent mainly on creating the spans in AppStart