### PR TITLE
DEMRUM-3367: Consolidate Gradle Plugin Publish Code

### DIFF
--- a/buildSrc/src/main/kotlin/GradlePluginPublishingUtils.kt
+++ b/buildSrc/src/main/kotlin/GradlePluginPublishingUtils.kt
@@ -1,0 +1,83 @@
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.get
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import utils.defaultGroupId
+
+fun Project.createStandardJars() {
+    tasks.create("javadocJar", Jar::class) {
+        archiveClassifier.set("javadoc")
+        from(tasks.named("javadoc"))
+    }
+
+    tasks.create("sourcesJar", Jar::class) {
+        archiveClassifier.set("sources")
+        from(provider {
+            project.extensions.getByType<SourceSetContainer>()["main"].allSource
+        })
+    }
+
+    tasks.named<Jar>("jar") {
+        manifest {
+            attributes(
+                "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
+            )
+        }
+    }
+
+    tasks.withType<PublishToMavenRepository>().configureEach {
+        dependsOn(tasks.withType<Sign>())
+    }
+}
+
+fun Project.configureGradlePluginPublishing(artifactIdValue: String) {
+    extensions.configure<PublishingExtension> {
+        publications {
+            withType<MavenPublication> {
+                if (!name.contains("PluginMarkerMaven")) {
+                    pom.withXml { asNode().addSplunkInfo() }
+                    artifactId = artifactIdValue
+                    artifact(tasks.named("javadocJar"))
+                    artifact(tasks.named("sourcesJar"))
+                }
+            }
+        }
+        repositories {
+            mavenLocal()
+        }
+    }
+}
+
+fun Project.configureGradlePluginSigning() {
+    extensions.configure<SigningExtension> {
+        val signingKey: String? = project.findProperty("signingKey") as String?
+        val signingPassword: String? = project.findProperty("signingPassword") as String?
+
+        if (signingKey != null && signingPassword != null) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+            sign(project.extensions.getByType<PublishingExtension>().publications)
+        } else {
+            println("WARNING: Environment variables signingKey and/or signingPassword not set. Skipping signing of artifacts.")
+        }
+    }
+}
+
+fun Project.addPublishingOutput() {
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        doLast {
+            val artifact = "$defaultGroupId:${publication.artifactId}:${publication.version}"
+
+            println("╔══════════════════════════════════════════════════════════════════════════════════════════════════╗")
+            println("published".toBoxString())
+            println(artifact.toBoxString())
+            println("╚══════════════════════════════════════════════════════════════════════════════════════════════════╝")
+        }
+    }
+}

--- a/instrumentation/buildtime/httpurlconnection-auto/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/httpurlconnection-auto/plugin/build.gradle.kts
@@ -11,27 +11,7 @@ plugins {
 group = defaultGroupId
 version = Configurations.sdkVersionName
 
-val javadocJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("javadoc")
-    from(tasks.named("javadoc"))
-}
-
-val sourcesJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource)
-}
-
-tasks.jar {
-    manifest {
-        attributes(
-            "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
-        )
-    }
-}
-
-tasks.withType<PublishToMavenRepository>().configureEach {
-    dependsOn(tasks.withType<Sign>())
-}
+createStandardJars()
 
 gradlePlugin {
     plugins {
@@ -49,34 +29,6 @@ dependencies {
     implementation(gradleApi())
 }
 
-signing {
-    val signingKey: String? = project.findProperty("signingKey") as String?
-    val signingPassword: String? = project.findProperty("signingPassword") as String?
-
-
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications)
-    } else {
-        println("WARNING: Environment variables signingKey and/or signingPassword not set. Skipping signing of artifacts.")
-    }
-}
-
-publishing {
-    publications {
-        withType(MavenPublication::class.java) {
-            pom.withXml { asNode().addSplunkInfo() }
-
-            artifactId = "${artifactPrefix}httpurlconnection-auto-plugin"
-
-            artifact(javadocJar)
-            artifact(sourcesJar)
-        }
-        repositories {
-            maven {
-                name = "local"
-                url = uri("$projectDir/repo")
-            }
-        }
-    }
-}
+configureGradlePluginSigning()
+configureGradlePluginPublishing("${artifactPrefix}httpurlconnection-auto-plugin")
+addPublishingOutput()

