### PR TITLE
NO-TICKET: set screen.name at log-emit time to fix batch span processor issue

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
@@ -33,6 +33,7 @@ import com.splunk.rum.integration.agent.internal.attributes.ScreenNameTracker
 import com.splunk.rum.integration.agent.internal.processor.ErrorIdentifierAttributesSpanProcessor
 import com.splunk.rum.integration.agent.internal.processor.GlobalAttributeSpanProcessor
 import com.splunk.rum.integration.agent.internal.processor.LastScreenNameSpanProcessor
+import com.splunk.rum.integration.agent.internal.processor.ScreenNameLogRecordProcessor
 import com.splunk.rum.integration.agent.internal.processor.SessionActivityLogProcessor
 import com.splunk.rum.integration.agent.internal.processor.SessionActivitySpanProcessor
 import com.splunk.rum.integration.agent.internal.processor.SessionIdSpanProcessor
@@ -102,6 +103,7 @@ internal object SplunkRumAgentCore {
             .addSpanProcessor(ErrorIdentifierAttributesSpanProcessor(application))
             .addSpanProcessor(SessionIdSpanProcessor(agentIntegration.sessionManager))
             .addSpanProcessor(SplunkInternalGlobalAttributeSpanProcessor())
+            .addLogRecordProcessor(ScreenNameLogRecordProcessor(ScreenNameTracker))
             .addLogRecordProcessor(SessionActivityLogProcessor(sessionManager))
             // Session Replay module is special case of Log Records that are NOT converted to Spans.
             .addLogRecordProcessor(SessionReplaySessionIdLogProcessor(agentIntegration.sessionManager))

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessor.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.agent.internal.processor
+
+import com.splunk.rum.common.otel.internal.GlobalRumConstants
+import com.splunk.rum.integration.agent.internal.attributes.IScreenNameTracker
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.LogRecordProcessor
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+
+/**
+ * Snapshots the current [IScreenNameTracker.screenName] onto every log record at emit time.
+ *
+ * Log records are batched before being converted to spans. Without this processor, the
+ * global `screen.name` attribute is applied later — at span-creation time — when the value
+ * may already reflect a *subsequent* navigation event. By stamping the value here we
+ * capture the screen that was active when the event actually occurred.
+ *
+ * Log records that already carry `screen.name` (e.g. navigation events set it in the
+ * emitter) are left untouched.
+ */
+class ScreenNameLogRecordProcessor(private val screenNameTracker: IScreenNameTracker) : LogRecordProcessor {
+
+    override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
+        val existing = logRecord.toLogRecordData().attributes.get(GlobalRumConstants.SCREEN_NAME_KEY)
+        if (existing == null) {
+            logRecord.setAttribute(GlobalRumConstants.SCREEN_NAME_KEY, screenNameTracker.screenName)
+        }
+    }
+}

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessor.kt
@@ -26,8 +26,8 @@ import io.opentelemetry.sdk.logs.ReadWriteLogRecord
  * Snapshots the current [IScreenNameTracker.screenName] onto every log record at emit time.
  *
  * Log records are batched before being converted to spans. Without this processor, the
