### PR TITLE
NO-TICKET: Fix Fragment name

### DIFF
--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/tracer/fragment/FragmentTracerManager.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/tracer/fragment/FragmentTracerManager.kt
@@ -35,7 +35,7 @@ internal class FragmentTracerManager(private val tracer: Tracer) {
 
         if (activityTracer == null) {
             activityTracer = FragmentTracer(
-                fragmentName = fragment::class.java.name,
+                fragmentName = fragment::class.java.simpleName,
                 screenName = ScreenNameDescriptor.getName(fragment),
                 tracer = tracer,
                 activeSpan = ActiveSpan()


### PR DESCRIPTION
`Fragment` and `Activity` uses class `simpleName` instead of `name`.