### PR TITLE
DEMRUM-3574: Update *signalfx.com with *observability.splunkcloud.com

### DIFF
--- a/app/src/main/java/com/splunk/app/ui/endpointconfiguration/EndpointConfigurationFragment.kt
+++ b/app/src/main/java/com/splunk/app/ui/endpointconfiguration/EndpointConfigurationFragment.kt
@@ -80,7 +80,7 @@ class EndpointConfigurationFragment : BaseFragment<FragmentEndpointConfiguration
         try {
             val realm = BuildConfig.SPLUNK_REALM
             val token = BuildConfig.SPLUNK_RUM_ACCESS_TOKEN
-            val tracesUrl = URL("https://rum-ingest.$realm.signalfx.com/v1/traces?auth=$token")
+            val tracesUrl = URL("https://rum-ingest.$realm.observability.splunkcloud.com/v1/traces?auth=$token")
 
             SplunkRum.instance.preferences.endpointConfiguration =
                 EndpointConfiguration(tracesUrl)
@@ -101,8 +101,8 @@ class EndpointConfigurationFragment : BaseFragment<FragmentEndpointConfiguration
         try {
             val realm = BuildConfig.SPLUNK_REALM
             val token = BuildConfig.SPLUNK_RUM_ACCESS_TOKEN
-            val tracesUrl = URL("https://rum-ingest.$realm.signalfx.com/v1/traces?auth=$token")
-            val logsUrl = URL("https://rum-ingest.$realm.signalfx.com/v1/logs?auth=$token")
+            val tracesUrl = URL("https://rum-ingest.$realm.observability.splunkcloud.com/v1/traces?auth=$token")
+            val logsUrl = URL("https://rum-ingest.$realm.observability.splunkcloud.com/v1/logs?auth=$token")
 
             SplunkRum.instance.preferences.endpointConfiguration =
                 EndpointConfiguration(tracesUrl, logsUrl)

--- a/instrumentation/buildtime/mapping-file/plugin/src/main/java/com/splunk/rum/mappingfile/plugin/utils/MappingFileUploadClient.kt
+++ b/instrumentation/buildtime/mapping-file/plugin/src/main/java/com/splunk/rum/mappingfile/plugin/utils/MappingFileUploadClient.kt
@@ -58,7 +58,8 @@ class MappingFileUploadClient(private val logger: SplunkLogger) {
     }
 
     private fun buildUploadUrl(realm: String, applicationId: String, versionCode: Int, buildId: String): String {
-        val url = "https://api.$realm.signalfx.com/v2/rum-mfm/proguard/$applicationId/$versionCode/$buildId"
+        val baseUrl = "https://api.$realm.observability.splunkcloud.com"
+        val url = "$baseUrl/v2/rum-mfm/proguard/$applicationId/$versionCode/$buildId"
         logger.debug("Upload", "Constructed upload URL for realm '$realm'")
         return url
     }
@@ -129,7 +130,7 @@ class MappingFileUploadClient(private val logger: SplunkLogger) {
             )
             logger.error(
                 "Upload",
-                "curl -X PUT \"https://api.$realm.signalfx.com/v2/rum-mfm/proguard/$applicationId/$versionCode/$buildId\" -H \"X-SF-Token: YOUR_API_TOKEN_HERE\" -F \"filename=${mappingFile.name}\" -F \"file=@${mappingFile.absolutePath}\""
+                "curl -X PUT \"https://api.$realm.observability.splunkcloud.com/v2/rum-mfm/proguard/$applicationId/$versionCode/$buildId\" -H \"X-SF-Token: YOUR_API_TOKEN_HERE\" -F \"filename=${mappingFile.name}\" -F \"file=@${mappingFile.absolutePath}\""
             )
             logger.error("Upload", "Replace YOUR_API_TOKEN_HERE with your actual API access token.")
 

--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/EndpointConfiguration.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/EndpointConfiguration.kt
@@ -37,8 +37,8 @@ class EndpointConfiguration {
     constructor(realm: String, rumAccessToken: String) {
         this.realm = realm
         this.rumAccessToken = rumAccessToken
-        this.traceEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/traces")
-        this.sessionReplayEndpoint = URL("https://rum-ingest.$realm.signalfx.com/v1/logs")
+        this.traceEndpoint = URL("https://rum-ingest.$realm.observability.splunkcloud.com/v1/traces")
+        this.sessionReplayEndpoint = URL("https://rum-ingest.$realm.observability.splunkcloud.com/v1/logs")
     }
 
     /**

--- a/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/EndpointConfigurationTest.kt
+++ b/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/EndpointConfigurationTest.kt
@@ -30,22 +30,25 @@ class EndpointConfigurationTest {
 
         assertEquals("us0", config.realm)
         assertEquals("test_token_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/logs", config.sessionReplayEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals(
+            "https://rum-ingest.us0.observability.splunkcloud.com/v1/logs",
+            config.sessionReplayEndpoint.toString()
+        )
     }
 
     @Test
     fun `single URL constructor extracts token and removes it from URL`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=extracted_token_123")
+        val url = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=extracted_token_123")
         val config = EndpointConfiguration(url)
 
         assertEquals("extracted_token_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
     }
 
     @Test
     fun `single URL constructor throws exception when no auth parameter`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces")
+        val url = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces")
 
         val exception = assertThrows(IllegalArgumentException::class.java) {
             EndpointConfiguration(url)
@@ -57,7 +60,7 @@ class EndpointConfigurationTest {
 
     @Test
     fun `single URL constructor throws exception when auth parameter is empty`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=")
+        val url = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=")
 
         val exception = assertThrows(IllegalArgumentException::class.java) {
             EndpointConfiguration(url)
@@ -69,7 +72,7 @@ class EndpointConfigurationTest {
 
     @Test
     fun `single URL constructor throws exception when no query string`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces")
+        val url = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces")
 
         val exception = assertThrows(IllegalArgumentException::class.java) {
             EndpointConfiguration(url)
@@ -81,32 +84,38 @@ class EndpointConfigurationTest {
 
     @Test
     fun `dual URL constructor extracts token from trace URL and removes it`() {
-        val traceUrl = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=trace_token_123")
-        val replayUrl = URL("https://rum-ingest.us0.signalfx.com/v1/logs")
+        val traceUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=trace_token_123")
+        val replayUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/logs")
 
         val config = EndpointConfiguration(traceUrl, replayUrl)
 
         assertEquals("trace_token_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/logs", config.sessionReplayEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals(
+            "https://rum-ingest.us0.observability.splunkcloud.com/v1/logs",
+            config.sessionReplayEndpoint.toString()
+        )
     }
 
     @Test
     fun `dual URL constructor extracts token from session replay URL and removes it`() {
-        val traceUrl = URL("https://rum-ingest.us0.signalfx.com/v1/traces")
-        val replayUrl = URL("https://rum-ingest.us0.signalfx.com/v1/logs?auth=replay_token_123")
+        val traceUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces")
+        val replayUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/logs?auth=replay_token_123")
 
         val config = EndpointConfiguration(traceUrl, replayUrl)
 
         assertEquals("replay_token_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/logs", config.sessionReplayEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals(
+            "https://rum-ingest.us0.observability.splunkcloud.com/v1/logs",
+            config.sessionReplayEndpoint.toString()
+        )
     }
 
     @Test
     fun `dual URL constructor prefers trace URL token over session replay URL token`() {
-        val traceUrl = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=trace_token_123")
-        val replayUrl = URL("https://rum-ingest.us0.signalfx.com/v1/logs?auth=replay_token_456")
+        val traceUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=trace_token_123")
+        val replayUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/logs?auth=replay_token_456")
 
         val config = EndpointConfiguration(traceUrl, replayUrl)
 
@@ -115,8 +124,8 @@ class EndpointConfigurationTest {
 
     @Test
     fun `dual URL constructor throws exception when no auth in either URL`() {
-        val traceUrl = URL("https://rum-ingest.us0.signalfx.com/v1/traces")
-        val replayUrl = URL("https://rum-ingest.us0.signalfx.com/v1/logs")
+        val traceUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces")
+        val replayUrl = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/logs")
 
         val exception = assertThrows(IllegalArgumentException::class.java) {
             EndpointConfiguration(traceUrl, replayUrl)
@@ -128,34 +137,38 @@ class EndpointConfigurationTest {
 
     @Test
     fun `URL constructor handles multiple query parameters and only removes auth`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces?other=value&auth=multi_param_token&another=param")
+        val url =
+            URL(
+                "https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?other=value&auth=multi_param_token&another=param"
+            )
 
         val config = EndpointConfiguration(url)
 
         assertEquals("multi_param_token", config.rumAccessToken)
         assertEquals(
-            "https://rum-ingest.us0.signalfx.com/v1/traces?other=value&another=param",
+            "https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?other=value&another=param",
             config.traceEndpoint.toString()
         )
     }
 
     @Test
     fun `URL constructor handles auth parameter with special characters`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=token_with-special.chars_123")
+        val url =
+            URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=token_with-special.chars_123")
 
         val config = EndpointConfiguration(url)
 
         assertEquals("token_with-special.chars_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
     }
 
     @Test
     fun `URL with only auth parameter removes query string entirely`() {
-        val url = URL("https://rum-ingest.us0.signalfx.com/v1/traces?auth=only_token_123")
+        val url = URL("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces?auth=only_token_123")
 
         val config = EndpointConfiguration(url)
 
         assertEquals("only_token_123", config.rumAccessToken)
-        assertEquals("https://rum-ingest.us0.signalfx.com/v1/traces", config.traceEndpoint.toString())
+        assertEquals("https://rum-ingest.us0.observability.splunkcloud.com/v1/traces", config.traceEndpoint.toString())
     }
 }


### PR DESCRIPTION
### Description

Changed all `signalfx.com` endpoints to use `observability.splunkcloud.com
`
### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Verify e2e works with various realms