### PR TITLE
DEMRUM-4990: Update lifecycle module default allowed events

### DIFF
--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -130,11 +130,10 @@ class App : Application() {
     )
 
     private val lifecycleModuleConfiguration = LifecycleModuleConfiguration(
-        isEnabled = true,
-        // Uncomment below allowedEvents to configure event filtration
-        allowedEvents = setOf(
-            LifecycleAction.RESUMED
-        )
+        isEnabled = true
+        // Default tracks CORE_LIFECYCLE_EVENTS (no pre/post variants). For other options:
+        //   allowedEvents = LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS
+        //   allowedEvents = setOf(LifecycleAction.RESUMED, LifecycleAction.PAUSED)
     )
 
     private val navigationModuleConfiguration = NavigationModuleConfiguration(

--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -131,8 +131,9 @@ class App : Application() {
 
     private val lifecycleModuleConfiguration = LifecycleModuleConfiguration(
         isEnabled = true
-        // Default tracks CORE_LIFECYCLE_EVENTS (no pre/post variants). For other options:
+        // Default tracks MAIN_LIFECYCLE_EVENTS (no pre/post variants). For other options:
         //   allowedEvents = LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS
+        //   allowedEvents = LifecycleModuleConfiguration.PRE_POST_LIFECYCLE_EVENTS
         //   allowedEvents = setOf(LifecycleAction.RESUMED, LifecycleAction.PAUSED)
     )
 

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
@@ -26,7 +26,7 @@ import com.splunk.rum.integration.lifecycle.model.LifecycleAction
  * as OpenTelemetry `device.app.ui.lifecycle` events.
  *
  * @property isEnabled Whether the module is enabled. Default is true.
- * @property allowedEvents Set of lifecycle actions to track. Default is all events.
+ * @property allowedEvents Set of lifecycle actions to track. Default is [CORE_LIFECYCLE_EVENTS].
  */
 data class LifecycleModuleConfiguration @JvmOverloads constructor(
     val isEnabled: Boolean = true,
@@ -42,8 +42,31 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
 
     companion object {
         /**
-         * Default set of allowed lifecycle events - includes all events.
+         * Core lifecycle events without pre/post variants. Covers the main lifecycle transitions
+         * for both Activities and Fragments.
          */
-        val DEFAULT_ALLOWED_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
+        val CORE_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
+            LifecycleAction.CREATED,
+            LifecycleAction.STARTED,
+            LifecycleAction.RESUMED,
+            LifecycleAction.PAUSED,
+            LifecycleAction.STOPPED,
+            LifecycleAction.DESTROYED,
+            LifecycleAction.ATTACHED,
+            LifecycleAction.VIEW_CREATED,
+            LifecycleAction.VIEW_DESTROYED,
+            LifecycleAction.DETACHED
+        )
+
+        /**
+         * Every lifecycle callback including pre/post variants (API 29+).
+         * Full diagnostic detail.
+         */
+        val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
+
+        /**
+         * Default: tracks core lifecycle events (no pre/post variants).
+         */
+        val DEFAULT_ALLOWED_EVENTS: Set<LifecycleAction> = CORE_LIFECYCLE_EVENTS
     }
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleModuleConfiguration.kt
@@ -26,11 +26,11 @@ import com.splunk.rum.integration.lifecycle.model.LifecycleAction
  * as OpenTelemetry `device.app.ui.lifecycle` events.
  *
  * @property isEnabled Whether the module is enabled. Default is true.
- * @property allowedEvents Set of lifecycle actions to track. Default is [CORE_LIFECYCLE_EVENTS].
+ * @property allowedEvents Set of lifecycle actions to track. Default is [MAIN_LIFECYCLE_EVENTS].
  */
 data class LifecycleModuleConfiguration @JvmOverloads constructor(
     val isEnabled: Boolean = true,
-    val allowedEvents: Set<LifecycleAction> = DEFAULT_ALLOWED_EVENTS
+    val allowedEvents: Set<LifecycleAction> = MAIN_LIFECYCLE_EVENTS
 ) : ModuleConfiguration {
 
     override val name: String = "lifecycle"
@@ -42,10 +42,10 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
 
     companion object {
         /**
-         * Core lifecycle events without pre/post variants. Covers the main lifecycle transitions
-         * for both Activities and Fragments.
+         * The 10 main lifecycle transitions for Activities and Fragments,
+         * without pre/post variants. This is the default.
          */
-        val CORE_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
+        val MAIN_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
             LifecycleAction.CREATED,
             LifecycleAction.STARTED,
             LifecycleAction.RESUMED,
@@ -59,14 +59,29 @@ data class LifecycleModuleConfiguration @JvmOverloads constructor(
         )
 
         /**
-         * Every lifecycle callback including pre/post variants (API 29+).
-         * Full diagnostic detail.
+         * Pre/post lifecycle variants only (API 29+).
+         * Use alongside [MAIN_LIFECYCLE_EVENTS] for full detail, or on its own.
          */
-        val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
+        val PRE_POST_LIFECYCLE_EVENTS: Set<LifecycleAction> = setOf(
+            LifecycleAction.PRE_CREATED,
+            LifecycleAction.POST_CREATED,
+            LifecycleAction.PRE_STARTED,
+            LifecycleAction.POST_STARTED,
+            LifecycleAction.PRE_RESUMED,
+            LifecycleAction.POST_RESUMED,
+            LifecycleAction.PRE_PAUSED,
+            LifecycleAction.POST_PAUSED,
+            LifecycleAction.PRE_STOPPED,
+            LifecycleAction.POST_STOPPED,
+            LifecycleAction.PRE_DESTROYED,
+            LifecycleAction.POST_DESTROYED,
+            LifecycleAction.PRE_ATTACHED
+        )
 
         /**
-         * Default: tracks core lifecycle events (no pre/post variants).
+         * Every lifecycle callback including pre/post variants (API 29+).
+         * Equivalent to [MAIN_LIFECYCLE_EVENTS] + [PRE_POST_LIFECYCLE_EVENTS].
          */
-        val DEFAULT_ALLOWED_EVENTS: Set<LifecycleAction> = CORE_LIFECYCLE_EVENTS
+        val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction> = LifecycleAction.values().toSet()
     }
 }


### PR DESCRIPTION
### Description

- Changed the default `allowedEvents` from all lifecycle events (~23 including pre/post variants) to `MAIN_LIFECYCLE_EVENTS` — the 10 main lifecycle transitions without pre/post variants:
Activity/Fragment common: `CREATED`, `STARTED`, `RESUMED`, `PAUSED`, `STOPPED`, `DESTROYED`
Fragment-specific: `ATTACHED`, `VIEW_CREATED`, `VIEW_DESTROYED`, `DETACHED`

- Added three self documenting preset constants to `LifecycleModuleConfiguration` for easy customer configuration:
`MAIN_LIFECYCLE_EVENTS` — the default (10 main transitions)
`PRE_POST_LIFECYCLE_EVENTS` — just the pre/post variants (13 events, API 29+)
`ALL_LIFECYCLE_EVENTS` — Main + Pre/Post combined (all 23 events)

Updated sample app to use the new default and document available presets

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Build test app with specific configuration of allowed events, or leave as default. 
Confirm that events emitted are correct