- * global `screen.name` attribute is applied later — at span-creation time — when the value
- * may already reflect a *subsequent* navigation event. By stamping the value here we
+ * global `screen.name` attribute is applied later, at span creation time, when the value
+ * may already reflect a subsequent navigation event. By stamping the value here we
  * capture the screen that was active when the event actually occurred.
  *
  * Log records that already carry `screen.name` (e.g. navigation events set it in the

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -28,12 +28,12 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
         attributes.forEach { key, value ->
-            // Navigation spans set screen.name at emit time via the log
-            // record. Without this guard the global attribute would overwrite the per event value
-            // at export time, causing a race when manual tracking (with differing screenName argument)
-            // and automatic tracking fire back to back
+            // screen.name is snapshotted onto every log record at emit time by
+            // ScreenNameLogRecordProcessor. When those log records are later converted to
+            // spans the attribute is already present. Overwriting it here with the current
+            // global value would be incorrect because ScreenNameTracker may have advanced
+            // to a different screen between emit and batch-flush.
             if (key == GlobalRumConstants.SCREEN_NAME_KEY &&
-                span.name == GlobalRumConstants.NAVIGATION_EVENT_NAME &&
                 span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY) != null
             ) {
                 return@forEach

--- a/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -28,11 +28,11 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
         attributes.forEach { key, value ->
-            // screen.name is snapshotted onto every log record at emit time by
+            // screen.name is added onto every log record at emit time by
             // ScreenNameLogRecordProcessor. When those log records are later converted to
             // spans the attribute is already present. Overwriting it here with the current
             // global value would be incorrect because ScreenNameTracker may have advanced
-            // to a different screen between emit and batch-flush.
+            // to a different screen between emit and batch flush.
             if (key == GlobalRumConstants.SCREEN_NAME_KEY &&
                 span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY) != null
             ) {

--- a/integration/agent/internal/src/test/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessorTest.kt
+++ b/integration/agent/internal/src/test/java/com/splunk/rum/integration/agent/internal/processor/ScreenNameLogRecordProcessorTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.agent.internal.processor
+
+import com.splunk.rum.common.otel.internal.GlobalRumConstants
+import com.splunk.rum.integration.agent.internal.attributes.IScreenNameTracker
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class ScreenNameLogRecordProcessorTest {
+
+    private val tracker = object : IScreenNameTracker {
+        override var lastScreenName: String? = null
+        override var screenName: String = "HomeFragment"
+    }
+
+    private val processor = ScreenNameLogRecordProcessor(tracker)
+
+    @Test
+    fun `stamps screen name on log record that has none`() {
+        val logRecord = mockLogRecord(screenName = null)
+
+        processor.onEmit(Context.root(), logRecord)
+
+        verify(logRecord).setAttribute(GlobalRumConstants.SCREEN_NAME_KEY, "HomeFragment")
+    }
+
+    @Test
+    fun `does not overwrite screen name already present on log record`() {
+        val logRecord = mockLogRecord(screenName = "OkHttpFragment")
+
+        processor.onEmit(Context.root(), logRecord)
+
+        verify(logRecord, never()).setAttribute(GlobalRumConstants.SCREEN_NAME_KEY, "HomeFragment")
+    }
+
+    @Test
+    fun `snapshots current tracker value at emit time`() {
+        tracker.screenName = "SettingsFragment"
+        val logRecord = mockLogRecord(screenName = null)
+
+        processor.onEmit(Context.root(), logRecord)
+
+        verify(logRecord).setAttribute(GlobalRumConstants.SCREEN_NAME_KEY, "SettingsFragment")
+    }
+
+    private fun mockLogRecord(screenName: String?): ReadWriteLogRecord {
+        val logRecord = mock(ReadWriteLogRecord::class.java)
+        val logRecordData = mock(LogRecordData::class.java)
+        val attributes = if (screenName != null) {
+            Attributes.of(GlobalRumConstants.SCREEN_NAME_KEY, screenName)
+        } else {
+            Attributes.empty()
+        }
+        `when`(logRecord.toLogRecordData()).thenReturn(logRecordData)
+        `when`(logRecordData.attributes).thenReturn(attributes)
+        `when`(logRecordData.instrumentationScopeInfo).thenReturn(InstrumentationScopeInfo.empty())
+        return logRecord
+    }
+}

--- a/integration/agent/internal/src/test/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessorTest.kt
+++ b/integration/agent/internal/src/test/java/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessorTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.agent.internal.processor
+
+import com.splunk.rum.common.otel.internal.GlobalRumConstants
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class SplunkInternalGlobalAttributeSpanProcessorTest {
+
+    private val processor = SplunkInternalGlobalAttributeSpanProcessor()
+
+    @Before
+    fun setup() {
+        SplunkInternalGlobalAttributeSpanProcessor.attributes[GlobalRumConstants.SCREEN_NAME_KEY] = "CurrentScreen"
+    }
+
+    @After
+    fun teardown() {
+        SplunkInternalGlobalAttributeSpanProcessor.attributes[GlobalRumConstants.SCREEN_NAME_KEY] =
+            GlobalRumConstants.DEFAULT_SCREEN_NAME
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `sets screen name on span that has none`() {
+        val span = mockSpan(name = "SomeHttpSpan", existingScreenName = null)
+
+        processor.onStart(Context.root(), span)
+
+        verify(span).setAttribute(
+            GlobalRumConstants.SCREEN_NAME_KEY as AttributeKey<Any>,
+            "CurrentScreen" as Any
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `does not overwrite screen name on navigation span`() {
+        val span = mockSpan(name = "app.ui.navigation", existingScreenName = "SnapshotScreen")
+
+        processor.onStart(Context.root(), span)
+
+        verify(span, never()).setAttribute(
+            GlobalRumConstants.SCREEN_NAME_KEY as AttributeKey<Any>,
+            "CurrentScreen" as Any
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `does not overwrite screen name on lifecycle span`() {
+        val span = mockSpan(name = "app.ui.lifecycle", existingScreenName = "SnapshotScreen")
+
+        processor.onStart(Context.root(), span)
+
+        verify(span, never()).setAttribute(
+            GlobalRumConstants.SCREEN_NAME_KEY as AttributeKey<Any>,
+            "CurrentScreen" as Any
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `does not overwrite screen name on any span type that already has it`() {
+        val span = mockSpan(name = "HTTP GET", existingScreenName = "SnapshotScreen")
+
+        processor.onStart(Context.root(), span)
+
+        verify(span, never()).setAttribute(
+            GlobalRumConstants.SCREEN_NAME_KEY as AttributeKey<Any>,
+            "CurrentScreen" as Any
+        )
+    }
+
+    @Test
+    fun `isStartRequired returns true`() {
+        assert(processor.isStartRequired())
+    }
+
+    @Test
+    fun `isEndRequired returns true`() {
+        assert(processor.isEndRequired())
+    }
+
+    private fun mockSpan(name: String, existingScreenName: String?): ReadWriteSpan {
+        val span = mock(ReadWriteSpan::class.java)
+        `when`(span.name).thenReturn(name)
+        `when`(span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY)).thenReturn(existingScreenName)
+        return span
+    }
+}


### PR DESCRIPTION
Adds `ScreenNameLogRecordProcessor` that stamps the current `screen.name` onto every log record synchronously during `emit()`. This captures the screen that was active when the event actually occurred, rather than whatever screen happens to be current when the batch flushes.

Broadens the guard in `SplunkInternalGlobalAttributeSpanProcessor`, the span side processor now skips `screen.name` on all span types that already carry it (not just navigation spans), preserving the per event snapshot through the log-to-span conversion pipeline.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI
