### PR TITLE
DEMRUM-2845: Add legacy API support for manual OkHttp interception

### DIFF
--- a/app/src/androidTest/java/com/splunk/app/JavaIntegration.java
+++ b/app/src/androidTest/java/com/splunk/app/JavaIntegration.java
@@ -40,6 +40,7 @@ import com.splunk.rum.integration.navigation.NavigationModuleConfiguration;
 import com.splunk.rum.integration.networkmonitor.NetworkMonitorModuleConfiguration;
 import com.splunk.rum.integration.okhttp3.auto.OkHttp3AutoModuleConfiguration;
 import com.splunk.rum.integration.okhttp3.manual.OkHttp3ManualModuleConfiguration;
+import com.splunk.rum.integration.okhttp3.manual.OkHttpManualInstrumentation;
 import com.splunk.rum.integration.sessionreplay.SessionReplayModuleConfiguration;
 import com.splunk.rum.integration.slowrendering.SlowRenderingModuleConfiguration;
 import com.splunk.rum.integration.startup.StartupModuleConfiguration;
@@ -50,6 +51,7 @@ import java.util.Arrays;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import okhttp3.OkHttpClient;
 
 public class JavaIntegration extends Application {
 
@@ -93,6 +95,10 @@ public class JavaIntegration extends Application {
         Span workflow = agent.startWorkflow("workflow");
 
         agent.integrateWithBrowserRum(new WebView(this));
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+        agent.createRumOkHttpCallFactory(okHttpClient);
+        OkHttpManualInstrumentation.getInstance().buildOkHttpCallFactory(okHttpClient);
     }
 
     private SplunkRum install() {

--- a/app/src/main/java/com/splunk/app/ui/okhttp/OkHttpFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/okhttp/OkHttpFragment.kt
@@ -32,7 +32,6 @@ import com.splunk.app.ui.BaseFragment
 import com.splunk.app.util.ApiVariant
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.navigation.extension.navigation
-import com.splunk.rum.integration.okhttp3.manual.extension.createRumOkHttpCallFactory
 import com.splunk.rum.integration.okhttp3.manual.extension.okHttpManualInstrumentation
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.OpenTelemetrySdk

--- a/integration/agent/api/build.gradle.kts
+++ b/integration/agent/api/build.gradle.kts
@@ -43,4 +43,13 @@ dependencies {
     implementation(Dependencies.SessionReplay.commonUtils)
 
     compileOnly(Dependencies.Android.Compose.ui)
+
+    /**
+     * Needed for the legacy API mapping. To be removed.
+     *
+     * Okio must be explicitly included since a newer version is being enforced than what is transitively used by OkHttp.
+     */
+    implementation(Dependencies.okhttp)
+    implementation(Dependencies.okio)
+
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRum.kt
@@ -40,6 +40,8 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.trace.Span
+import okhttp3.Call
+import okhttp3.OkHttpClient
 import java.util.function.Consumer
 
 /**
@@ -183,6 +185,27 @@ class SplunkRum private constructor(
             parameterTypes = arrayOf(Throwable::class.java, Attributes::class.java),
             args = arrayOf(throwable, attributes)
         )
+    }
+
+    /**
+     * Wrap the provided [OkHttpClient] with OpenTelemetry and RUM instrumentation. Since
+     * [Call.Factory] is the primary useful interface implemented by the OkHttpClient, this
+     * should be a drop-in replacement for any usages of OkHttpClient.
+     *
+     * @param client The [OkHttpClient] to wrap with OpenTelemetry and RUM instrumentation.
+     * @return A [Call.Factory] implementation.
+     */
+    @Deprecated(
+        "Use SplunkRum.buildOkHttpCallFactory(client)",
+        ReplaceWith("SplunkRum.buildOkHttpCallFactory(client)")
+    )
+    fun createRumOkHttpCallFactory(client: OkHttpClient): Call.Factory {
+        return LegacyAPIReflectionUtils.invokeOnCompanionInstance<Call.Factory>(
+            className = "com.splunk.rum.integration.okhttp3.manual.OkHttpManualInstrumentation",
+            methodName = "buildOkHttpCallFactory",
+            parameterTypes = arrayOf(OkHttpClient::class.java),
+            args = arrayOf(client)
+        ) ?: throw IllegalStateException()
     }
 
     companion object {

--- a/integration/okhttp3-manual/src/main/java/com/splunk/rum/integration/okhttp3/manual/extension/SplunkRumExt.kt
+++ b/integration/okhttp3-manual/src/main/java/com/splunk/rum/integration/okhttp3/manual/extension/SplunkRumExt.kt
@@ -26,18 +26,3 @@ import okhttp3.OkHttpClient
  */
 val SplunkRum.okHttpManualInstrumentation: OkHttpManualInstrumentation
     get() = OkHttpManualInstrumentation.instance
-
-/**
- * Wrap the provided [OkHttpClient] with OpenTelemetry and RUM instrumentation. Since
- * [Call.Factory] is the primary useful interface implemented by the OkHttpClient, this
- * should be a drop-in replacement for any usages of OkHttpClient.
- *
- * @param client The [OkHttpClient] to wrap with OpenTelemetry and RUM instrumentation.
- * @return A [Call.Factory] implementation.
- */
-@Deprecated(
-    "Use SplunkRum.buildOkHttpCallFactory(client)",
-    ReplaceWith("SplunkRum.buildOkHttpCallFactory(client)")
-)
-fun SplunkRum.createRumOkHttpCallFactory(client: OkHttpClient): Call.Factory =
-    okHttpManualInstrumentation.buildOkHttpCallFactory(client)


### PR DESCRIPTION
This PR introduces support for the legacy API method:
```kotlin
SplunkRum.createRumOkHttpCallFactory(client: OkHttpClient): Call.Factory
```

Calls to this method are now internally mapped to:
```koltin
OkHttpManualInstrumentation.buildOkHttpCallFactory(client: OkHttpClient): Call.Factory
```

This ensures backward compatibility for projects that still use the legacy `SplunkRum` APIs. The mapping works for both Kotlin and Java codebases.