### PR TITLE
NO-TICKET: Bump Version

### DIFF
--- a/buildSrc/src/main/kotlin/Configurations.kt
+++ b/buildSrc/src/main/kotlin/Configurations.kt
@@ -19,5 +19,5 @@ object Configurations {
     }
 
     const val sdkVersionCode = 1
-    val sdkVersionName = "2.0.0"
+    val sdkVersionName = "2.0.1"
 }


### PR DESCRIPTION
Bump the version so that further work on the agent and snapshots does not affect the release version 2.0.0.