### PR TITLE
NO-TICKET: Restore missing navigation changes

### DIFF
--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitter.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitter.kt
@@ -45,9 +45,7 @@ internal class NavigationEventEmitter {
      */
     fun emitNavigationEvent(screenName: String, attributes: Attributes = Attributes.empty()) {
         val timestamp = System.currentTimeMillis()
-        val previousScreenName = ScreenNameTracker.screenName.takeIf {
-            it != GlobalRumConstants.DEFAULT_SCREEN_NAME
-        }
+        val previousScreenName = ScreenNameTracker.screenName
         ScreenNameTracker.screenName = screenName
         if (!isInstallComplete) {
             Logger.d(TAG) {

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -41,6 +41,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     private var lastResumedFragmentName: String? = null
     private var lastComposeRouteName: String? = null
     private var composeRouteActivityName: String? = null
+    private val deferredPauseRunnable = Runnable { tryEmitIfChanged() }
 
     /**
      * Current visible screen name: Compose route > Fragment > Activity.
@@ -77,6 +78,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     }
 
     fun onFragmentResumed(fragment: Fragment) {
+        cancelPendingPauseEmit()
         if (ScreenNameDescriptor.isIgnored(fragment)) return
 
         val name = ScreenNameDescriptor.getName(fragment)
@@ -90,8 +92,14 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         val name = ScreenNameDescriptor.getName(fragment)
         if (lastResumedFragmentName == name) {
             lastResumedFragmentName = findResumedAncestorName(fragment)
+                ?: findResumedSiblingName(fragment)
         }
-        handler.post { tryEmitIfChanged() }
+        handler.removeCallbacks(deferredPauseRunnable)
+        handler.post(deferredPauseRunnable)
+    }
+
+    private fun cancelPendingPauseEmit() {
+        handler.removeCallbacks(deferredPauseRunnable)
     }
 
     private fun findResumedAncestorName(fragment: Fragment): String? {
@@ -105,6 +113,21 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
         return null
     }
 
+    /**
+     * Finds a resumed sibling fragment in the same FragmentManager.
+     * Handles add()-based overlays where the underlying fragment was never paused.
+     */
+    private fun findResumedSiblingName(fragment: Fragment): String? {
+        val fm = try {
+            fragment.parentFragmentManager
+        } catch (_: IllegalStateException) {
+            return null
+        }
+        return fm.fragments.lastOrNull {
+            it !== fragment && it.isResumed && !ScreenNameDescriptor.isIgnored(it)
+        }?.let { ScreenNameDescriptor.getName(it) }
+    }
+
     private var lastEmittedScreenName: String? = null
     private var lastEmittedComposeAttributes: Attributes? = null
 
@@ -115,6 +138,7 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
      */
     fun recordEmittedScreen(screenName: String) {
         lastEmittedScreenName = screenName
+        lastEmittedComposeAttributes = Attributes.empty()
     }
 
     /**
@@ -142,7 +166,6 @@ internal class ScreenChangeDetector(private val eventEmitter: NavigationEventEmi
     fun clearComposeRoute() {
         lastComposeRouteName = null
         composeRouteActivityName = null
-        lastEmittedComposeAttributes = null
     }
 
     /**

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitterTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/NavigationEventEmitterTest.kt
@@ -30,7 +30,6 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -151,14 +150,14 @@ class NavigationEventEmitterTest {
     }
 
     @Test
-    fun `emitted log record omits last screen name when previous is DEFAULT_SCREEN_NAME`() {
+    fun `emitted log record includes unknown as last screen name on first navigation`() {
         val emitter = NavigationEventEmitter()
         emitter.processCachedEvents()
 
         emitter.emitNavigationEvent("Menu")
 
         val log = exportedLogs.single()
-        assertNull(log.attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", log.attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }
 
     @Test
@@ -225,7 +224,7 @@ class NavigationEventEmitterTest {
         emitter.processCachedEvents()
 
         assertEquals(2, exportedLogs.size)
-        assertNull(exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
         assertEquals("Menu", exportedLogs[1].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }
 
@@ -241,7 +240,7 @@ class NavigationEventEmitterTest {
 
         assertEquals(2, exportedLogs.size)
         assertEquals("Login", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
-        assertNull(exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
+        assertEquals("unknown", exportedLogs[0].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
         assertEquals("Dashboard", exportedLogs[1].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
         assertEquals("Login", exportedLogs[1].attributes.get(GlobalRumConstants.LAST_SCREEN_NAME_KEY))
     }

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetectorTest.kt
@@ -170,6 +170,15 @@ class ScreenChangeDetectorTest {
     }
 
     @Test
+    fun `recordEmittedScreen prevents duplicate emission from automatic Compose tracking`() {
+        detector.recordEmittedScreen("home")
+
+        detector.onComposeRouteChanged("home")
+
+        assertTrue(exportedLogs.isEmpty())
+    }
+
+    @Test
     fun `activity becomes visible screen when fragment is paused`() {
         val activity = activityController.create().get()
         val menu = MenuFragment()
@@ -311,6 +320,86 @@ class ScreenChangeDetectorTest {
 
         assertEquals(1, exportedLogs.size)
         assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `navigating to ignored fragment does not emit a false activity event`() {
+        val activity = activityController.create().get()
+        val menu = MenuFragment()
+        val ignored = IgnoredFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+        assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+
+        detector.onFragmentPaused(menu)
+        detector.onFragmentResumed(ignored)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1, exportedLogs.size)
+    }
+
+    @Test
+    fun `returning from ignored fragment to tracked fragment emits correctly`() {
+        val activity = activityController.create().get()
+        val menu = MenuFragment()
+        val ignored = IgnoredFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onFragmentPaused(menu)
+        detector.onFragmentResumed(ignored)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onFragmentPaused(ignored)
+        detector.onFragmentResumed(menu)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1, exportedLogs.size)
+        assertEquals("Menu", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `back to back fragment pauses do not emit duplicate events`() {
+        val activity = activityController.create().get()
+        val parent = MenuFragment()
+        val child = CrashReportsFragment()
+
+        detector.onActivityResumed(activity)
+        detector.onFragmentResumed(parent)
+        detector.onFragmentResumed(child)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(2, exportedLogs.size)
+
+        detector.onFragmentPaused(child)
+        detector.onFragmentPaused(parent)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(3, exportedLogs.size)
+        assertEquals("Main", exportedLogs[2].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `clearComposeRoute does not re-emit when fragment has same name`() {
+        val activity = activityController.create().get()
+
+        detector.onActivityResumed(activity)
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, exportedLogs.size)
+
+        detector.onComposeRouteChanged("Main")
+        assertEquals(2, exportedLogs.size)
+
+        detector.clearComposeRoute()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(2, exportedLogs.size)
     }
 
     @NavigationElement(name = "Main")


### PR DESCRIPTION
### Description

Adding in the changes from the two below PRs. For some reason, they were merged into `feature/navigation-event-based` but the changes did not show up in develop. Probably lost when the branch was rebased before the merge into `develop`

https://github.com/signalfx/splunk-otel-android/pull/1604
https://github.com/signalfx/splunk-otel-android/pull/1605

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI
