### PR TITLE
DEMRUM-1983: Cleanup style + present okhttp manual options on the UI

### DIFF
--- a/app/src/main/res/layout/fragment_crash_reports.xml
+++ b/app/src/main/res/layout/fragment_crash_reports.xml
@@ -10,14 +10,6 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/crash_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/crash_reports_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/crash_reports_illegal"
             style="@style/Button"
             android:layout_width="match_parent"
@@ -26,7 +18,8 @@
             android:layout_marginTop="20dp"
             android:layout_marginRight="20dp"
             android:text="@string/crash_reports_illegal"
-            app:layout_constraintTop_toBottomOf="@id/crash_title" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/crash_reports_main_thread"

--- a/app/src/main/res/layout/fragment_crash_reports.xml
+++ b/app/src/main/res/layout/fragment_crash_reports.xml
@@ -15,8 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/crash_reports_title"
-            android:textSize="18sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView

--- a/app/src/main/res/layout/fragment_custom_tracking.xml
+++ b/app/src/main/res/layout/fragment_custom_tracking.xml
@@ -15,19 +15,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/custom_tracking_title"
-            android:textSize="25sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/custom_tracking_latest_api_title"
-            style="@style/Header"
+            style="@style/SubHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/latest_api_title"
-            android:textSize="20sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/custom_tracking_title"/>
 
 
@@ -77,13 +73,11 @@
 
         <TextView
             android:id="@+id/custom_tracking_legacy_api_title"
-            style="@style/Header"
+            style="@style/SubHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/legacy_api_title"
-            android:textSize="20sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/track_exception_with_attributes"/>
 
 

--- a/app/src/main/res/layout/fragment_custom_tracking.xml
+++ b/app/src/main/res/layout/fragment_custom_tracking.xml
@@ -10,22 +10,14 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/custom_tracking_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/custom_tracking_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/custom_tracking_latest_api_title"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/latest_api_title"
-            app:layout_constraintTop_toBottomOf="@id/custom_tracking_title"/>
-
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <TextView
             android:id="@+id/track_custom_event"
@@ -73,7 +65,7 @@
 
         <TextView
             android:id="@+id/custom_tracking_legacy_api_title"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"

--- a/app/src/main/res/layout/fragment_global_attributes.xml
+++ b/app/src/main/res/layout/fragment_global_attributes.xml
@@ -15,19 +15,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/global_attributes_title"
-            android:textSize="25sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/global_attributes_latest_api_title"
-            style="@style/Header"
+            style="@style/SubHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/latest_api_title"
-            android:textSize="20sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/global_attributes_title"/>
 
 
@@ -165,13 +161,11 @@
 
         <TextView
             android:id="@+id/global_attributes_legacy_api_title"
-            style="@style/Header"
+            style="@style/SubHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/legacy_api_title"
-            android:textSize="20sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/get_all_global_attributes"/>
 
         <TextView
@@ -180,7 +174,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="20dp"
-            android:layout_marginTop="5dp"
+            android:layout_marginTop="20dp"
             android:layout_marginRight="20dp"
             android:text="@string/set_string_global_attribute"
             app:layout_constraintTop_toBottomOf="@id/global_attributes_legacy_api_title" />

--- a/app/src/main/res/layout/fragment_global_attributes.xml
+++ b/app/src/main/res/layout/fragment_global_attributes.xml
@@ -10,22 +10,14 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/global_attributes_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/global_attributes_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/global_attributes_latest_api_title"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/latest_api_title"
-            app:layout_constraintTop_toBottomOf="@id/global_attributes_title"/>
-
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <TextView
             android:id="@+id/set_string_attribute"
@@ -161,7 +153,7 @@
 
         <TextView
             android:id="@+id/global_attributes_legacy_api_title"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"

--- a/app/src/main/res/layout/fragment_http_url_connection.xml
+++ b/app/src/main/res/layout/fragment_http_url_connection.xml
@@ -11,23 +11,14 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/httpurlconnection_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/httpurlconnection_title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/customUrlSectionTitle"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/custom_url_section_title"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/httpurlconnection_title"  />
+            app:layout_constraintTop_toTopOf="parent"  />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout"
@@ -64,7 +55,7 @@
 
         <TextView
             android:id="@+id/othersSectionTitle"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/others_section_title"

--- a/app/src/main/res/layout/fragment_http_url_connection.xml
+++ b/app/src/main/res/layout/fragment_http_url_connection.xml
@@ -11,15 +11,23 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/customUrlSectionTitle"
+            android:id="@+id/httpurlconnection_title"
             style="@style/Header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/custom_url_section_title"
