### PR TITLE
DEMRUM-4990: Update new lifecycle module with default allowed events

### DIFF
--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -130,13 +130,14 @@ class App : Application() {
     )
 
     private val lifecycleModuleConfiguration = LifecycleModuleConfiguration(
-        isEnabled = true
-        // Uncomment below allowedEvents to configure event filtration
-//        allowedEvents = setOf(
-//            LifecycleAction.CREATED,
-//            LifecycleAction.RESUMED,
-//            LifecycleAction.DESTROYED
-//        )
+        isEnabled = true,
+        allowedEvents = setOf(LifecycleAction.POST_CREATED, LifecycleAction.DESTROYED)
+        // Default tracks RESUMED + PAUSED only. For more detail, use a preset:
+        //   allowedEvents = LifecycleModuleConfiguration.CORE_LIFECYCLE_EVENTS
+        //   allowedEvents = LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS
+        // or a custom set of events:
+        //   allowedEvents = setOf(LifecycleAction.POST_CREATED, LifecycleAction.DESTROYED)
+
     )
 
     private val navigationModuleConfiguration = NavigationModuleConfiguration()

--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -130,12 +130,11 @@ class App : Application() {
     )
 
     private val lifecycleModuleConfiguration = LifecycleModuleConfiguration(
-        isEnabled = true,
-        allowedEvents = setOf(LifecycleAction.POST_CREATED, LifecycleAction.DESTROYED)
+        isEnabled = true
         // Default tracks RESUMED + PAUSED only. For more detail, use a preset:
         //   allowedEvents = LifecycleModuleConfiguration.CORE_LIFECYCLE_EVENTS
         //   allowedEvents = LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS
-        // or a custom set of events:
+        // or a custom set of events eg:
         //   allowedEvents = setOf(LifecycleAction.POST_CREATED, LifecycleAction.DESTROYED)
 
     )

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
@@ -25,8 +25,12 @@ import com.splunk.rum.integration.lifecycle.model.LifecycleAction
  * This module captures Android Activity and Fragment lifecycle transitions and emits them
  * as OpenTelemetry `device.app.ui.lifecycle` events.
  *
+ * By default, only [LifecycleAction.RESUMED] and [LifecycleAction.PAUSED] events are tracked,
+ * producing roughly the same event volume as the legacy navigation module. Use the preset
+ * constants ([CORE_LIFECYCLE_EVENTS], [ALL_LIFECYCLE_EVENTS]) or a custom set for more detail.
+ *
  * @property isEnabled Whether the module is enabled. Default is true.
- * @property allowedEvents Set of lifecycle actions to track. Default is all events.
+ * @property allowedEvents Set of lifecycle actions to track. Default is RESUMED and PAUSED.
  */
 data class LifecycleModuleConfiguration @JvmOverloads constructor(
     val isEnabled: Boolean = true,
@@ -42,8 +46,35 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
 
     companion object {
         /**
-         * Default set of allowed lifecycle events - includes all events.
+         * Default: tracks only screen visible (resumed) and screen hidden (paused) transitions.
          */
-        val DEFAULT_ALLOWED_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
+        val DEFAULT_ALLOWED_EVENTS: Set<LifecycleAction> = setOf(
+            LifecycleAction.RESUMED,
+            LifecycleAction.PAUSED
+        )
+
+        /**
+         * Core lifecycle events without pre/post variants. Covers the main lifecycle transitions
+         * for both Activities and Fragments
+         */
+        @JvmField
+        val CORE_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
+            LifecycleAction.CREATED,
+            LifecycleAction.STARTED,
+            LifecycleAction.RESUMED,
+            LifecycleAction.PAUSED,
+            LifecycleAction.STOPPED,
+            LifecycleAction.DESTROYED,
+            LifecycleAction.ATTACHED,
+            LifecycleAction.VIEW_CREATED,
+            LifecycleAction.VIEW_DESTROYED,
+            LifecycleAction.DETACHED
+        )
+
+        /**
+         * Every lifecycle callback including pre/post variants (API 29+).
+         */
+        @JvmField
+        val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
     }
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
@@ -57,7 +57,6 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
          * Core lifecycle events without pre/post variants. Covers the main lifecycle transitions
          * for both Activities and Fragments
          */
-        @JvmField
         val CORE_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
             LifecycleAction.CREATED,
             LifecycleAction.STARTED,
@@ -74,7 +73,6 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
         /**
          * Every lifecycle callback including pre/post variants (API 29+).
          */
-        @JvmField
         val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
     }
 }


### PR DESCRIPTION
### Description

The lifecycle module currently defaults to emitting every lifecycle callback (including pre/post on API 29+), which clutters the session view and overwhelms the data from the old navigation module that's still in production. This change makes the default output cleaner while keeping full lifecycle available as an opt in.

Description
- Change `DEFAULT_ALLOWED_EVENTS` from all lifecycle events to only `RESUMED` and `PAUSED` , reducing session view noise to a volume comparable to the legacy navigation module
- Add `CORE_LIFECYCLE_EVENTS` preset (10 main events, no pre/post variants) and `ALL_LIFECYCLE_EVENTS` preset (restores previous default) so customers can easily opt in to more detail without enumerating individual events
- Update sample app comments to show preset usage

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Build and run the sample app with no configuration changes, verify only resumed and paused lifecycle events appear in the session view or logcat
- Set allowedEvents = `LifecycleModuleConfiguration.CORE_LIFECYCLE_EVENTS` and verify core events (created, started, resumed, paused, stopped, destroyed, attached, view_created, view_destroyed, detached) appear
- Set allowedEvents = `LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS` and verify all events including pre/post appear
- Repeat same with custom set of events if desired