### PR TITLE
DEMRUM-4549: Implemented Jetpack Compose Navigation Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,11 @@ android {
 
     buildFeatures {
         viewBinding = true
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = AppDependencies.Android.Compose.compilerVersion
     }
 
     packagingOptions {
@@ -93,6 +98,13 @@ dependencies {
      */
     implementation(AppDependencies.okhttp)
     implementation(AppDependencies.okio)
+
+    implementation(AppDependencies.Android.Compose.ui)
+    implementation(AppDependencies.Android.Compose.material)
+    implementation(AppDependencies.Android.Compose.uiToolingPreview)
+    implementation(AppDependencies.Android.Compose.activityCompose)
+    implementation(AppDependencies.Android.Compose.navigationCompose)
+    debugImplementation(AppDependencies.Android.Compose.uiTooling)
 
     debugImplementation(AppDependencies.leakCanary)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
 			</intent-filter>
 		</activity>
 
+		<activity
+			android:name=".ui.compose.ComposeNavigationActivity"
+			android:exported="false"
+			android:screenOrientation="fullSensor"
+			android:theme="@style/Theme.MaterialComponents.Light" />
+
         <service
             android:name=".restart.TerminationWatcherService"
             android:stopWithTask="false" />

--- a/app/src/main/java/com/splunk/app/ui/compose/ComposeNavigationActivity.kt
+++ b/app/src/main/java/com/splunk/app/ui/compose/ComposeNavigationActivity.kt
@@ -1,0 +1,309 @@
+@file:Suppress("ktlint:standard:function-naming")
+
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.app.ui.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.dialog
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.splunk.rum.integration.agent.api.SplunkRum
+import com.splunk.rum.integration.navigation.extension.navigation
+
+class ComposeNavigationActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                ComposeNavigationApp(onBack = { finish() })
+            }
+        }
+    }
+}
+
+@Composable
+fun ComposeNavigationApp(onBack: () -> Unit = {}) {
+    val navController = rememberNavController()
+
+    SplunkRum.instance.navigation.registerNavController(navController)
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Compose Navigation") }) }
+    ) { padding ->
+        NavHost(
+            navController = navController,
+            startDestination = "home",
+            modifier = Modifier.padding(padding)
+        ) {
+            composable("home") { HomeScreen(navController, onBack) }
+            composable("settings") { SettingsScreen(navController) }
+            composable(
+                route = "profile/{userId}",
+                arguments = listOf(navArgument("userId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                ProfileScreen(
+                    userId = backStackEntry.arguments?.getString("userId") ?: "unknown",
+                    navController = navController
+                )
+            }
+            composable(
+                route = "search?query={query}",
+                arguments = listOf(
+                    navArgument("query") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    }
+                )
+            ) { backStackEntry ->
+                SearchScreen(
+                    query = backStackEntry.arguments?.getString("query") ?: "",
+                    navController = navController
+                )
+            }
+            composable("nested_tabs") { NestedTabsScreen(navController) }
+            dialog("confirm_dialog") {
+                ConfirmDialog(navController)
+            }
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(navController: NavController, onBack: () -> Unit = {}) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Home", style = MaterialTheme.typography.h5)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { navController.navigate("settings") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Go to Settings") }
+
+        Button(
+            onClick = { navController.navigate("profile/user_12345") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Profile (user_12345)") }
+
+        Button(
+            onClick = { navController.navigate("profile/user_67890") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Profile (user_67890)") }
+
+        Button(
+            onClick = { navController.navigate("search?query=opentelemetry") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Search: opentelemetry") }
+
+        Button(
+            onClick = { navController.navigate("search") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Search (no query)") }
+
+        Button(
+            onClick = { navController.navigate("confirm_dialog") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Show Dialog") }
+
+        Button(
+            onClick = { navController.navigate("nested_tabs") },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Nested Tabs (own NavHost)") }
+
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Back to Main Menu") }
+    }
+}
+
+@Composable
+fun SettingsScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Settings", style = MaterialTheme.typography.h5)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+    }
+}
+
+@Composable
+fun ProfileScreen(userId: String, navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Profile", style = MaterialTheme.typography.h5)
+        Text("User ID: $userId", style = MaterialTheme.typography.body1)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+    }
+}
+
+@Composable
+fun SearchScreen(query: String, navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Search", style = MaterialTheme.typography.h5)
+        Text(
+            text = if (query.isNotEmpty()) "Query: $query" else "No query provided",
+            style = MaterialTheme.typography.body1
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+    }
+}
+
+@Composable
+fun NestedTabsScreen(parentNavController: NavController) {
+    val nestedNavController = rememberNavController()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            "Nested Tabs (separate NavController)",
+            style = MaterialTheme.typography.h6,
+            modifier = Modifier.padding(16.dp)
+        )
+
+        val currentRoute = nestedNavController.currentBackStackEntryAsState().value
+            ?.destination?.route
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            val tabs = listOf("tab_feed" to "Feed", "tab_trending" to "Trending", "tab_inbox" to "Inbox")
+            tabs.forEach { (route, label) ->
+                val selected = currentRoute == route
+                if (selected) {
+                    Button(
+                        onClick = {},
+                        modifier = Modifier.weight(1f)
+                    ) { Text(label) }
+                } else {
+                    OutlinedButton(
+                        onClick = {
+                            nestedNavController.navigate(route) {
+                                popUpTo("tab_feed") { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) { Text(label) }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        NavHost(
+            navController = nestedNavController,
+            startDestination = "tab_feed",
+            modifier = Modifier
+                .weight(1f)
+                .padding(16.dp)
+        ) {
+            composable("tab_feed") { TabContent("Feed", "Latest posts and updates") }
+            composable("tab_trending") { TabContent("Trending", "Popular content right now") }
+            composable("tab_inbox") { TabContent("Inbox", "Your messages and notifications") }
+        }
+
+        Button(
+            onClick = { parentNavController.popBackStack() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) { Text("Back to Home") }
+    }
+}
+
+@Composable
+fun TabContent(title: String, description: String) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(title, style = MaterialTheme.typography.h5)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(description, style = MaterialTheme.typography.body1)
+    }
+}
+
+@Composable
+fun ConfirmDialog(navController: NavController) {
+    AlertDialog(
+        onDismissRequest = { navController.popBackStack() },
+        title = { Text("Confirm") },
+        text = { Text("This is a dialog destination.") },
+        confirmButton = {
+            TextButton(onClick = { navController.popBackStack() }) { Text("OK") }
+        },
+        dismissButton = {
+            TextButton(onClick = { navController.popBackStack() }) { Text("Cancel") }
+        }
+    )
+}

--- a/app/src/main/java/com/splunk/app/ui/compose/ComposeNavigationActivity.kt
+++ b/app/src/main/java/com/splunk/app/ui/compose/ComposeNavigationActivity.kt
@@ -70,15 +70,21 @@ fun ComposeNavigationApp(onBack: () -> Unit = {}) {
     SplunkRum.instance.navigation.registerNavController(navController)
 
     Scaffold(
-        topBar = { TopAppBar(title = { Text("Compose Navigation") }) }
+        topBar = {
+            TopAppBar(title = { Text("Compose Navigation") })
+        }
     ) { padding ->
         NavHost(
             navController = navController,
             startDestination = "home",
             modifier = Modifier.padding(padding)
         ) {
-            composable("home") { HomeScreen(navController, onBack) }
-            composable("settings") { SettingsScreen(navController) }
+            composable("home") {
+                HomeScreen(navController, onBack)
+            }
+            composable("settings") {
+                SettingsScreen(navController)
+            }
             composable(
                 route = "profile/{userId}",
                 arguments = listOf(navArgument("userId") { type = NavType.StringType })
@@ -102,7 +108,9 @@ fun ComposeNavigationApp(onBack: () -> Unit = {}) {
                     navController = navController
                 )
             }
-            composable("nested_tabs") { NestedTabsScreen(navController) }
+            composable("nested_tabs") {
+                NestedTabsScreen(navController)
+            }
             dialog("confirm_dialog") {
                 ConfirmDialog(navController)
             }
@@ -125,42 +133,58 @@ fun HomeScreen(navController: NavController, onBack: () -> Unit = {}) {
         Button(
             onClick = { navController.navigate("settings") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Go to Settings") }
+        ) {
+            Text("Go to Settings")
+        }
 
         Button(
             onClick = { navController.navigate("profile/user_12345") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Profile (user_12345)") }
+        ) {
+            Text("Profile (user_12345)")
+        }
 
         Button(
             onClick = { navController.navigate("profile/user_67890") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Profile (user_67890)") }
+        ) {
+            Text("Profile (user_67890)")
+        }
 
         Button(
             onClick = { navController.navigate("search?query=opentelemetry") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Search: opentelemetry") }
+        ) {
+            Text("Search: opentelemetry")
+        }
 
         Button(
             onClick = { navController.navigate("search") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Search (no query)") }
+        ) {
+            Text("Search (no query)")
+        }
 
         Button(
             onClick = { navController.navigate("confirm_dialog") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Show Dialog") }
+        ) {
+            Text("Show Dialog")
+        }
 
         Button(
             onClick = { navController.navigate("nested_tabs") },
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Nested Tabs (own NavHost)") }
+        ) {
+            Text("Nested Tabs (own NavHost)")
+        }
 
         OutlinedButton(
             onClick = onBack,
             modifier = Modifier.fillMaxWidth()
-        ) { Text("Back to Main Menu") }
+        ) {
+            Text("Back to Main Menu")
+        }
     }
 }
 
@@ -175,7 +199,9 @@ fun SettingsScreen(navController: NavController) {
     ) {
         Text("Settings", style = MaterialTheme.typography.h5)
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+        Button(onClick = { navController.popBackStack() }) {
+            Text("Back")
+        }
     }
 }
 
@@ -191,7 +217,9 @@ fun ProfileScreen(userId: String, navController: NavController) {
         Text("Profile", style = MaterialTheme.typography.h5)
         Text("User ID: $userId", style = MaterialTheme.typography.body1)
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+        Button(onClick = { navController.popBackStack() }) {
+            Text("Back")
+        }
     }
 }
 
@@ -210,7 +238,9 @@ fun SearchScreen(query: String, navController: NavController) {
             style = MaterialTheme.typography.body1
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = { navController.popBackStack() }) { Text("Back") }
+        Button(onClick = { navController.popBackStack() }) {
+            Text("Back")
+        }
     }
 }
 
@@ -220,7 +250,7 @@ fun NestedTabsScreen(parentNavController: NavController) {
 
     Column(modifier = Modifier.fillMaxSize()) {
         Text(
-            "Nested Tabs (separate NavController)",
+            text = "Nested Tabs (separate NavController)",
             style = MaterialTheme.typography.h6,
             modifier = Modifier.padding(16.dp)
         )
@@ -234,14 +264,20 @@ fun NestedTabsScreen(parentNavController: NavController) {
                 .padding(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            val tabs = listOf("tab_feed" to "Feed", "tab_trending" to "Trending", "tab_inbox" to "Inbox")
+            val tabs = listOf(
+                "tab_feed" to "Feed",
+                "tab_trending" to "Trending",
+                "tab_inbox" to "Inbox"
+            )
             tabs.forEach { (route, label) ->
                 val selected = currentRoute == route
                 if (selected) {
                     Button(
                         onClick = {},
                         modifier = Modifier.weight(1f)
-                    ) { Text(label) }
+                    ) {
+                        Text(label)
+                    }
                 } else {
                     OutlinedButton(
                         onClick = {
@@ -252,7 +288,9 @@ fun NestedTabsScreen(parentNavController: NavController) {
                             }
                         },
                         modifier = Modifier.weight(1f)
-                    ) { Text(label) }
+                    ) {
+                        Text(label)
+                    }
                 }
             }
         }
@@ -266,9 +304,15 @@ fun NestedTabsScreen(parentNavController: NavController) {
                 .weight(1f)
                 .padding(16.dp)
         ) {
-            composable("tab_feed") { TabContent("Feed", "Latest posts and updates") }
-            composable("tab_trending") { TabContent("Trending", "Popular content right now") }
-            composable("tab_inbox") { TabContent("Inbox", "Your messages and notifications") }
+            composable("tab_feed") {
+                TabContent("Feed", "Latest posts and updates")
+            }
+            composable("tab_trending") {
+                TabContent("Trending", "Popular content right now")
+            }
+            composable("tab_inbox") {
+                TabContent("Inbox", "Your messages and notifications")
+            }
         }
 
         Button(
@@ -276,7 +320,9 @@ fun NestedTabsScreen(parentNavController: NavController) {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)
-        ) { Text("Back to Home") }
+        ) {
+            Text("Back to Home")
+        }
     }
 }
 
@@ -300,10 +346,14 @@ fun ConfirmDialog(navController: NavController) {
         title = { Text("Confirm") },
         text = { Text("This is a dialog destination.") },
         confirmButton = {
-            TextButton(onClick = { navController.popBackStack() }) { Text("OK") }
+            TextButton(onClick = { navController.popBackStack() }) {
+                Text("OK")
+            }
         },
         dismissButton = {
-            TextButton(onClick = { navController.popBackStack() }) { Text("Cancel") }
+            TextButton(onClick = { navController.popBackStack() }) {
+                Text("Cancel")
+            }
         }
     )
 }

--- a/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/menu/MenuFragment.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.app.ui.menu
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -26,6 +27,7 @@ import com.splunk.app.databinding.FragmentMenuBinding
 import com.splunk.app.extension.showToast
 import com.splunk.app.restart.TerminationWatcherService
 import com.splunk.app.ui.BaseFragment
+import com.splunk.app.ui.compose.ComposeNavigationActivity
 import com.splunk.app.ui.crashreports.CrashReportsFragment
 import com.splunk.app.ui.customtracking.CustomTrackingFragment
 import com.splunk.app.ui.endpointconfiguration.EndpointConfigurationFragment
@@ -78,6 +80,9 @@ class MenuFragment : BaseFragment<FragmentMenuBinding>() {
             }
             endpointConfiguration.setOnClickListener {
                 navigateTo(EndpointConfigurationFragment(), FragmentAnimation.FADE)
+            }
+            composeNavigation.setOnClickListener {
+                startActivity(Intent(requireContext(), ComposeNavigationActivity::class.java))
             }
             startupRestart.setOnClickListener {
                 TerminationWatcherService.restartOnClose(requireContext())

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -175,6 +175,26 @@
 			android:text="@string/endpoint_configuration_title"
 			app:layout_constraintTop_toBottomOf="@id/endpoint_configuration_title" />
 
+		<TextView
+			android:id="@+id/compose_navigation_title"
+			style="@style/Heading"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="30dp"
+			android:text="Compose Navigation"
+			app:layout_constraintTop_toBottomOf="@+id/endpoint_configuration" />
+
+		<TextView
+			android:id="@+id/compose_navigation"
+			style="@style/Button"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginLeft="20dp"
+			android:layout_marginTop="20dp"
+			android:layout_marginRight="20dp"
+			android:text="Compose Navigation"
+			app:layout_constraintTop_toBottomOf="@id/compose_navigation_title" />
+
         <TextView
             android:id="@+id/startup_title"
             style="@style/Heading"
@@ -182,7 +202,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="30dp"
             android:text="@string/startup_title"
-            app:layout_constraintTop_toBottomOf="@+id/endpoint_configuration" />
+            app:layout_constraintTop_toBottomOf="@+id/compose_navigation" />
 
         <TextView
             android:id="@+id/startup_restart"

--- a/buildSrc/src/main/kotlin/AppDependencies.kt
+++ b/buildSrc/src/main/kotlin/AppDependencies.kt
@@ -35,5 +35,21 @@ object AppDependencies {
         const val activityKtx = "androidx.activity:activity-ktx:$activityKtxVersion"
         const val fragmentKtx = "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
         const val material = "com.google.android.material:material:$materialVersion"
+
+        object Compose {
+            const val compilerVersion = "1.4.0"
+
+            private const val uiVersion = "1.3.3"
+            private const val materialVersion = "1.3.1"
+            private const val activityComposeVersion = "1.6.1"
+            private const val navigationComposeVersion = "2.5.3"
+
+            const val ui = "androidx.compose.ui:ui:$uiVersion"
+            const val material = "androidx.compose.material:material:$materialVersion"
+            const val uiToolingPreview = "androidx.compose.ui:ui-tooling-preview:$uiVersion"
+            const val uiTooling = "androidx.compose.ui:ui-tooling:$uiVersion"
+            const val activityCompose = "androidx.activity:activity-compose:$activityComposeVersion"
+            const val navigationCompose = "androidx.navigation:navigation-compose:$navigationComposeVersion"
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -53,9 +53,11 @@ object Dependencies {
 
         private const val annotationVersion = "1.9.1"
         private const val fragmentKtxVersion = "1.3.3"
+        private const val navigationVersion = "2.4.0"
 
         const val annotation = "androidx.annotation:annotation:$annotationVersion"
         const val fragmentKtx = "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
+        const val navigationRuntime = "androidx.navigation:navigation-runtime:$navigationVersion"
 
         object Compose {
             private const val UiVersion = "1.2.1" // No need to update

--- a/integration/navigation/build.gradle.kts
+++ b/integration/navigation/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
 
     implementation(Dependencies.Android.fragmentKtx)
 
+    compileOnly(Dependencies.Android.navigationRuntime)
+
     implementation(Dependencies.SessionReplay.commonUtils)
     implementation(Dependencies.SessionReplay.commonLogger)
 

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/Navigation.kt
@@ -16,11 +16,15 @@
 
 package com.splunk.rum.integration.navigation
 
+import androidx.navigation.NavController
+import com.splunk.android.common.logger.Logger
+import com.splunk.rum.integration.navigation.automatic.ComposeNavigationTracker
 import io.opentelemetry.api.common.Attributes
 
 class Navigation internal constructor() {
 
     internal var listener: Listener? = null
+    internal var composeTracker: ComposeNavigationTracker? = null
 
     /**
      * Record a navigation to [screenName] with optional [attributes] (manual tracking).
@@ -30,11 +34,37 @@ class Navigation internal constructor() {
         listener?.onScreenNameChanged(screenName, attributes)
     }
 
+    /**
+     * Register a [NavController] for automatic Compose navigation tracking.
+     *
+     * The SDK attaches an [NavController.OnDestinationChangedListener] to track route changes.
+     * Only one NavController can be tracked at a time; registering a new one replaces the previous.
+     * Passing the same instance again is a no-op.
+     *
+     * Call this after [NavController] is created (e.g. in your Activity's `setContent` block).
+     */
+    fun registerNavController(navController: NavController) {
+        val tracker = composeTracker
+        if (tracker == null) {
+            Logger.w(TAG, "Navigation module not installed. Cannot register NavController.")
+            return
+        }
+        tracker.register(navController)
+    }
+
+    /**
+     * Unregister a previously registered [NavController], removing the destination listener.
+     */
+    fun unregisterNavController(navController: NavController) {
+        composeTracker?.unregister(navController)
+    }
+
     internal interface Listener {
         fun onScreenNameChanged(screenName: String, attributes: Attributes)
     }
 
     companion object {
+        private const val TAG = "Navigation"
 
         @JvmStatic
         val instance by lazy { Navigation() }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEvent.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEvent.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.navigation
+
+/**
+ * Represents a navigation event that can be inspected and modified by a [NavigationEventProcessor]
+ * before it is emitted.
+ *
+ * @property screenName The screen name for this event. Modify to rename the screen.
+ * @property attributes Mutable map of event attributes. Modify to add, remove, or change attributes.
+ * @property sourceType The origin of this navigation event.
+ */
+class NavigationEvent(var screenName: String, val attributes: MutableMap<String, String>, val sourceType: SourceType) {
+
+    /**
+     * Identifies the origin of a navigation event.
+     */
+    enum class SourceType {
+        ACTIVITY,
+        FRAGMENT,
+        COMPOSE_ROUTE
+    }
+}

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEvent.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEvent.kt
@@ -20,11 +20,11 @@ package com.splunk.rum.integration.navigation
  * Represents a navigation event that can be inspected and modified by a [NavigationEventProcessor]
  * before it is emitted.
  *
- * @property screenName The screen name for this event. Modify to rename the screen.
+ * @property name The screen name for this event. Modify to rename the screen.
  * @property attributes Mutable map of event attributes. Modify to add, remove, or change attributes.
  * @property sourceType The origin of this navigation event.
  */
-class NavigationEvent(var screenName: String, val attributes: MutableMap<String, String>, val sourceType: SourceType) {
+class NavigationEvent(var name: String, val attributes: MutableMap<String, String>, val sourceType: SourceType) {
 
     /**
      * Identifies the origin of a navigation event.

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEventProcessor.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEventProcessor.kt
@@ -20,11 +20,8 @@ package com.splunk.rum.integration.navigation
  * Processes navigation events before they are emitted.
  *
  * Use to transform screen names, filter events, or modify attributes.
- * The [NavigationEvent] passed to [process] is mutable: modify [NavigationEvent.screenName]
- * or [NavigationEvent.attributes] as needed.
- *
- * Return `true` to emit the event, or `false` to suppress it.
+ * Return the [NavigationEvent] (modified or as-is) to emit it, or `null` to suppress it.
  */
 fun interface NavigationEventProcessor {
-    fun process(event: NavigationEvent): Boolean
+    fun process(event: NavigationEvent): NavigationEvent?
 }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEventProcessor.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationEventProcessor.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.navigation
+
+/**
+ * Processes navigation events before they are emitted.
+ *
+ * Use to transform screen names, filter events, or modify attributes.
+ * The [NavigationEvent] passed to [process] is mutable: modify [NavigationEvent.screenName]
+ * or [NavigationEvent.attributes] as needed.
+ *
+ * Return `true` to emit the event, or `false` to suppress it.
+ */
+fun interface NavigationEventProcessor {
+    fun process(event: NavigationEvent): Boolean
+}

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleConfiguration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleConfiguration.kt
@@ -27,10 +27,13 @@ import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
  *
  * @property isEnabled Whether the module is enabled. Default is true.
  * @property isAutomatedTrackingEnabled Whether Fragment and Activity lifecycle tracking is enabled. Default is false.
+ * @property navigationEventProcessor Optional processor for transforming or filtering navigation events
+ *   from Compose routes before they are emitted. See [NavigationEventProcessor].
  */
 data class NavigationModuleConfiguration @JvmOverloads constructor(
     val isEnabled: Boolean = true,
-    val isAutomatedTrackingEnabled: Boolean = false
+    val isAutomatedTrackingEnabled: Boolean = false,
+    val navigationEventProcessor: NavigationEventProcessor? = null
 ) : ModuleConfiguration {
 
     override val name: String = "navigation"

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -113,7 +113,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             )
             Logger.d(TAG, "ComposeNavigationTracker initialized")
         } else {
-            Logger.d(TAG, "androidx.navigation not found on classpath, Compose navigation tracking disabled")
+            Logger.d(TAG, "androidx.navigation.NavDestination.getRoute not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+")
         }
 
         (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -25,6 +25,7 @@ import com.splunk.android.common.logger.Logger
 import com.splunk.android.common.utils.adapters.ActivityLifecycleCallbacksAdapter
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
+import com.splunk.rum.integration.navigation.automatic.ComposeNavigationTracker
 import com.splunk.rum.integration.navigation.automatic.NavigationEventEmitter
 import com.splunk.rum.integration.navigation.automatic.ScreenChangeDetector
 import com.splunk.rum.integration.navigation.automatic.callback.NavigationActivityCallback
@@ -72,18 +73,21 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         Logger.d(TAG, "onInstall")
         if (!moduleConfiguration.isEnabled) {
             Navigation.instance.listener = null
+            Navigation.instance.composeTracker?.unregisterCurrent()
+            Navigation.instance.composeTracker = null
             emitter.clearCache()
             (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
             currentActivityReference = null
             return
         }
 
+        val detector = ScreenChangeDetector(emitter)
+        screenChangeDetector = detector
+
         if (moduleConfiguration.isAutomatedTrackingEnabled) {
             Logger.d(TAG, "Navigation module automated tracking enabled. Registering navigation callbacks.")
 
             val application = context.applicationContext as Application
-            val detector = ScreenChangeDetector(emitter)
-            screenChangeDetector = detector
 
             registerActivityLifecycle(application, detector)
             registerFragmentLifecycle(application, detector)
@@ -102,6 +106,12 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
                 detector.onActivityResumed(activity)
             }
         }
+
+        Navigation.instance.composeTracker = ComposeNavigationTracker(
+            screenChangeDetector = detector,
+            processor = moduleConfiguration.navigationEventProcessor
+        )
+        Logger.d(TAG, "ComposeNavigationTracker initialized")
 
         (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
         currentActivityReference = null

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -113,7 +113,10 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             )
             Logger.d(TAG, "ComposeNavigationTracker initialized")
         } else {
-            Logger.d(TAG, "androidx.navigation.NavDestination.getRoute not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+")
+            Logger.d(
+                TAG,
+                "androidx.navigation.NavDestination.getRoute not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+"
+            )
         }
 
         (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -156,9 +156,10 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
     }
 
     private fun isNavigationAvailable(): Boolean = try {
-        Class.forName("androidx.navigation.NavController")
+        Class.forName("androidx.navigation.NavDestination")
+            .getMethod("getRoute")
         true
-    } catch (_: ClassNotFoundException) {
+    } catch (_: Exception) {
         false
     }
 

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -107,11 +107,15 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             }
         }
 
-        Navigation.instance.composeTracker = ComposeNavigationTracker(
-            screenChangeDetector = detector,
-            processor = moduleConfiguration.navigationEventProcessor
-        )
-        Logger.d(TAG, "ComposeNavigationTracker initialized")
+        if (isNavigationAvailable()) {
+            Navigation.instance.composeTracker = ComposeNavigationTracker(
+                screenChangeDetector = detector,
+                processor = moduleConfiguration.navigationEventProcessor
+            )
+            Logger.d(TAG, "ComposeNavigationTracker initialized")
+        } else {
+            Logger.d(TAG, "androidx.navigation not found on classpath, Compose navigation tracking disabled")
+        }
 
         (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
         currentActivityReference = null
@@ -149,6 +153,13 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         }
 
         application.registerActivityLifecycleCallbacks(fragmentActivityCallback)
+    }
+
+    private fun isNavigationAvailable(): Boolean = try {
+        Class.forName("androidx.navigation.NavController")
+        true
+    } catch (_: ClassNotFoundException) {
+        false
     }
 
     private val navigationListener = object : Navigation.Listener {

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -73,7 +73,6 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         Logger.d(TAG, "onInstall")
         if (!moduleConfiguration.isEnabled) {
             Navigation.instance.listener = null
-            Navigation.instance.composeTracker?.unregisterCurrent()
             Navigation.instance.composeTracker = null
             emitter.clearCache()
             (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.navigation.automatic
+
+import android.os.Bundle
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
+import com.splunk.android.common.logger.Logger
+import com.splunk.rum.integration.navigation.NavigationEvent
+import com.splunk.rum.integration.navigation.NavigationEventProcessor
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import java.lang.ref.WeakReference
+
+/**
+ * Manages NavController registration and processes Compose navigation destination changes.
+ *
+ * Filters out NavGraph containers and dialog destinations, extracts route templates as screen names,
+ * and separates resolved arguments into event attributes. Events are routed through
+ * [ScreenChangeDetector] so the Compose route takes priority over Activity/Fragment names.
+ */
+internal class ComposeNavigationTracker(
+    private val screenChangeDetector: ScreenChangeDetector,
+    private val processor: NavigationEventProcessor?
+) {
+
+    private var registeredController: WeakReference<NavController>? = null
+    private var activeListener: NavController.OnDestinationChangedListener? = null
+
+    fun register(navController: NavController) {
+        if (registeredController?.get() === navController) {
+            navController.currentDestination?.route?.let {
+                screenChangeDetector.onComposeRouteChanged(it)
+            }
+            return
+        }
+
+        unregisterCurrent()
+
+        val listener = NavController.OnDestinationChangedListener { _, destination, arguments ->
+            handleDestinationChanged(destination, arguments)
+        }
+        navController.addOnDestinationChangedListener(listener)
+        registeredController = WeakReference(navController)
+        activeListener = listener
+        Logger.d(TAG, "Registered NavController for Compose navigation tracking")
+    }
+
+    fun unregister(navController: NavController) {
+        if (registeredController?.get() === navController) {
+            activeListener?.let { navController.removeOnDestinationChangedListener(it) }
+            registeredController = null
+            activeListener = null
+            screenChangeDetector.clearComposeRoute()
+            Logger.d(TAG, "Unregistered NavController")
+        }
+    }
+
+    fun unregisterCurrent() {
+        registeredController?.get()?.let { controller ->
+            activeListener?.let { controller.removeOnDestinationChangedListener(it) }
+        }
+        registeredController = null
+        activeListener = null
+        screenChangeDetector.clearComposeRoute()
+    }
+
+    private fun handleDestinationChanged(destination: NavDestination, arguments: Bundle?) {
+        if (destination is NavGraph) return
+        if (destination.navigatorName == NAVIGATOR_NAME_DIALOG) return
+
+        val screenName = destination.route ?: return
+
+        if (processor != null) {
+            val attrMap = extractArguments(arguments)
+            destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+
+            val event = NavigationEvent(
+                screenName = screenName,
+                attributes = attrMap,
+                sourceType = NavigationEvent.SourceType.COMPOSE_ROUTE
+            )
+
+            if (!processor.process(event)) {
+                Logger.d(TAG, "NavigationEventProcessor suppressed event for: $screenName")
+                return
+            }
+
+            screenChangeDetector.onComposeRouteChanged(event.screenName, mapToAttributes(event.attributes))
+        } else {
+            val attrs = buildAttributes(arguments, destination)
+            screenChangeDetector.onComposeRouteChanged(screenName, attrs)
+        }
+    }
+
+    private fun extractArguments(arguments: Bundle?): MutableMap<String, String> {
+        val map = mutableMapOf<String, String>()
+        if (arguments == null) return map
+        for (key in arguments.keySet()) {
+            if (key.startsWith(NAV_INTERNAL_KEY_PREFIX)) continue
+            @Suppress("DEPRECATION")
+            val value = arguments.get(key)
+            if (value != null) {
+                map[key] = value.toString()
+            }
+        }
+        return map
+    }
+
+    private fun buildAttributes(arguments: Bundle?, destination: NavDestination): Attributes {
+        val builder = Attributes.builder()
+        if (arguments != null) {
+            for (key in arguments.keySet()) {
+                if (key.startsWith(NAV_INTERNAL_KEY_PREFIX)) continue
+                @Suppress("DEPRECATION")
+                val value = arguments.get(key)
+                if (value != null) {
+                    builder.put(AttributeKey.stringKey(key), value.toString())
+                }
+            }
+        }
+        destination.parent?.route?.let {
+            builder.put(AttributeKey.stringKey(ATTR_NAV_GRAPH), it)
+        }
+        return builder.build()
+    }
+
+    private fun mapToAttributes(map: Map<String, String>): Attributes {
+        if (map.isEmpty()) return Attributes.empty()
+        val builder = Attributes.builder()
+        for ((key, value) in map) {
+            builder.put(AttributeKey.stringKey(key), value)
+        }
+        return builder.build()
+    }
+
+    private companion object {
+        const val TAG = "ComposeNavigationTracker"
+        const val NAV_INTERNAL_KEY_PREFIX = "android-support-nav:"
+        const val NAVIGATOR_NAME_DIALOG = "dialog"
+        const val ATTR_NAV_GRAPH = "nav.graph"
+    }
+}

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -78,10 +78,10 @@ internal class ComposeNavigationTracker(
 
         val screenName = destination.route ?: return
 
-        if (processor != null) {
-            val attrMap = extractArguments(arguments)
-            destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+        val attrMap = extractArguments(arguments)
+        destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
 
+        if (processor != null) {
             val event = NavigationEvent(
                 name = screenName,
                 attributes = attrMap,
@@ -96,8 +96,7 @@ internal class ComposeNavigationTracker(
 
             screenChangeDetector.onComposeRouteChanged(result.name, mapToAttributes(result.attributes))
         } else {
-            val attrs = buildAttributes(arguments, destination)
-            screenChangeDetector.onComposeRouteChanged(screenName, attrs)
+            screenChangeDetector.onComposeRouteChanged(screenName, mapToAttributes(attrMap))
         }
     }
 
@@ -113,24 +112,6 @@ internal class ComposeNavigationTracker(
             }
         }
         return map
-    }
-
-    private fun buildAttributes(arguments: Bundle?, destination: NavDestination): Attributes {
-        val builder = Attributes.builder()
-        if (arguments != null) {
-            for (key in arguments.keySet()) {
-                if (key.startsWith(NAV_INTERNAL_KEY_PREFIX)) continue
-                @Suppress("DEPRECATION")
-                val value = arguments.get(key)
-                if (value != null) {
-                    builder.put(AttributeKey.stringKey(key), value.toString())
-                }
-            }
-        }
-        destination.parent?.route?.let {
-            builder.put(AttributeKey.stringKey(ATTR_NAV_GRAPH), it)
-        }
-        return builder.build()
     }
 
     private fun mapToAttributes(map: Map<String, String>): Attributes {

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -43,12 +43,7 @@ internal class ComposeNavigationTracker(
     private var activeListener: NavController.OnDestinationChangedListener? = null
 
     fun register(navController: NavController) {
-        if (registeredController?.get() === navController) {
-            navController.currentDestination?.let { destination ->
-                handleDestinationChanged(destination, navController.currentBackStackEntry?.arguments)
-            }
-            return
-        }
+        if (registeredController?.get() === navController) return
 
         unregisterCurrent()
 

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -45,7 +45,7 @@ internal class ComposeNavigationTracker(
     fun register(navController: NavController) {
         if (registeredController?.get() === navController) return
 
-        unregisterCurrent()
+        clearRegistration()
 
         val listener = NavController.OnDestinationChangedListener { _, destination, arguments ->
             handleDestinationChanged(destination, arguments)
@@ -58,15 +58,12 @@ internal class ComposeNavigationTracker(
 
     fun unregister(navController: NavController) {
         if (registeredController?.get() === navController) {
-            activeListener?.let { navController.removeOnDestinationChangedListener(it) }
-            registeredController = null
-            activeListener = null
-            screenChangeDetector.clearComposeRoute()
+            clearRegistration()
             Logger.d(TAG, "Unregistered NavController")
         }
     }
 
-    fun unregisterCurrent() {
+    private fun clearRegistration() {
         registeredController?.get()?.let { controller ->
             activeListener?.let { controller.removeOnDestinationChangedListener(it) }
         }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -44,8 +44,8 @@ internal class ComposeNavigationTracker(
 
     fun register(navController: NavController) {
         if (registeredController?.get() === navController) {
-            navController.currentDestination?.route?.let {
-                screenChangeDetector.onComposeRouteChanged(it)
+            navController.currentDestination?.let { destination ->
+                handleDestinationChanged(destination, navController.currentBackStackEntry?.arguments)
             }
             return
         }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -86,17 +86,18 @@ internal class ComposeNavigationTracker(
             destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
 
             val event = NavigationEvent(
-                screenName = screenName,
+                name = screenName,
                 attributes = attrMap,
                 sourceType = NavigationEvent.SourceType.COMPOSE_ROUTE
             )
 
-            if (!processor.process(event)) {
+            val result = processor.process(event)
+            if (result == null) {
                 Logger.d(TAG, "NavigationEventProcessor suppressed event for: $screenName")
                 return
             }
 
-            screenChangeDetector.onComposeRouteChanged(event.screenName, mapToAttributes(event.attributes))
+            screenChangeDetector.onComposeRouteChanged(result.name, mapToAttributes(result.attributes))
         } else {
             val attrs = buildAttributes(arguments, destination)
             screenChangeDetector.onComposeRouteChanged(screenName, attrs)

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -57,9 +57,12 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         val name = ScreenNameDescriptor.getName(activity)
         lastResumedActivityName = name
 
-        if (composeRouteActivityName != null && composeRouteActivityName != name) {
+        if (lastComposeRouteName != null && composeRouteActivityName == null) {
+            composeRouteActivityName = name
+        } else if (composeRouteActivityName != null && composeRouteActivityName != name) {
             lastComposeRouteName = null
             composeRouteActivityName = null
+            lastEmittedComposeAttributes = null
         }
 
         // Defer so fragment callbacks, which run synchronously during the same resume, execute

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -106,6 +106,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     }
 
     private var lastEmittedScreenName: String? = null
+    private var lastEmittedComposeAttributes: Attributes? = null
 
     /**
      * Records that a navigation event was emitted for [screenName] (e.g. from manual tracking).
@@ -121,12 +122,16 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
      * highest-priority screen name and emits the event with optional [attributes].
      * Associates the route with the currently resumed activity so it can be cleared
      * when a different activity resumes.
+     *
+     * Deduplicates by both screen name and attributes so navigating the same route template
+     * with different arguments (e.g. profile/user_123 → profile/user_456) still emits.
      */
     fun onComposeRouteChanged(screenName: String, attributes: Attributes = Attributes.empty()) {
         lastComposeRouteName = screenName
         composeRouteActivityName = lastResumedActivityName
-        if (screenName == lastEmittedScreenName) return
+        if (screenName == lastEmittedScreenName && attributes == lastEmittedComposeAttributes) return
         lastEmittedScreenName = screenName
+        lastEmittedComposeAttributes = attributes
         eventEmitter.emitNavigationEvent(screenName, attributes)
     }
 
@@ -137,6 +142,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     fun clearComposeRoute() {
         lastComposeRouteName = null
         composeRouteActivityName = null
+        lastEmittedComposeAttributes = null
     }
 
     /**

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -45,11 +45,8 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     /**
      * Current visible screen name: Compose route > Fragment > Activity.
      */
-    private fun getCurrentVisibleScreenName(): String? {
-        lastComposeRouteName?.let { return it }
-        lastResumedFragmentName?.let { return it }
-        return lastResumedActivityName
-    }
+    private fun getCurrentVisibleScreenName(): String? =
+        lastComposeRouteName ?: lastResumedFragmentName ?: lastResumedActivityName
 
     fun onActivityResumed(activity: Activity) {
         if (ScreenNameDescriptor.isIgnored(activity)) return

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -21,10 +21,11 @@ import android.os.Handler
 import android.os.Looper
 import androidx.fragment.app.Fragment
 import com.splunk.rum.integration.navigation.descriptor.ScreenNameDescriptor
+import io.opentelemetry.api.common.Attributes
 
 /**
- * Detects visible screen changes (Activity/Fragment) and notifies [NavigationEventEmitter].
- * Fragment takes precedence over Activity when both are present.
+ * Detects visible screen changes (Activity/Fragment/Compose route) and notifies
+ * [NavigationEventEmitter]. Priority: Compose route > Fragment > Activity.
  *
  * Elements marked as ignored by [ScreenNameDescriptor] (e.g. DialogFragment, NavHostFragment,
  * or annotated with isIgnored = true) are skipped entirely.
@@ -38,13 +39,14 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     private val handler = Handler(Looper.getMainLooper())
     private var lastResumedActivityName: String? = null
     private var lastResumedFragmentName: String? = null
+    private var lastComposeRouteName: String? = null
 
     /**
-     * Current visible screen name: fragment if any, else activity.
+     * Current visible screen name: Compose route > Fragment > Activity.
      */
     private fun getCurrentVisibleScreenName(): String? {
-        val fragment = lastResumedFragmentName
-        if (fragment != null) return fragment
+        lastComposeRouteName?.let { return it }
+        lastResumedFragmentName?.let { return it }
         return lastResumedActivityName
     }
 
@@ -65,6 +67,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         if (lastResumedActivityName == name) {
             lastResumedActivityName = null
         }
+        lastComposeRouteName = null
     }
 
     fun onFragmentResumed(fragment: Fragment) {
@@ -105,6 +108,25 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
      */
     fun recordEmittedScreen(screenName: String) {
         lastEmittedScreenName = screenName
+    }
+
+    /**
+     * Called when a Compose NavController destination changes. Sets the compose route as the
+     * highest-priority screen name and emits the event with optional [attributes].
+     */
+    fun onComposeRouteChanged(screenName: String, attributes: Attributes = Attributes.empty()) {
+        lastComposeRouteName = screenName
+        if (screenName == lastEmittedScreenName) return
+        lastEmittedScreenName = screenName
+        eventEmitter.emitNavigationEvent(screenName, attributes)
+    }
+
+    /**
+     * Clears the active Compose route, allowing Fragment/Activity names to take precedence again.
+     * Called when a NavController is unregistered.
+     */
+    fun clearComposeRoute() {
+        lastComposeRouteName = null
     }
 
     /**

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -40,6 +40,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     private var lastResumedActivityName: String? = null
     private var lastResumedFragmentName: String? = null
     private var lastComposeRouteName: String? = null
+    private var composeRouteActivityName: String? = null
 
     /**
      * Current visible screen name: Compose route > Fragment > Activity.
@@ -55,6 +56,12 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
 
         val name = ScreenNameDescriptor.getName(activity)
         lastResumedActivityName = name
+
+        if (composeRouteActivityName != null && composeRouteActivityName != name) {
+            lastComposeRouteName = null
+            composeRouteActivityName = null
+        }
+
         // Defer so fragment callbacks, which run synchronously during the same resume, execute
         // first thus avoiding emitting an intermediate activity only event when a fragment is present
         handler.post { tryEmitIfChanged() }
@@ -67,7 +74,6 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         if (lastResumedActivityName == name) {
             lastResumedActivityName = null
         }
-        lastComposeRouteName = null
     }
 
     fun onFragmentResumed(fragment: Fragment) {
@@ -113,9 +119,12 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     /**
      * Called when a Compose NavController destination changes. Sets the compose route as the
      * highest-priority screen name and emits the event with optional [attributes].
+     * Associates the route with the currently resumed activity so it can be cleared
+     * when a different activity resumes.
      */
     fun onComposeRouteChanged(screenName: String, attributes: Attributes = Attributes.empty()) {
         lastComposeRouteName = screenName
+        composeRouteActivityName = lastResumedActivityName
         if (screenName == lastEmittedScreenName) return
         lastEmittedScreenName = screenName
         eventEmitter.emitNavigationEvent(screenName, attributes)
@@ -127,6 +136,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
      */
     fun clearComposeRoute() {
         lastComposeRouteName = null
+        composeRouteActivityName = null
     }
 
     /**


### PR DESCRIPTION
## Add Compose Navigation tracking via NavController registration

### Description

- New public API: `Navigation.registerNavController(navController)` and `Navigation.unregisterNavController(navController)` for tracking Jetpack Compose navigation routes via the Navigation library's NavController

- New `ComposeNavigationTracker` (internal): Manages `NavController` registration, attaches an `OnDestinationChangedListener`, filters out NavGraph containers and dialog destinations, extracts route templates as screen names, and separates resolved arguments into event attributes

-  `ComposeNavigationTracker` internals: Holds a WeakReference to the registered `NavController` and attaches an `OnDestinationChangedListener`. On each destination change it: 
(1) filters out `NavGraph` containers and dialog destinations via `navigatorName`
(2) uses the route template (e.g. `profile/{userId}`) as the screen name to avoid cardinality explosion
(3) extracts resolved arguments into OTel attributes while skipping internal android-support-nav: keys
(4) runs the event through `NavigationEventProcessor` if configured
(5) routes the result through `ScreenChangeDetector.onComposeRouteChanged()` for deduplication and priority handling. Re registering the same NavController (eg on activity resume), Reregistering the same `NavController` (eg on activity resume) routes the current destination through the full `handleDestinationChanged` pipeline so processor logic and filtering apply consistently.

- New `NavigationEvent` and `NavigationEventProcessor`: Allows customers to transform screen names, filter events, or modify attributes before they are emitted. Configured via `NavigationModuleConfiguration.navigationEventProcessor`. only applies to `COMPOSE_ROUTE`, not `ACTIVITY` or `FRAGMENT`

- Updated `ScreenChangeDetector`: Implements a priority system (Compose route > Fragment > Activity) so Compose routes take precedence when active, with proper fallback to Fragment/Activity tracking when the Compose activity is paused or the `NavController` is unregistered

- `compileOnly` dependency on `androidx.navigation:navigation-runtime:2.4.0`: Provides compile time type safety for `NavController` without bundling into consuming apps. Version `2.4.0` is the minimum that supports Compose Navigation

- Sample app: Added `ComposeNavigationActivity` with test scenarios for simple routes, parameterized routes `(profile/{userId})`, optional query parameters `(search?query={query})`, dialog destinations, nested NavHost (unregistered secondary controller), and back navigation to Fragment based screens

- `ScreenChangeDetector` tracks which activity owns the compose route via `composeRouteActivityName`. The compose route is preserved through background/foreground cycles (same activity resumes) and only cleared when a different activity resumes (navigated away), preventing spurious activity name events.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- build and run sample app
- open compose navigation menu
- navigate through compose navigation part of sample app
- filter logcat by `NavigationEventEmitter` | `ComposeNavigationTracker` to observe events and verify they are correct
- confirm in session that they are correct
- optionally: configure navigationEventProcessor to tailor the navigation events generated for compose elements.

A session involving the compose navigation part of the sample app may look something like this (in this example, screen name "search" was renamed to "Search!!!" in the navigationEventProcessor:

<img width="808" height="676" alt="Screenshot 2026-04-08 at 2 00 25 PM" src="https://github.com/user-attachments/assets/8541bd25-4b77-4f2d-ac10-36b575d196eb" />

### Future Considerations (Optional)

- Support registration of multiple navControllers
- Support 100% automatic instrumentation via reflection