### PR TITLE
NO-TICKET: Migrate from FOSSA to SRS configuration

### DIFF
--- a/srs.yaml
+++ b/srs.yaml
@@ -1,0 +1,16 @@
+# SRS configuration file
+# Generated from .fossa.yml
+#
+# WARNING: The following FOSSA features are NOT supported in SRS
+# (only skip-files and skip-dirs are supported for now):
+#
+#   - experimental.gradle.configurations-only: ['androidApis', 'androidJdkImage', 'compileOnly', 'compileOnlyApi', 'coreLibraryDesugaring', 'debugApi', 'debugApiElements', 'debugImplementation', 'debugRuntimeClasspath', 'debugRuntimeElements', 'debugRuntimeOnly', 'debugWearApp', 'implementation', 'releaseApi', 'releaseApiElements', 'releaseImplementation', 'releaseRuntimeClasspath', 'releaseRuntimeElements', 'releaseRuntimeOnly', 'releaseVariantReleaseApiPublication', 'releaseVariantReleaseRuntimePublication', 'releaseWearApp', 'runtimeOnly', 'wearApp']
+#     FOSSA was configured to scan only Gradle configurations: ['androidApis', 'androidJdkImage', 'compileOnly', 'compileOnlyApi', 'coreLibraryDesugaring', 'debugApi', 'debugApiElements', 'debugImplementation', 'debugRuntimeClasspath', 'debugRuntimeElements', 'debugRuntimeOnly', 'debugWearApp', 'implementation', 'releaseApi', 'releaseApiElements', 'releaseImplementation', 'releaseRuntimeClasspath', 'releaseRuntimeElements', 'releaseRuntimeOnly', 'releaseVariantReleaseApiPublication', 'releaseVariantReleaseRuntimePublication', 'releaseWearApp', 'runtimeOnly', 'wearApp']
+#     SRS does not support Gradle configuration filtering.
+#     Only 'compileClasspath', 'runtimeClasspath' configurations will be scanned.
+#
+
+scan:
+  scanners:
+  - vuln
+  - license


### PR DESCRIPTION
**Summary**

This PR adds a srs.yaml configuration file generated from the existing .fossa.yml configuration.

**What Changed**

Added srs.yaml with settings migrated from .fossa.yml
Mapped FOSSA paths.exclude to SRS skip-dirs
Mapped FOSSA targets.exclude (type + path) to SRS skip-files

**Next Steps**

- Review the generated srs.yaml configuration
- Check warning comments for any unsupported features

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI