### PR TITLE
NO-TICKET: Fix Gradle Plugin Publish Bug

### DIFF
--- a/buildSrc/src/main/kotlin/GradlePluginPublishingUtils.kt
+++ b/buildSrc/src/main/kotlin/GradlePluginPublishingUtils.kt
@@ -49,6 +49,7 @@ fun Project.configureGradlePluginPublishing(artifactIdValue: String) {
                 }
             }
         }
+        
         repositories {
             mavenLocal()
         }


### PR DESCRIPTION
Resolve issue of Splunk Info not being added to POM

### Description

Resolve issue of Splunk Info not being added to POM

Removed check for PluginMarkerMaven which was no longer necessary after we decided to not go with the single unified ConfigPlugin approach.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Publish to Maven Local and ensure that the .plugin file is present in all the gradle plugin directories