### PR TITLE
NO-TICKET: Skip GAI usage disclosure for bots

### DIFF
--- a/.github/actions/validate-gai-usage-disclosure/action.yml
+++ b/.github/actions/validate-gai-usage-disclosure/action.yml
@@ -9,4 +9,5 @@ runs:
       shell: bash
       env:
         PR_BODY: ${{ github.event.pull_request.body }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: bash ./.github/actions/validate-gai-usage-disclosure/gai_usage_disclosure_check.sh

--- a/.github/actions/validate-gai-usage-disclosure/gai_usage_disclosure_check.sh
+++ b/.github/actions/validate-gai-usage-disclosure/gai_usage_disclosure_check.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# List of authors to skip
+SKIP_AUTHORS=("renovate[bot]" "renovate-bot")
+
+for author in "${SKIP_AUTHORS[@]}"; do
+  if [[ "$PR_AUTHOR" == "$author" ]]; then
+    echo "PR authored by $PR_AUTHOR, skipping validation."
+    exit 0
+  fi
+done
+
 # Get PR body from the environment variable set in the workflow
 body="$PR_BODY"
 

--- a/.github/actions/validate-pr-title/pr_title_check.sh
+++ b/.github/actions/validate-pr-title/pr_title_check.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-# Debug logging
-echo "DEBUG: PR_AUTHOR='$PR_AUTHOR'"
-echo "DEBUG: PR_TITLE='$PR_TITLE'"
-
 # List of authors to skip
 SKIP_AUTHORS=("renovate[bot]" "renovate-bot")
 


### PR DESCRIPTION
### Description

The bots submitting code to our repository do not need to disclose GAI usage.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Merge the PR and rerun the pipelines for PRs from bots.
