### PR TITLE
NO-TICKET: ci: temporarily disable instrumented tests in PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,50 +42,51 @@ jobs:
           java-version: 17
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
-  instrumented_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        api-level: [ 29 ]
-    steps:
-      - uses: actions/checkout@v4.3.1
-      - name: Set up JDK 17 for running Gradle
-        uses: actions/setup-java@v4.8.0
-        with:
-          distribution: temurin
-          java-version: 17
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-      - name: Setup Gradle cache
-        uses: gradle/actions/setup-gradle@v3
-      - name: Setup AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-      - name: Run Instrumented Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest
+  # Temporarily disabled because instrumented tests are not working correctly in the PR workflow.
+  # instrumented_tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       api-level: [ 29 ]
+  #   steps:
+  #     - uses: actions/checkout@v4.3.1
+  #     - name: Set up JDK 17 for running Gradle
+  #       uses: actions/setup-java@v4.8.0
+  #       with:
+  #         distribution: temurin
+  #         java-version: 17
+  #     - name: Enable KVM
+  #       run: |
+  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+  #         sudo udevadm control --reload-rules
+  #         sudo udevadm trigger --name-match=kvm
+  #     - name: Setup Gradle cache
+  #       uses: gradle/actions/setup-gradle@v3
+  #     - name: Setup AVD cache
+  #       uses: actions/cache@v4
+  #       id: avd-cache
+  #       with:
+  #         path: |
+  #           ~/.android/avd/*
+  #           ~/.android/adb*
+  #         key: avd-${{ matrix.api-level }}
+  #     - name: Create AVD and generate snapshot for caching
+  #       if: steps.avd-cache.outputs.cache-hit != 'true'
+  #       uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         api-level: ${{ matrix.api-level }}
+  #         force-avd-creation: false
+  #         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+  #         disable-animations: false
+  #         script: echo "Generated AVD snapshot for caching."
+  #     - name: Run Instrumented Tests
+  #       uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         api-level: ${{ matrix.api-level }}
+  #         force-avd-creation: false
+  #         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+  #         disable-animations: true
+  #         script: ./gradlew connectedDebugAndroidTest
 
   jacoco_test_coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temporarily comment out the `instrumented_tests` job in the PR GitHub Actions workflow.

The job is currently not working correctly and is preventing the rest of the PR workflow from completing as expected. This change keeps the remaining PR checks running while we investigate and fix the instrumented test setup separately.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI