### PR TITLE
DEMRUM-4990: Add fragment hierarchy attributes to fragment lifecycle events

### DIFF
--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleEventEmitter.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleEventEmitter.kt
@@ -66,12 +66,16 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
     fun emitFragmentEvent(fragment: Fragment, action: LifecycleAction) {
         val elementId = fragment::class.java.name // Class-level tracking
         val elementName = fragment::class.java.simpleName
+        val activityName = fragment.activity?.javaClass?.simpleName
+        val parentFragmentName = fragment.parentFragment?.javaClass?.simpleName
         emitEvent(
             elementType = RumConstants.UI_LIFECYCLE_FRAGMENT_TYPE,
             elementName = elementName,
             elementId = elementId,
             action = action,
-            timestamp = System.currentTimeMillis()
+            timestamp = System.currentTimeMillis(),
+            activityName = activityName,
+            parentFragmentName = parentFragmentName
         )
     }
 
@@ -85,7 +89,9 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
         elementName: String,
         elementId: String,
         action: LifecycleAction,
-        timestamp: Long
+        timestamp: Long,
+        activityName: String? = null,
+        parentFragmentName: String? = null
     ) {
         if (action !in allowedEvents) {
             Logger.d(TAG) {
@@ -99,12 +105,12 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
                 Logger.d(TAG) {
                     "Install not complete, caching lifecycle event: $elementType.$elementName - ${action.attributeValue}"
                 }
-                cache += LifecycleEventData(elementType, elementName, elementId, action, timestamp)
+                cache += LifecycleEventData(elementType, elementName, elementId, action, timestamp, activityName, parentFragmentName)
                 return
             }
         }
 
-        emitEventInternal(elementType, elementName, elementId, action, timestamp)
+        emitEventInternal(elementType, elementName, elementId, action, timestamp, activityName, parentFragmentName)
     }
 
     /**
@@ -115,7 +121,9 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
         elementName: String,
         elementId: String,
         action: LifecycleAction,
-        timestamp: Long
+        timestamp: Long,
+        activityName: String? = null,
+        parentFragmentName: String? = null
     ) {
         val logger = SplunkOpenTelemetrySdk.instance?.sdkLoggerProvider
 
@@ -126,7 +134,7 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
 
         Logger.d(TAG) { "Emitting lifecycle event: $elementType.$elementName - ${action.attributeValue}" }
 
-        logger.get(GlobalRumConstants.RUM_TRACER_NAME)
+        val builder = logger.get(GlobalRumConstants.RUM_TRACER_NAME)
             .logRecordBuilder()
             .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
             .setAttribute(GlobalRumConstants.LOG_EVENT_NAME_KEY, RumConstants.UI_LIFECYCLE_LOG_NAME)
@@ -135,7 +143,15 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
             .setAttribute(RumConstants.ELEMENT_NAME_KEY, elementName)
             .setAttribute(RumConstants.ELEMENT_ID_KEY, elementId)
             .setAttribute(RumConstants.LIFECYCLE_ACTION_KEY, action.attributeValue)
-            .emit()
+
+        if (activityName != null) {
+            builder.setAttribute(RumConstants.ELEMENT_ACTIVITY_NAME_KEY, activityName)
+        }
+        if (parentFragmentName != null) {
+            builder.setAttribute(RumConstants.ELEMENT_PARENT_FRAGMENT_NAME_KEY, parentFragmentName)
+        }
+
+        builder.emit()
     }
 
     /**
@@ -169,7 +185,9 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
                     event.elementName,
                     event.elementId,
                     event.action,
-                    event.timestamp
+                    event.timestamp,
+                    event.activityName,
+                    event.parentFragmentName
                 )
             }
         }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleEventEmitter.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/LifecycleEventEmitter.kt
@@ -105,7 +105,16 @@ internal class LifecycleEventEmitter(private val allowedEvents: Set<LifecycleAct
                 Logger.d(TAG) {
                     "Install not complete, caching lifecycle event: $elementType.$elementName - ${action.attributeValue}"
                 }
-                cache += LifecycleEventData(elementType, elementName, elementId, action, timestamp, activityName, parentFragmentName)
+                cache +=
+                    LifecycleEventData(
+                        elementType,
+                        elementName,
+                        elementId,
+                        action,
+                        timestamp,
+                        activityName,
+                        parentFragmentName
+                    )
                 return
             }
         }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/RumConstants.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/RumConstants.kt
@@ -35,5 +35,7 @@ internal object RumConstants {
 
     // Fragment hierarchy attributes
     val ELEMENT_ACTIVITY_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.activity.name")
-    val ELEMENT_PARENT_FRAGMENT_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.parent.fragment.name")
+    val ELEMENT_PARENT_FRAGMENT_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey(
+        "device.app.ui.element.parent.fragment.name"
+    )
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/RumConstants.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/RumConstants.kt
@@ -32,4 +32,8 @@ internal object RumConstants {
     val ELEMENT_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.name")
     val ELEMENT_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.id")
     val LIFECYCLE_ACTION_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.lifecycle.action")
+
+    // Fragment hierarchy attributes
+    val ELEMENT_ACTIVITY_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.activity.name")
+    val ELEMENT_PARENT_FRAGMENT_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("device.app.ui.element.parent.fragment.name")
 }

--- a/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/model/LifecycleEventData.kt
+++ b/integration/lifecycle/src/main/java/com/splunk/rum/integration/lifecycle/model/LifecycleEventData.kt
@@ -21,5 +21,7 @@ internal data class LifecycleEventData(
     val elementName: String,
     val elementId: String,
     val action: LifecycleAction,
-    val timestamp: Long
+    val timestamp: Long,
+    val activityName: String? = null,
+    val parentFragmentName: String? = null
 )


### PR DESCRIPTION
### Description

Added two new attributes to fragment lifecycle events to encode the UI element containment hierarchy:
 - `device.app.ui.element.activity.name` the host Activity's simple class name (present on all fragment events where fragment.activity is non null)
 - `device.app.ui.element.parent.fragment.name` the parent Fragment's simple class name (present only on nested/child fragment events where fragment.parentFragment is non null)

- Activity lifecycle events are unaffected, they carry neither attribute since Activities are top level containers
- Attribute values are captured at emit time from the Fragment's existing references and cached correctly for deferred emission
- These attributes allow the UI to establish the relationship between Fragments and the Activity (or parent Fragment) that hosts them, potentially enabling future hierarchical grouping in the session view (Activity → Fragment → lifecycle events etc) without changing the flat, event based data model

Attribute naming is open to change for cross platform consistency. The current names are Android specific.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Build and run app
Verify fragment lifecycle events have correct parent fragment and activity attribute names