### PR TITLE
NO-TICKET: Fix screen.name override

### DIFF
--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
@@ -60,6 +60,11 @@ object GlobalRumConstants {
     val PREVIOUS_SESSION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("session.previous_id")
 
     /**
+     * Log event names.
+     */
+    const val NAVIGATION_LOG_EVENT_NAME = "app.ui.navigation"
+
+    /**
      * Screen values and attribute keys.
      */
     const val DEFAULT_SCREEN_NAME = "unknown"

--- a/common/otel/src/main/java/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
+++ b/common/otel/src/main/java/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
@@ -62,7 +62,7 @@ object GlobalRumConstants {
     /**
      * Log event names.
      */
-    const val NAVIGATION_LOG_EVENT_NAME = "app.ui.navigation"
+    const val NAVIGATION_EVENT_NAME = "app.ui.navigation"
 
     /**
      * Screen values and attribute keys.

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -28,6 +28,16 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
         attributes.forEach { key, value ->
+            // Navigation spans set screen.name at emit time via the log
+            // record. Without this guard the global attribute would overwrite the per event value
+            // at export time, causing a race when manual tracking (with differing screenName argument)
+            // and automatic tracking fire back to back
+            if (key == GlobalRumConstants.SCREEN_NAME_KEY &&
+                span.name == GlobalRumConstants.NAVIGATION_LOG_EVENT_NAME &&
+                span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY) != null
+            ) {
+                return@forEach
+            }
             @Suppress("UNCHECKED_CAST")
             span.setAttribute(key as AttributeKey<Any>, value)
         }

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -33,7 +33,7 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
             // at export time, causing a race when manual tracking (with differing screenName argument)
             // and automatic tracking fire back to back
             if (key == GlobalRumConstants.SCREEN_NAME_KEY &&
-                span.name == GlobalRumConstants.NAVIGATION_LOG_EVENT_NAME &&
+                span.name == GlobalRumConstants.NAVIGATION_EVENT_NAME &&
                 span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY) != null
             ) {
                 return@forEach

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/RumConstant.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/RumConstant.kt
@@ -23,7 +23,7 @@ internal object RumConstant {
 
     const val COMPONENT_NAVIGATION = "ui"
 
-    const val NAVIGATION_LOG_EVENT_NAME = GlobalRumConstants.NAVIGATION_LOG_EVENT_NAME
+    const val NAVIGATION_LOG_EVENT_NAME = GlobalRumConstants.NAVIGATION_EVENT_NAME
 
     val NAVIGATION_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("navigation.name")
 }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/RumConstant.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/RumConstant.kt
@@ -16,13 +16,14 @@
 
 package com.splunk.rum.integration.navigation
 
+import com.splunk.rum.common.otel.internal.GlobalRumConstants
 import io.opentelemetry.api.common.AttributeKey
 
 internal object RumConstant {
 
     const val COMPONENT_NAVIGATION = "ui"
 
-    const val NAVIGATION_LOG_EVENT_NAME = "app.ui.navigation"
+    const val NAVIGATION_LOG_EVENT_NAME = GlobalRumConstants.NAVIGATION_LOG_EVENT_NAME
 
     val NAVIGATION_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("navigation.name")
 }


### PR DESCRIPTION
Navigation events set `screen.name `on the log record at emit time, but the global attribute processor (`SplunkInternalGlobalAttributeSpanProcessor`) was unconditionally overwriting it at export time with the current global value. When manual and automatic tracking fired in rapid succession, both exported spans would show the latest` screen.name `, when the manual one should have screen.name of whatever the customer set.

This is a problem when the customer calls a manual track API passing in a DIFFERENT screenName argument, causing both screens in the session view to have the same `screen.name`

The fix adds a guard in` onStart()` that skips setting` screen.name` when all three conditions are met:
- The attribute being applied is` screen.name`
- The span is a navigation span `app.ui.navigation`
- The span already has a `screen.name` value carried from the log record

This only affects navigation spans

[Bullet list of the changes or enhancements made in this PR.]

[Provide any necessary context or background information that reviewers should be aware of.]

[Link to any relevant issues or discussions, if applicable.]

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

build sample app
add/uncomment existing manual track call, make sure screenName argument is different to the actual screen.name
run app
verify both manual and auto tracked screens show up in session view with correct screen names