### PR TITLE
DEMRUM-3114: Remove usages of license.txt

### DIFF
--- a/buildSrc/src/main/kotlin/plugins/ConfigPublish.kt
+++ b/buildSrc/src/main/kotlin/plugins/ConfigPublish.kt
@@ -38,9 +38,6 @@ class ConfigPublish : Plugin<Project> by local plugin {
 //            from(File(buildDir, "dokka/javadoc"))
             from("$rootDir/README.md")
             archiveClassifier.set("javadoc")
-            metaInf {
-                from("$projectDir/src/main/assets/LICENSE.txt")
-            }
         }
 
         configure<SigningExtension> {

--- a/instrumentation/buildtime/httpurlconnection-auto/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/httpurlconnection-auto/plugin/build.gradle.kts
@@ -14,17 +14,11 @@ version = Configurations.sdkVersionName
 val javadocJar by tasks.creating(Jar::class) {
     archiveClassifier.set("javadoc")
     from(tasks.named("javadoc"))
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
-    }
 }
 
 val sourcesJar by tasks.creating(Jar::class) {
     archiveClassifier.set("sources")
     from(sourceSets["main"].allSource)
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
-    }
 }
 
 tasks.jar {
@@ -32,9 +26,6 @@ tasks.jar {
         attributes(
             "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
         )
-    }
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
     }
 }
 

--- a/instrumentation/buildtime/okhttp3-auto/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/okhttp3-auto/plugin/build.gradle.kts
@@ -14,17 +14,11 @@ version = Configurations.sdkVersionName
 val javadocJar by tasks.creating(Jar::class) {
     archiveClassifier.set("javadoc")
     from(tasks.named("javadoc"))
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
-    }
 }
 
 val sourcesJar by tasks.creating(Jar::class) {
     archiveClassifier.set("sources")
     from(sourceSets["main"].allSource)
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
-    }
 }
 
 tasks.jar {
@@ -32,9 +26,6 @@ tasks.jar {
         attributes(
             "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
         )
-    }
-    metaInf {
-        from("$projectDir/src/main/assets/LICENSE.txt")
     }
 }
 


### PR DESCRIPTION
Removes the blob that added META-INF/LICENSE.txt files to various artifacts. 