### PR TITLE
DEMRUM-3132: Modify scriptId to copy sessionId but take only SCRIPT_ID_LENGTH chars

### DIFF
--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SessionReplaySessionIdLogProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SessionReplaySessionIdLogProcessor.kt
@@ -29,9 +29,14 @@ class SessionReplaySessionIdLogProcessor(private val sessionManager: ISplunkSess
     override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
         val logRecordData = logRecord.toLogRecordData()
         if (logRecordData.instrumentationScopeInfo.name == RumConstants.SESSION_REPLAY_INSTRUMENTATION_SCOPE_NAME) {
-            logRecord.setAttribute(SESSION_ID_KEY, sessionManager.sessionId(logRecordData.timestampEpochNanos))
-                .setAttribute(SESSION_RUM_ID_KEY, sessionManager.sessionId(logRecordData.timestampEpochNanos))
-                .setAttribute(SCRIPT_INSTANCE_KEY, sessionManager.scriptId())
+            val id = sessionManager.sessionId(logRecordData.timestampEpochNanos)
+            logRecord.setAttribute(SESSION_ID_KEY, id)
+                .setAttribute(SESSION_RUM_ID_KEY, id)
+                .setAttribute(SCRIPT_INSTANCE_KEY, id.take(SCRIPT_ID_LENGTH))
         }
+    }
+
+    private companion object {
+        const val SCRIPT_ID_LENGTH = 16
     }
 }

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
@@ -22,12 +22,11 @@ import com.splunk.android.common.utils.AppStateObserver
 import com.splunk.android.common.utils.extensions.forEachFast
 import com.splunk.android.common.utils.extensions.safeSchedule
 import com.splunk.rum.common.storage.IAgentStorage
-import com.splunk.rum.common.storage.SessionId as SessionIdStorageData
 import com.splunk.rum.integration.agent.internal.id.SessionId
-import com.splunk.rum.integration.agent.internal.id.SimpleId
 import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager.SessionListener
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
+import com.splunk.rum.common.storage.SessionId as SessionIdStorageData
 
 interface ISplunkSessionManager {
     val sessionId: String
@@ -37,7 +36,6 @@ interface ISplunkSessionManager {
     fun install(context: Context)
     fun reset()
     fun sessionId(timestamp: Long): String
-    fun scriptId(): String
 }
 
 object NoOpSplunkSessionManager : ISplunkSessionManager {
@@ -48,7 +46,6 @@ object NoOpSplunkSessionManager : ISplunkSessionManager {
     override fun reset() = Unit
 
     override fun sessionId(timestamp: Long): String = ""
-    override fun scriptId(): String = ""
 }
 
 class SplunkSessionManager internal constructor(private val agentStorage: IAgentStorage) : ISplunkSessionManager {
@@ -59,8 +56,6 @@ class SplunkSessionManager internal constructor(private val agentStorage: IAgent
     private var sessionValidityWatcher: ScheduledFuture<*>? = null
 
     private val sessionIds: MutableList<SessionIdStorageData> = agentStorage.readSessionIds().toMutableList()
-
-    private val scriptId = SimpleId.generate(SCRIPT_ID_LENGTH)
 
     /**
      * The value is valid after the [install] function is called.
@@ -99,8 +94,6 @@ class SplunkSessionManager internal constructor(private val agentStorage: IAgent
         .maxByOrNull { it.validFrom }
         ?.id
         ?: throw IllegalArgumentException("No valid session for timestamp: $timestamp")
-
-    override fun scriptId(): String = scriptId
 
     @Synchronized
     private fun createNewSessionIfNeeded(): String {
@@ -200,6 +193,5 @@ class SplunkSessionManager internal constructor(private val agentStorage: IAgent
     private companion object {
         const val DEFAULT_SESSION_BACKGROUND_TIMEOUT = 15L * 60L * 1000L // 15m
         const val DEFAULT_SESSION_LENGTH = 4L * 60L * 60L * 1000L // 4h
-        const val SCRIPT_ID_LENGTH = 16
     }
 }

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
@@ -22,11 +22,11 @@ import com.splunk.android.common.utils.AppStateObserver
 import com.splunk.android.common.utils.extensions.forEachFast
 import com.splunk.android.common.utils.extensions.safeSchedule
 import com.splunk.rum.common.storage.IAgentStorage
+import com.splunk.rum.common.storage.SessionId as SessionIdStorageData
 import com.splunk.rum.integration.agent.internal.id.SessionId
 import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager.SessionListener
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
-import com.splunk.rum.common.storage.SessionId as SessionIdStorageData
 
 interface ISplunkSessionManager {
     val sessionId: String


### PR DESCRIPTION
## Title: Modify scriptId to copy sessionId but take only SCRIPT_ID_LENGTH chars

### Description

According to new specification, scriptId should copy sessionId but take only first 16 chars.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.
