### PR TITLE
DEMRUM-5357: Add AutoValue consumer R8 rules to common/otel

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,9 +1,0 @@
-#compile-time annotation
--dontwarn com.google.auto.value.AutoValue
--dontwarn com.google.auto.value.AutoValue$Builder
--dontwarn com.google.auto.value.AutoValue$CopyAnnotations
--dontwarn com.google.auto.value.extension.memoized.Memoized
-
-#compile-time dependency in io.opentelemetry.exporter
--dontwarn com.fasterxml.jackson.core.JsonGenerator
--dontwarn com.fasterxml.jackson.core.JsonFactory

--- a/common/otel/consumer-rules.pro
+++ b/common/otel/consumer-rules.pro
@@ -1,0 +1,4 @@
+#compile-time annotation
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations


### PR DESCRIPTION
## Title: Add AutoValue consumer R8 rules to common/otel

### Description

- Added R8 consumer rules for missing class errors on AutoValue annotations as they're always compile-time and not needed at runtime
- It's safe to ignore other rules not migrated from app as those are no longer concerning as identified in thorough testing. 

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes
- Build project with R8 minification enabled.
- Test a locally published sdk artifact with another sample app with R8 minification enabled. This app should not already contain the AutoValue rules added in this PR. It should build successfully.