### PR TITLE
NO-TICKET: Update badges on nextgen branch README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,5 @@ The Splunk Android RUM Instrumentation is licensed under the terms of the Apache
 version 2.0. See [the license file](./LICENSE) for more details.
 
 [stable-image]: https://img.shields.io/badge/status-stable-informational?style=for-the-badge
-[otel-image]: https://img.shields.io/badge/otel-1.33.5-blueviolet?style=for-the-badge
-[otel-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.33.5
-[android-image]: https://img.shields.io/github/v/release/signalfx/splunk-otel-android?include_prereleases&style=for-the-badge
-[android-link]: https://github.com/signalfx/splunk-otel-android/releases
-[gdi-image]: https://img.shields.io/badge/GDI-1.4.0-blueviolet?style=for-the-badge
-[gdi-link]: https://github.com/signalfx/gdi-specification/releases/tag/v1.4.0
 [maven-image]: https://img.shields.io/maven-central/v/com.splunk/splunk-otel-android?style=for-the-badge
 [maven-link]: https://mvnrepository.com/artifact/com.splunk/splunk-otel-android/latest
-[build-image]: https://img.shields.io/github/actions/workflow/status/signalfx/splunk-otel-android/main.yaml?branch=main&style=for-the-badge
-[build-link]: https://github.com/signalfx/splunk-otel-android/actions/workflows/main.yaml


### PR DESCRIPTION
- Remove otel badge as it was pointing to the java-instrumentation repo version used but we're using java, java-instrumentation and android repo artifacts, so we can't link to just one. 
- Remove Android badge as that was pointing to the released tag in this repo. We haven't added this new tag to the releases making that irrelevant. 
- Removed GDI badge as that is not relevant anymore. 
- removed build badge that was taking to continuous build workflows page which shows main branch builds, again not relevant. 