### PR TITLE
NO-TICKET: minSdk 21

### DIFF
--- a/buildSrc/src/main/kotlin/Configurations.kt
+++ b/buildSrc/src/main/kotlin/Configurations.kt
@@ -1,14 +1,11 @@
 import org.gradle.api.JavaVersion
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 
 object Configurations {
 
     object Android {
         const val appCompileVersion = 34
         const val compileVersion = 34
-        const val minVersion = 24
+        const val minVersion = 21
         const val targetVersion = 34
     }
 

--- a/buildSrc/src/main/kotlin/Configurations.kt
+++ b/buildSrc/src/main/kotlin/Configurations.kt
@@ -19,5 +19,5 @@ object Configurations {
     }
 
     const val sdkVersionCode = 1
-    val sdkVersionName = "2.0.0"
+    val sdkVersionName = "2.0.1"
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/Status.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/Status.kt
@@ -27,5 +27,7 @@ sealed interface Status {
         object Subprocess : NotRunning
 
         object SampledOut : NotRunning
+
+        object UnsupportedOsVersion : NotRunning
     }
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/resource/AgentResource.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/resource/AgentResource.kt
@@ -12,6 +12,21 @@ internal object AgentResource {
     private const val OS_DESCRIPTION_TEMPLATE = "Android Version %s (Build %s API level %s)"
     private const val FALLBACK_VERSION = "0.0.0"
 
+    private const val KEY_APP = "app"
+    private const val KEY_APP_VERSION = "app.version"
+    private const val KEY_DEPLOYMENT_ENVIRONMENT = "deployment.environment"
+    private const val KEY_RUM_SDK_VERSION = "rum.sdk.version"
+    private const val KEY_DEVICE_ID = "device.id"
+    private const val KEY_DEVICE_MODEL_NAME = "device.model.name"
+    private const val KEY_DEVICE_MANUFACTURER = "device.manufacturer"
+    private const val KEY_OD_NAME = "os.name"
+    private const val KEY_OS_TYPE = "os.type"
+    private const val KEY_OS_VERSION = "os.version"
+    private const val KEY_OS_DESCRIPTION = "os.description"
+    private const val KEY_SPLUNK_RUM_VERSION = "splunk.rumVersion"
+    private const val KEY_PROCESS_RUNTIME_NAME = "process.runtime.name"
+    private const val KEY_SERVICE_NAME = "service.name"
+
     /**
      * Builds a complete Resource by combining:
      * - Default OpenTelemetry attributes
@@ -26,25 +41,25 @@ internal object AgentResource {
 
     private fun agentConfigResource(context: Context, agentConfiguration: AgentConfiguration): Resource =
         Resource.empty().toBuilder()
-            .put("app", agentConfiguration.appName)
-            .put("app.version", agentConfiguration.appVersion ?: context.appVersion ?: FALLBACK_VERSION)
-            .put("deployment.environment", agentConfiguration.deploymentEnvironment)
+            .put(KEY_APP, agentConfiguration.appName)
+            .put(KEY_APP_VERSION, agentConfiguration.appVersion ?: context.appVersion ?: FALLBACK_VERSION)
+            .put(KEY_DEPLOYMENT_ENVIRONMENT, agentConfiguration.deploymentEnvironment)
             .build()
 
     private fun buildResource(): Resource = Resource.empty().toBuilder()
-        .put("rum.sdk.version", BuildConfig.VERSION_NAME)
-        .put("device.id", Build.MODEL)
-        .put("device.model.name", Build.MODEL)
-        .put("device.manufacturer", Build.MANUFACTURER)
-        .put("os.name", "Android")
-        .put("os.type", "linux")
-        .put("os.version", Build.VERSION.RELEASE)
-        .put("os.description", OS_DESCRIPTION_TEMPLATE.format(Build.VERSION.RELEASE, Build.ID, Build.VERSION.SDK_INT))
+        .put(KEY_RUM_SDK_VERSION, BuildConfig.VERSION_NAME)
+        .put(KEY_DEVICE_ID, Build.MODEL)
+        .put(KEY_DEVICE_MODEL_NAME, Build.MODEL)
+        .put(KEY_DEVICE_MANUFACTURER, Build.MANUFACTURER)
+        .put(KEY_OD_NAME, "Android")
+        .put(KEY_OS_TYPE, "linux")
+        .put(KEY_OS_VERSION, Build.VERSION.RELEASE)
+        .put(KEY_OS_DESCRIPTION, OS_DESCRIPTION_TEMPLATE.format(Build.VERSION.RELEASE, Build.ID, Build.VERSION.SDK_INT))
         .build()
 
     private fun sessionReplayResource(): Resource = Resource.empty().toBuilder()
-        .put("splunk.rumVersion", BuildConfig.VERSION_NAME)
-        .put("process.runtime.name", "mobile")
-        .put("service.name", "unknown_service")
+        .put(KEY_SPLUNK_RUM_VERSION, BuildConfig.VERSION_NAME)
+        .put(KEY_PROCESS_RUNTIME_NAME, "mobile")
+        .put(KEY_SERVICE_NAME, "unknown_service")
         .build()
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/resource/AgentResource.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/resource/AgentResource.kt
@@ -6,13 +6,6 @@ import com.splunk.rum.integration.agent.api.AgentConfiguration
 import com.splunk.rum.integration.agent.api.BuildConfig
 import com.splunk.rum.utils.extensions.appVersion
 import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION
 
 internal object AgentResource {
 
@@ -40,13 +33,13 @@ internal object AgentResource {
 
     private fun buildResource(): Resource = Resource.empty().toBuilder()
         .put("rum.sdk.version", BuildConfig.VERSION_NAME)
-        .put(DEVICE_MODEL_IDENTIFIER, Build.MODEL)
-        .put(DEVICE_MODEL_NAME, Build.MODEL)
-        .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
-        .put(OS_NAME, "Android")
-        .put(OS_TYPE, "linux")
-        .put(OS_VERSION, Build.VERSION.RELEASE)
-        .put(OS_DESCRIPTION, OS_DESCRIPTION_TEMPLATE.format(Build.VERSION.RELEASE, Build.ID, Build.VERSION.SDK_INT))
+        .put("device.id", Build.MODEL)
+        .put("device.model.name", Build.MODEL)
+        .put("device.manufacturer", Build.MANUFACTURER)
+        .put("os.name", "Android")
+        .put("os.type", "linux")
+        .put("os.version", Build.VERSION.RELEASE)
+        .put("os.description", OS_DESCRIPTION_TEMPLATE.format(Build.VERSION.RELEASE, Build.ID, Build.VERSION.SDK_INT))
         .build()
 
     private fun sessionReplayResource(): Resource = Resource.empty().toBuilder()

--- a/integration/okhttp3-manual/src/main/java/com/splunk/rum/integration/okhttp3/manual/OkHttpManualInstrumentation.kt
+++ b/integration/okhttp3-manual/src/main/java/com/splunk/rum/integration/okhttp3/manual/OkHttpManualInstrumentation.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.okhttp3.manual
 
+import com.splunk.android.common.logger.Logger
 import okhttp3.Call
 import okhttp3.Call.Factory
 import okhttp3.OkHttpClient
@@ -30,12 +31,21 @@ class OkHttpManualInstrumentation internal constructor() {
      * @param client The [OkHttpClient] to wrap with Splunk RUM instrumentation.
      * @return A [Call.Factory] implementation.
      */
-    fun buildOkHttpCallFactory(client: OkHttpClient): Factory =
-        OkHttp3ManualModuleIntegration.okHttpTelemetry?.let { okHttpTelemetry ->
-            okHttpTelemetry.newCallFactory(client)
-        } ?: throw IllegalStateException("OkHttp3 manual instrumentation is not initialized")
+    fun buildOkHttpCallFactory(client: OkHttpClient): Factory {
+        val okHttpTelemetry = OkHttp3ManualModuleIntegration.okHttpTelemetry
+
+        if (okHttpTelemetry == null) {
+            Logger.w(TAG, "OkHttp3 manual instrumentation is not initialized. Check 'SplunkRum.instance.state.status'.")
+            return client
+        }
+
+        return okHttpTelemetry.newCallFactory(client)
+    }
 
     companion object {
+
+        private const val TAG = "OkHttpManualInstrumentation"
+
         /**
          * The instance of [OkHttpManualInstrumentation].
          */

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/State.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/State.kt
@@ -19,17 +19,21 @@ package com.splunk.rum.integration.sessionreplay.api
 import com.splunk.android.instrumentation.recording.core.api.SessionReplay
 import com.splunk.rum.integration.sessionreplay.api.mapping.toSplunk
 
-class State internal constructor() {
+class State internal constructor(private var statusOverrider: StatusOverrideProvider) {
 
     /**
      * The current SDK status.
      */
     val status: Status
-        get() = SessionReplay.instance.state.status.toSplunk()
+        get() = statusOverrider.onGetStatus() ?: SessionReplay.instance.state.status.toSplunk()
 
     /**
      * Screen data rendering mode.
      */
     val renderingMode: RenderingMode
         get() = SessionReplay.instance.state.renderingMode.toSplunk()
+
+    internal interface StatusOverrideProvider {
+        fun onGetStatus(): Status?
+    }
 }


### PR DESCRIPTION
## minSdk 21+

### Description

The SDK can now be integrated into applications with a `minSdk` of 21 or higher. However, its functionality is limited to API 24 and above.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### How to Test These Changes

Run the agent on Android 5.0+