--- a/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
@@ -13,27 +13,7 @@ plugins {
 group = defaultGroupId
 version = Configurations.sdkVersionName
 
-val javadocJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("javadoc")
-    from(tasks.named("javadoc"))
-}
-
-val sourcesJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource)
-}
-
-tasks.jar {
-    manifest {
-        attributes(
-            "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
-        )
-    }
-}
-
-tasks.withType<PublishToMavenRepository>().configureEach {
-    dependsOn(tasks.withType<Sign>())
-}
+createStandardJars()
 
 gradlePlugin {
     plugins {
@@ -50,33 +30,6 @@ dependencies {
     implementation(Dependencies.gradle)
 }
 
-signing {
-    val signingKey: String? = project.findProperty("signingKey") as String?
-    val signingPassword: String? = project.findProperty("signingPassword") as String?
-
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications)
-    } else {
-        println("WARNING: Environment variables signingKey and/or signingPassword not set. Skipping signing of artifacts.")
-    }
-}
-
-publishing {
-    publications {
-        withType(MavenPublication::class.java) {
-            pom.withXml { asNode().addSplunkInfo() }
-
-            artifactId = "${artifactPrefix}$pluginName"
-
-            artifact(javadocJar)
-            artifact(sourcesJar)
-        }
-        repositories {
-            maven {
-                name = "local"
-                url = uri("$projectDir/repo")
-            }
-        }
-    }
-}
+configureGradlePluginSigning()
+configureGradlePluginPublishing("${artifactPrefix}$pluginName")
+addPublishingOutput()

--- a/instrumentation/buildtime/okhttp3-auto/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/okhttp3-auto/plugin/build.gradle.kts
@@ -11,27 +11,7 @@ plugins {
 group = defaultGroupId
 version = Configurations.sdkVersionName
 
-val javadocJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("javadoc")
-    from(tasks.named("javadoc"))
-}
-
-val sourcesJar by tasks.creating(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource)
-}
-
-tasks.jar {
-    manifest {
-        attributes(
-            "Implementation-Version" to Dependencies.Otel.otelAndroidBomVersion
-        )
-    }
-}
-
-tasks.withType<PublishToMavenRepository>().configureEach {
-    dependsOn(tasks.withType<Sign>())
-}
+createStandardJars()
 
 gradlePlugin {
     plugins {
@@ -49,33 +29,6 @@ dependencies {
     implementation(gradleApi())
 }
 
-signing {
-    val signingKey: String? = project.findProperty("signingKey") as String?
-    val signingPassword: String? = project.findProperty("signingPassword") as String?
-
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications)
-    } else {
-        println("WARNING: Environment variables signingKey and/or signingPassword not set. Skipping signing of artifacts.")
-    }
-}
-
-publishing {
-    publications {
-        withType(MavenPublication::class.java) {
-            pom.withXml { asNode().addSplunkInfo() }
-
-            artifactId = "${artifactPrefix}okhttp3-auto-plugin"
-
-            artifact(javadocJar)
-            artifact(sourcesJar)
-        }
-        repositories {
-            maven {
-                name = "local"
-                url = uri("$projectDir/repo")
-            }
-        }
-    }
-}
+configureGradlePluginSigning()
+configureGradlePluginPublishing("${artifactPrefix}okhttp3-auto-plugin")
+addPublishingOutput()


### PR DESCRIPTION
## Title: Unify common Gradle Plugin code

Created a unified publishing configuration for Gradle plugin modules in `instrumentation:buildtime` through shared helper functions in `GradlePluginPublishingUtils.kt `. This reduces code duplication while ensuring consistent gradle setup, formatting, and publishing across all plugin modules.

### Changes 

Created `GradlePluginPublishingUtils.kt` with four shared helper functions:

- `createStandardJars()` - Creates javadoc and sources JARs with proper configuration
- `configureGradlePluginPublishing()` - Configures Maven publication while preserving plugin marker publications
- `configureGradlePluginSigning()` - Configures artifact signing with proper key handling
- `addPublishingOutput()` - Prints formatted console output when artifacts are published

Updated httpurlconnection-auto-plugin, mapping-file-plugin, and okhttp3-auto-plugin `build.gradle` files to use the shared helper functions

### Context
Although creating a `ConfigPlugin` style class like the existing `ConfigPublish` for our runtime modules is ideal, there are some issues. 

The existing `ConfigPublish` works well for Android runtime modules because it explicitly creates its own Maven publication with full control. However, Gradle plugins require the `java-gradle-plugin`, which automatically creates TWO publications: the main plugin JAR and a plugin marker publication.

Without going into too much detail here, attempting to create a `ConfigPlugin` class or precompiled script plugin for these Gradle Plugins fails due to timing/lifecycle issues:
- Wrapping configuration in `afterEvaluate` created race conditions with `java-gradle-plugin`'s own `afterEvaluate` callback
- The plugin marker publications were either misconfigured or not created at all, breaking the plugin resolution
- Property access via `extra` wasn't available at the right time in the configuration lifecycle

This approach by unifying much of the common code in the `GradlePluginPublishingUtils.kt ` class preserves the natural configuration order of Gradle and enables the markers to be published properly.

Each module's own `gradlePlugin {}` block runs at the top level where it works with the `java-gradle-plugin` as its supposed to, but still we were able to significantly reduce duplicate setups which could be prone to varying or differing in the future

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [n/a?] I have added license headers to all files. - I don't think this is needed for gradle build script files?
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage 

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Build and publish to Maven Local
- Verify Gradle Plugins are published successfully to Maven Local
- Add all three Gradle Plugins to sample app (with locally published snapshot version) and verify build succeeds