### PR TITLE
NO-TICKET: Include last.screen.name=unknown on first navigation event

### DIFF
--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitter.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitter.kt
@@ -45,9 +45,7 @@ internal class NavigationEventEmitter {
      */
     fun emitNavigationEvent(screenName: String, attributes: Attributes = Attributes.empty()) {
         val timestamp = System.currentTimeMillis()
-        val previousScreenName = ScreenNameTracker.screenName.takeIf {
-            it != GlobalRumConstants.DEFAULT_SCREEN_NAME
-        }
+        val previousScreenName = ScreenNameTracker.screenName
         ScreenNameTracker.screenName = screenName
         if (!isInstallComplete) {
             Logger.d(TAG) {

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitterTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitterTest.kt
@@ -30,7 +30,6 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -151,14 +150,14 @@ class NavigationEventEmitterTest {
     }
 
     @Test
-    fun `emitted log record omits last screen name when previous is DEFAULT_SCREEN_NAME`() {
+    fun `emitted log record includes unknown as last screen name on first navigation`() {
         val emitter = NavigationEventEmitter()
         emitter.processCachedEvents()
 
         emitter.emitNavigationEvent("Menu")
 
         val log = exportedLogs.single()
-        assertNull(log.attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", log.attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }
 
     @Test
@@ -225,7 +224,7 @@ class NavigationEventEmitterTest {
         emitter.processCachedEvents()
 
         assertEquals(2, exportedLogs.size)
-        assertNull(exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
         assertEquals("Menu", exportedLogs[1].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }
 
@@ -241,7 +240,7 @@ class NavigationEventEmitterTest {
 
         assertEquals(2, exportedLogs.size)
         assertEquals("Login", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
-        assertNull(exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
         assertEquals("Dashboard", exportedLogs[1].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
         assertEquals("Login", exportedLogs[1].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }


### PR DESCRIPTION
The first app.ui.navigation event previously omitted last.screen.name entirely because the default screen name (unknown) was filtered out. 

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to test

Run sample app, verify first navigation event is unknown -> menu instead of null -> menu 