-            android:textSize="25sp"
-            android:textStyle="bold"
+            android:text="@string/httpurlconnection_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/customUrlSectionTitle"
+            style="@style/SubHeading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/custom_url_section_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/httpurlconnection_title"  />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout"
@@ -56,12 +64,10 @@
 
         <TextView
             android:id="@+id/othersSectionTitle"
-            style="@style/Header"
+            style="@style/SubHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/others_section_title"
-            android:textSize="25sp"
-            android:textStyle="bold"
             android:layout_marginTop="20dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/customUrlGet" />

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -10,21 +10,14 @@
 		android:padding="20dp">
 
 		<TextView
-			android:id="@+id/menu_title"
-			style="@style/Header"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:text="@string/menu_title"
-			app:layout_constraintTop_toTopOf="parent" />
-
-		<TextView
 			android:id="@+id/crash_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/crash_reports_title"
-			app:layout_constraintTop_toBottomOf="@id/menu_title"  />
+			app:layout_constraintStart_toStartOf="parent"
+			app:layout_constraintTop_toTopOf="parent"  />
 
 		<TextView
 			android:id="@+id/crash_reports"
@@ -39,7 +32,7 @@
 
 		<TextView
 			android:id="@+id/network_request_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
@@ -70,7 +63,7 @@
 
 		<TextView
 			android:id="@+id/web_view_native_bridge_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
@@ -101,7 +94,7 @@
 
 		<TextView
 			android:id="@+id/menu_custom_tracking_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
@@ -123,7 +116,7 @@
 
 		<TextView
 			android:id="@+id/global_attributes_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
@@ -144,7 +137,7 @@
 
 		<TextView
 			android:id="@+id/slow_rendering_title"
-			style="@style/SubHeading"
+			style="@style/Heading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -10,14 +10,21 @@
 		android:padding="20dp">
 
 		<TextView
-			android:id="@+id/crash_title"
+			android:id="@+id/menu_title"
 			style="@style/Header"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:text="@string/crash_reports_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
+			android:text="@string/menu_title"
 			app:layout_constraintTop_toTopOf="parent" />
+
+		<TextView
+			android:id="@+id/crash_title"
+			style="@style/SubHeading"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="30dp"
+			android:text="@string/crash_reports_title"
+			app:layout_constraintTop_toBottomOf="@id/menu_title"  />
 
 		<TextView
 			android:id="@+id/crash_reports"
@@ -32,13 +39,11 @@
 
 		<TextView
 			android:id="@+id/network_request_title"
-			style="@style/Header"
+			style="@style/SubHeading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/menu_network_request_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@id/crash_reports" />
 
 		<TextView
@@ -65,13 +70,11 @@
 
 		<TextView
 			android:id="@+id/web_view_native_bridge_title"
-			style="@style/Header"
+			style="@style/SubHeading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/web_view_native_bridge_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@id/http_url_connection" />
 
 		<TextView
@@ -98,13 +101,11 @@
 
 		<TextView
 			android:id="@+id/menu_custom_tracking_title"
-			style="@style/Header"
+			style="@style/SubHeading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/custom_tracking_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@+id/web_view_legacy" />
 
 
@@ -122,13 +123,11 @@
 
 		<TextView
 			android:id="@+id/global_attributes_title"
-			style="@style/Header"
+			style="@style/SubHeading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/global_attributes_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@+id/menu_custom_tracking" />
 
 
@@ -145,13 +144,11 @@
 
 		<TextView
 			android:id="@+id/slow_rendering_title"
-			style="@style/Header"
+			style="@style/SubHeading"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="30dp"
 			android:text="@string/slow_rendering_title"
-			android:textSize="18sp"
-			android:textStyle="bold"
 			app:layout_constraintTop_toBottomOf="@+id/global_attributes" />
 
 		<TextView

--- a/app/src/main/res/layout/fragment_okhttp.xml
+++ b/app/src/main/res/layout/fragment_okhttp.xml
@@ -10,16 +10,8 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/okhttp_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/okhttp_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/manual_instrumentation_api_selection"
-            style="@style/SubHeading"
+            style="@style/Heading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/manual_instrumentation_api_selection_title"
@@ -28,7 +20,7 @@
             android:layout_marginRight="20dp"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/okhttp_title" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <RadioGroup
             android:id="@+id/apiVariantRadioGroup"

