### PR TITLE
DEMRUM-5261: Ignore navhost implementations

### DIFF
--- a/integration/navigation/build.gradle.kts
+++ b/integration/navigation/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
     testImplementation(Dependencies.Test.mockito)
     testImplementation(Dependencies.Test.robolectric)
     testImplementation(Dependencies.Test.androidXTestCore)
+    testImplementation(Dependencies.Android.navigationRuntime)
 }

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/automatic/ScreenChangeDetector.kt
@@ -27,7 +27,7 @@ import io.opentelemetry.api.common.Attributes
  * Detects visible screen changes (Activity/Fragment/Compose route) and notifies
  * [NavigationEventEmitter]. Priority: Compose route > Fragment > Activity.
  *
- * Elements marked as ignored by [ScreenNameDescriptor] (e.g. DialogFragment, NavHostFragment,
+ * Elements marked as ignored by [ScreenNameDescriptor] (e.g. DialogFragment, NavHost implementations,
  * or annotated with isIgnored = true) are skipped entirely.
  *
  * Emits on resumed (onFragmentResumed / onActivityResumed) as the primary trigger.

--- a/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/descriptor/ScreenNameDescriptor.kt
+++ b/integration/navigation/src/main/java/com/splunk/rum/integration/navigation/descriptor/ScreenNameDescriptor.kt
@@ -37,14 +37,19 @@ internal object ScreenNameDescriptor {
 
     private fun isIgnored(element: Any): Boolean {
         if (element is DialogFragment) return true
-        // Ignore NavHostFragment by default (Jetpack Navigation container; not a user-facing screen).
-        if (element is Fragment && element.javaClass.name == NAV_HOST_FRAGMENT_CLASS_NAME) {
-            return true
-        }
+        if (element is Fragment && element.isNavHost()) return true
         return getNavigationElement(element)?.isIgnored ?: getRumScreenName(element)?.isIgnored ?: false
     }
 
-    private const val NAV_HOST_FRAGMENT_CLASS_NAME = "androidx.navigation.fragment.NavHostFragment"
+    private val navHostClass: Class<*>? by lazy {
+        try {
+            Class.forName("androidx.navigation.NavHost")
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+    }
+
+    private fun Fragment.isNavHost(): Boolean = navHostClass?.isAssignableFrom(javaClass) ?: false
 
     private fun getRumScreenName(element: Any): RumScreenName? {
         val javaClass = element::class.java

--- a/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/descriptor/ScreenNameDescriptorTest.kt
+++ b/integration/navigation/src/test/java/com/splunk/rum/integration/navigation/descriptor/ScreenNameDescriptorTest.kt
@@ -19,6 +19,8 @@ package com.splunk.rum.integration.navigation.descriptor
 import android.app.Activity
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.NavHost
 import com.splunk.rum.integration.navigation.NavigationElement
 import com.splunk.rum.integration.navigation.screen.RumScreenName
 import org.junit.Assert.assertEquals
@@ -115,6 +117,12 @@ class ScreenNameDescriptorTest {
         assertTrue(ScreenNameDescriptor.isIgnored(dialog))
     }
 
+    @Test
+    fun `isIgnored returns true for custom NavHost implementation`() {
+        val fragment = CustomNavHostFragment()
+        assertTrue(ScreenNameDescriptor.isIgnored(fragment))
+    }
+
     @NavigationElement(name = "Menu")
     class MenuFragment : Fragment()
 
@@ -148,4 +156,11 @@ class ScreenNameDescriptorTest {
 
     @NavigationElement(name = "Confirmation")
     class AnnotatedDialogFragment : DialogFragment()
+
+    class CustomNavHostFragment :
+        Fragment(),
+        NavHost {
+        override val navController: NavController
+            get() = throw UnsupportedOperationException("stub for test")
+    }
 }


### PR DESCRIPTION
### Description

- Broadens the `NavHost` ignore logic in `ScreenNameDescriptor` to filter out all `NavHost` implementations (not just the exact `NavHostFragment` class), using reflection with `isAssignableFrom`
- Avoid a compile time dependency on` androidx.navigation `by lazily resolving the `NavHost` class via `Class.forName`, gracefully falling back to a no op if the library isn't on the classpath

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Run unit tests
- Add an implementation of `NavHost` to the sample app and verify that it is ignored
