### PR TITLE
NO-TICKET: Fix ignored fragment behaviour

### DIFF
--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -124,6 +124,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
      */
     fun recordEmittedScreen(screenName: String) {
         lastEmittedScreenName = screenName
+        lastEmittedComposeAttributes = Attributes.empty()
     }
 
     /**

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -41,6 +41,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     private var lastResumedFragmentName: String? = null
     private var lastComposeRouteName: String? = null
     private var composeRouteActivityName: String? = null
+    private var pendingPauseEmit: Runnable? = null
 
     /**
      * Current visible screen name: Compose route > Fragment > Activity.
@@ -77,6 +78,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     }
 
     fun onFragmentResumed(fragment: Fragment) {
+        cancelPendingPauseEmit()
         if (ScreenNameDescriptor.isIgnored(fragment)) return
 
         val name = ScreenNameDescriptor.getName(fragment)
@@ -91,7 +93,14 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         if (lastResumedFragmentName == name) {
             lastResumedFragmentName = findResumedAncestorName(fragment)
         }
-        handler.post { tryEmitIfChanged() }
+        val runnable = Runnable { tryEmitIfChanged() }
+        pendingPauseEmit = runnable
+        handler.post(runnable)
+    }
+
+    private fun cancelPendingPauseEmit() {
+        pendingPauseEmit?.let { handler.removeCallbacks(it) }
+        pendingPauseEmit = null
     }
 
     private fun findResumedAncestorName(fragment: Fragment): String? {

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -166,7 +166,6 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     fun clearComposeRoute() {
         lastComposeRouteName = null
         composeRouteActivityName = null
-        lastEmittedComposeAttributes = null
     }
 
     /**

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -41,7 +41,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     private var lastResumedFragmentName: String? = null
     private var lastComposeRouteName: String? = null
     private var composeRouteActivityName: String? = null
-    private var pendingPauseEmit: Runnable? = null
+    private val deferredPauseRunnable = Runnable { tryEmitIfChanged() }
 
     /**
      * Current visible screen name: Compose route > Fragment > Activity.
@@ -93,14 +93,12 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         if (lastResumedFragmentName == name) {
             lastResumedFragmentName = findResumedAncestorName(fragment)
         }
-        val runnable = Runnable { tryEmitIfChanged() }
-        pendingPauseEmit = runnable
-        handler.post(runnable)
+        handler.removeCallbacks(deferredPauseRunnable)
+        handler.post(deferredPauseRunnable)
     }
 
     private fun cancelPendingPauseEmit() {
-        pendingPauseEmit?.let { handler.removeCallbacks(it) }
-        pendingPauseEmit = null
+        handler.removeCallbacks(deferredPauseRunnable)
     }
 
     private fun findResumedAncestorName(fragment: Fragment): String? {

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
@@ -170,6 +170,15 @@ class ScreenChangeDetectorTest {
     }
 
     @Test
+    fun `recordEmittedScreen prevents duplicate emission from automatic Compose tracking`() {
+        detector.recordEmittedScreen("home")
+
+        detector.onComposeRouteChanged("home")
+
+        assertTrue(exportedLogs.isEmpty())
+    }
+
+    @Test
     fun `activity becomes visible screen when fragment is paused`() {
         val activity = activityController.create().get()
         val menu = MenuFragment()

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
@@ -323,7 +323,7 @@ class ScreenChangeDetectorTest {
     }
 
     @Test
-    fun `navigating to ignored fragment does not emit spurious activity event`() {
+    fun `navigating to ignored fragment does not emit false activity event`() {
         val activity = activityController.create().get()
         val menu = MenuFragment()
         val ignored = IgnoredFragment()

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
@@ -323,7 +323,7 @@ class ScreenChangeDetectorTest {
     }
 
     @Test
-    fun `navigating to ignored fragment does not emit false activity event`() {
+    fun `navigating to ignored fragment does not emit a false activity event`() {
         val activity = activityController.create().get()
         val menu = MenuFragment()
         val ignored = IgnoredFragment()
@@ -363,6 +363,43 @@ class ScreenChangeDetectorTest {
 
         assertEquals(1, exportedLogs.size)
         assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `back to back fragment pauses do not emit duplicate events`() {
+        val activity = activityController.create().get()
+        val parent = MenuFragment()
+        val child = CrashReportsFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(parent)
+        detector.onFragmentResumed(child)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(2, exportedLogs.size)
+
+        detector.onFragmentPaused(child)
+        detector.onFragmentPaused(parent)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(3, exportedLogs.size)
+        assertEquals("Main", exportedLogs[2].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `clearComposeRoute does not re-emit when fragment has same name`() {
+        val activity = activityController.create().get()
+
+        detector.onActivityResumed(activity)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onComposeRouteChanged("Main")
+        assertEquals(2, exportedLogs.size)
+
+        detector.clearComposeRoute()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(2, exportedLogs.size)
     }
 
     @NavigationElement(name = "Main")

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
@@ -313,6 +313,49 @@ class ScreenChangeDetectorTest {
         assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
     }
 
+    @Test
+    fun `navigating to ignored fragment does not emit spurious activity event`() {
+        val activity = activityController.create().get()
+        val menu = MenuFragment()
+        val ignored = IgnoredFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+        assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+
+        detector.onFragmentPaused(menu)
+        detector.onFragmentResumed(ignored)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1, exportedLogs.size)
+    }
+
+    @Test
+    fun `returning from ignored fragment to tracked fragment emits correctly`() {
+        val activity = activityController.create().get()
+        val menu = MenuFragment()
+        val ignored = IgnoredFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onFragmentPaused(menu)
+        detector.onFragmentResumed(ignored)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onFragmentPaused(ignored)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1, exportedLogs.size)
+        assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
     @NavigationElement(name = "Main")
     class MainActivity : Activity()
 


### PR DESCRIPTION
When a tracked fragment paused and an ignored fragment resumed (e.g. @NavigationElement(isIgnored = true)), the deferred emit from onFragmentPaused would fire and fall back to the Activity name, producing a false navigation event. 

This fix cancels the pending deferred emit whenever any fragment resumes, so ignored fragments no longer trigger an Activity fallback. The "fragment removed without replacement" fallback is unaffected since no replacement fragment resumes to cancel it.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- add isIgnored annotation to a fragment, ie crashReportsFragment
- Build app
- navigate to and back
- observe zero navigation events when tapping "Crash Reports" and pressing back