--- a/app/src/main/res/layout/fragment_okhttp.xml
+++ b/app/src/main/res/layout/fragment_okhttp.xml
@@ -15,9 +15,49 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/okhttp_title"
-            android:textSize="25sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/manual_instrumentation_api_selection"
+            style="@style/SubHeading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/manual_instrumentation_api_selection_title"
+            android:layout_marginTop="20dp"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/okhttp_title" />
+
+        <RadioGroup
+            android:id="@+id/apiVariantRadioGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="5dp"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/manual_instrumentation_api_selection">
+
+        <RadioButton
+            android:id="@+id/latestApi"
+            style="@style/RadioOptionsText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/latest_api_option"
+            android:layout_marginEnd="20dp" />
+
+        <RadioButton
+            android:id="@+id/legacyApi"
+            style="@style/RadioOptionsText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/legacy_api_option"/>
+
+    </RadioGroup>
 
         <TextView
             android:id="@+id/synchronousGet"
@@ -28,7 +68,7 @@
             android:layout_marginTop="20dp"
             android:layout_marginRight="20dp"
             android:text="@string/synchronous_get"
-            app:layout_constraintTop_toBottomOf="@id/okhttp_title" />
+            app:layout_constraintTop_toBottomOf="@id/apiVariantRadioGroup" />
 
         <TextView
             android:id="@+id/asynchronousGet"

--- a/app/src/main/res/layout/fragment_slow_rendering.xml
+++ b/app/src/main/res/layout/fragment_slow_rendering.xml
@@ -15,8 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/slow_rendering_title"
-            android:textSize="18sp"
-            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView

--- a/app/src/main/res/layout/fragment_slow_rendering.xml
+++ b/app/src/main/res/layout/fragment_slow_rendering.xml
@@ -10,14 +10,6 @@
         android:padding="20dp">
 
         <TextView
-            android:id="@+id/slow_rendering_title"
-            style="@style/Header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/slow_rendering_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             android:id="@+id/slow_render"
             style="@style/Button"
             android:layout_width="match_parent"
@@ -26,7 +18,8 @@
             android:layout_marginTop="20dp"
             android:layout_marginRight="20dp"
             android:text="@string/slow_render"
-            app:layout_constraintTop_toBottomOf="@id/slow_rendering_title" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/frozen_render"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
 
     <!-- HttpURLConnection -->
     <string name="httpurlconnection_title">HttpURLConnection</string>
-    <string name="custom_url_section_title">Test with Custom URL</string>
+    <string name="custom_url_section_title">Custom URL Test</string>
     <string name="custom_url">URL</string>
     <string name="custom_url_get">GET</string>
     <string name="others_section_title">Other Tests</string>
@@ -63,6 +63,9 @@
     <!-- Okhttp -->
     <string name="okhttp_sample_calls">Okhttp sample calls</string>
     <string name="okhttp_title">OkHttp</string>
+    <string name="manual_instrumentation_api_selection_title">Manual Instrumentation API type</string>
+    <string name="latest_api_option">Latest APIs</string>
+    <string name="legacy_api_option">Legacy APIs</string>
     <string name="synchronous_get">Synchronous GET</string>
     <string name="asynchronous_get">Asynchronous GET</string>
     <string name="concurrent_asynchronous_get">Concurrent asynchronous GET</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,13 +6,7 @@
 		<item name="colorAccent">@color/splunk_lipstick</item>
 	</style>
 
-	<style name="Header">
-		<item name="android:textColor">@color/splunk_flamingo</item>
-		<item name="android:textSize">25sp</item>
-		<item name="android:textStyle">bold</item>
-	</style>
-
-	<style name="SubHeading">
+	<style name="Heading">
 		<item name="android:textColor">@color/splunk_flamingo</item>
 		<item name="android:textSize">20sp</item>
 		<item name="android:textStyle">bold</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,18 @@
 
 	<style name="Header">
 		<item name="android:textColor">@color/splunk_flamingo</item>
+		<item name="android:textSize">25sp</item>
+		<item name="android:textStyle">bold</item>
+	</style>
+
+	<style name="SubHeading">
+		<item name="android:textColor">@color/splunk_flamingo</item>
+		<item name="android:textSize">20sp</item>
+		<item name="android:textStyle">bold</item>
+	</style>
+
+	<style name="RadioOptionsText">
+		<item name="android:textColor">@color/splunk_flamingo</item>
 		<item name="android:textSize">18sp</item>
 		<item name="android:textStyle">bold</item>
 	</style>


### PR DESCRIPTION
- Style cleanup + remove the extra header showing up in all screens (as also shown in the screenshot below)
- For OkHttp3, Introduce radio buttons that show up only when auto-instrumentation is not enabled, so customers can choose between latest/legacy kotlin API usage for manual instrumentation, earlier they needed to uncomment lines of code. 

<img width="316" height="617" alt="This one" src="https://github.com/user-attachments/assets/b982746f-37c0-4bed-9582-07bdf571b493" />
