### PR TITLE
DEMRUM-3130: Update Android MRUM Agent to use standard /v1/logs and /v1/traces/ endpoints

### DIFF
--- a/common/otel/src/main/AndroidManifest.xml
+++ b/common/otel/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
             android:name="com.splunk.rum.common.otel.logRecord.UploadOtelLogRecordDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
-            android:name=".span.UploadSessionReplayDataJob"
+            android:name=".logRecord.UploadSessionReplayDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
     </application>
 

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/AndroidLogRecordExporter.kt
@@ -21,7 +21,6 @@ import com.splunk.android.common.job.JobIdStorage
 import com.splunk.rum.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.rum.common.otel.extensions.createZeroLengthSpan
 import com.splunk.rum.common.otel.internal.RumConstants
-import com.splunk.rum.common.otel.span.UploadSessionReplayData
 import com.splunk.rum.common.storage.IAgentStorage
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
@@ -53,7 +53,7 @@ internal class UploadOtelLogRecordDataJob : JobService() {
         params?.extras?.getString(DATA_SERIALIZE_KEY)?.let { id ->
             Logger.d(TAG, "startUpload() id: $id")
 
-            val url = storage.readBaseUrl()
+            val url = storage.readTracesBaseUrl()
 
             if (url == null) {
                 Logger.d(TAG, "startUpload() url is not valid")

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadSessionReplayData.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadSessionReplayData.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.common.otel.span
+package com.splunk.rum.common.otel.logRecord
 
 import android.app.job.JobInfo
 import android.content.Context

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.rum.common.otel.span
+package com.splunk.rum.common.otel.logRecord
 
 import android.annotation.SuppressLint
 import android.app.job.JobInfo
@@ -53,7 +53,7 @@ internal class UploadSessionReplayDataJob : JobService() {
         params?.extras?.getString(DATA_SERIALIZE_KEY)?.let { id ->
             Logger.d(TAG, "startUpload() id: $id")
 
-            val url = storage.readSessionReplayBaseUrl()
+            val url = storage.readLogsBaseUrl()
 
             if (url == null) {
                 Logger.d(TAG, "startUpload() url is not valid")

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
@@ -53,7 +53,7 @@ internal class UploadOtelSpanDataJob : JobService() {
         params?.extras?.getString(DATA_SERIALIZE_KEY)?.let { id ->
             Logger.d(TAG, "startUpload() id: $id")
 
-            val url = storage.readBaseUrl()
+            val url = storage.readTracesBaseUrl()
 
             if (url == null) {
                 Logger.d(TAG, "startUpload() url is not valid")

--- a/common/storage/src/main/java/com/splunk/rum/common/storage/AgentStorage.kt
+++ b/common/storage/src/main/java/com/splunk/rum/common/storage/AgentStorage.kt
@@ -93,24 +93,24 @@ class AgentStorage(context: Context) : IAgentStorage {
         }
 
     override fun writeTracesBaseUrl(value: String) {
-        preferences.putString(BASE_URL, value).commit()
+        preferences.putString(TRACES_BASE_URL, value).commit()
     }
 
     override fun deleteTracesBaseUrl() {
-        preferences.remove(BASE_URL)
+        preferences.remove(TRACES_BASE_URL)
     }
 
-    override fun readTracesBaseUrl(): String? = preferences.getString(BASE_URL)
+    override fun readTracesBaseUrl(): String? = preferences.getString(TRACES_BASE_URL)
 
     override fun writeLogsBaseUrl(value: String) {
-        preferences.putString(SESSION_REPLAY_BASE_URL, value).commit()
+        preferences.putString(LOGS_BASE_URL, value).commit()
     }
 
     override fun deleteLogsBaseUrl() {
-        preferences.remove(SESSION_REPLAY_BASE_URL)
+        preferences.remove(LOGS_BASE_URL)
     }
 
-    override fun readLogsBaseUrl(): String? = preferences.getString(SESSION_REPLAY_BASE_URL)
+    override fun readLogsBaseUrl(): String? = preferences.getString(LOGS_BASE_URL)
 
     override fun writeDeviceId(value: String) {
         preferences.putString(DEVICE_ID, value).commit()
@@ -275,8 +275,8 @@ class AgentStorage(context: Context) : IAgentStorage {
     }
 
     companion object {
-        private const val BASE_URL = "BASE_URL"
-        private const val SESSION_REPLAY_BASE_URL = "SESSION_REPLAY_BASE_URL"
+        private const val TRACES_BASE_URL = "TRACES_BASE_URL"
+        private const val LOGS_BASE_URL = "LOGS_BASE_URL"
         private const val DEVICE_ID = "DEVICE_ID"
         private const val SESSION_ID = "SESSION_ID"
         private const val SESSION_IDS = "SESSION_IDS"

--- a/common/storage/src/main/java/com/splunk/rum/common/storage/AgentStorage.kt
+++ b/common/storage/src/main/java/com/splunk/rum/common/storage/AgentStorage.kt
@@ -92,25 +92,25 @@ class AgentStorage(context: Context) : IAgentStorage {
             return isFull
         }
 
-    override fun writeBaseUrl(value: String) {
+    override fun writeTracesBaseUrl(value: String) {
         preferences.putString(BASE_URL, value).commit()
     }
 
-    override fun deleteBaseUrl() {
+    override fun deleteTracesBaseUrl() {
         preferences.remove(BASE_URL)
     }
 
-    override fun readBaseUrl(): String? = preferences.getString(BASE_URL)
+    override fun readTracesBaseUrl(): String? = preferences.getString(BASE_URL)
 
-    override fun writeSessionReplayBaseUrl(value: String) {
+    override fun writeLogsBaseUrl(value: String) {
         preferences.putString(SESSION_REPLAY_BASE_URL, value).commit()
     }
 
-    override fun deleteSessionReplayBaseUrl() {
+    override fun deleteLogsBaseUrl() {
         preferences.remove(SESSION_REPLAY_BASE_URL)
     }
 
-    override fun readSessionReplayBaseUrl(): String? = preferences.getString(SESSION_REPLAY_BASE_URL)
+    override fun readLogsBaseUrl(): String? = preferences.getString(SESSION_REPLAY_BASE_URL)
 
     override fun writeDeviceId(value: String) {
         preferences.putString(DEVICE_ID, value).commit()

--- a/common/storage/src/main/java/com/splunk/rum/common/storage/IAgentStorage.kt
+++ b/common/storage/src/main/java/com/splunk/rum/common/storage/IAgentStorage.kt
@@ -21,13 +21,13 @@ interface IAgentStorage {
     val rootDirPath: String
     val isStorageFull: Boolean
 
-    fun writeBaseUrl(value: String)
-    fun deleteBaseUrl()
-    fun readBaseUrl(): String?
+    fun writeTracesBaseUrl(value: String)
+    fun deleteTracesBaseUrl()
+    fun readTracesBaseUrl(): String?
 
-    fun writeSessionReplayBaseUrl(value: String)
-    fun deleteSessionReplayBaseUrl()
-    fun readSessionReplayBaseUrl(): String?
+    fun writeLogsBaseUrl(value: String)
+    fun deleteLogsBaseUrl()
+    fun readLogsBaseUrl(): String?
 
     fun writeDeviceId(value: String)
     fun readDeviceId(): String?

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/EndpointConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/EndpointConfiguration.kt
@@ -20,9 +20,9 @@ import java.net.URL
 
 class EndpointConfiguration {
 
-    var traceEndpoint: URL? = null
+    var tracesEndpoint: URL? = null
         private set
-    var sessionReplayEndpoint: URL? = null
+    var logsEndpoint: URL? = null
         private set
     var realm: String? = null
         private set
@@ -38,23 +38,23 @@ class EndpointConfiguration {
     constructor(realm: String, rumAccessToken: String) {
         this.realm = realm
         this.rumAccessToken = rumAccessToken
-        traceEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/rumotlp?auth=$rumAccessToken")
-        this.sessionReplayEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/rumreplay?auth=$rumAccessToken")
+        this.tracesEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/traces?auth=$rumAccessToken")
+        this.logsEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/logs?auth=$rumAccessToken")
     }
 
     /**
-     * @param trace Sets the "beacon" endpoint URL to be used by the RUM library.
+     * @param traces Sets the "beacon" endpoint URL to be used by the RUM library.
      */
-    constructor(trace: URL) {
-        traceEndpoint = trace
+    constructor(traces: URL) {
+        tracesEndpoint = traces
     }
 
     /**
-     * @param trace Sets the "beacon" endpoint URL to be used by the RUM library.
-     * @param sessionReplay Sets the "session replay" endpoint URL to be used by the RUM library.
+     * @param traces Sets the "beacon" endpoint URL to be used by the RUM library.
+     * @param logs Sets the "session replay" endpoint URL to be used by the RUM library.
      */
-    constructor(trace: URL, sessionReplay: URL) {
-        traceEndpoint = trace
-        this.sessionReplayEndpoint = sessionReplay
+    constructor(traces: URL, logs: URL) {
+        tracesEndpoint = traces
+        logsEndpoint = logs
     }
 }

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/SplunkRumBuilder.kt
@@ -259,7 +259,7 @@ class SplunkRumBuilder {
                 accessToken ?: throw IllegalStateException("rumAccessToken was not set")
             )
             beaconEndpoint != null -> EndpointConfiguration(
-                trace = URL(beaconEndpoint)
+                traces = URL(beaconEndpoint)
             )
             else ->
                 throw IllegalStateException("setRealm() or setBeaconEndpoint() was not called")

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/configuration/ConfigurationManager.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/configuration/ConfigurationManager.kt
@@ -29,8 +29,8 @@ internal class ConfigurationManager private constructor(private val agentStorage
             config = config.copy(appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName)
         }
 
-        agentStorage.writeSessionReplayBaseUrl(config.endpoint.sessionReplayEndpoint!!.toExternalForm())
-        agentStorage.writeBaseUrl(config.endpoint.traceEndpoint!!.toExternalForm())
+        agentStorage.writeLogsBaseUrl(config.endpoint.logsEndpoint!!.toExternalForm())
+        agentStorage.writeTracesBaseUrl(config.endpoint.tracesEndpoint!!.toExternalForm())
 
         Logger.d(TAG, "preProcessConfiguration() proposalConfig: $proposalConfig, config: $config")
 


### PR DESCRIPTION
## Title: Update Android MRUM Agent to use standard /v1/logs and /v1/traces/ endpoints

### Description

- Rename urls used for uploading traces and session replay data (logs)
- Change api to reflect this change (Rename properties in EndpointConfiguration)

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### How to Test These Changes

[Provide clear and step-by-step instructions on how reviewers can test the changes you've made.]

### Future Considerations (Optional)

[Mention any related upcoming work or considerations for the future.]