### PR TITLE
DEMRUM-5293: Fix instrumented tests job hanging on emulator shutdown

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew testDebugUnitTest
   instrumented_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         api-level: [ 29 ]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 24, 29 ]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK 17 for running Gradle

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,51 +42,59 @@ jobs:
           java-version: 17
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
-  # Temporarily disabled because instrumented tests are not working correctly in the PR workflow.
-  # instrumented_tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       api-level: [ 29 ]
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-  #     - name: Set up JDK 17 for running Gradle
-  #       uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
-  #       with:
-  #         distribution: temurin
-  #         java-version: 17
-  #     - name: Enable KVM
-  #       run: |
-  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-  #         sudo udevadm control --reload-rules
-  #         sudo udevadm trigger --name-match=kvm
-  #     - name: Setup Gradle cache
-  #       uses: gradle/actions/setup-gradle@v3
-  #     - name: Setup AVD cache
-  #       uses: actions/cache@v4
-  #       id: avd-cache
-  #       with:
-  #         path: |
-  #           ~/.android/avd/*
-  #           ~/.android/adb*
-  #         key: avd-${{ matrix.api-level }}
-  #     - name: Create AVD and generate snapshot for caching
-  #       if: steps.avd-cache.outputs.cache-hit != 'true'
-  #       uses: reactivecircus/android-emulator-runner@v2
-  #       with:
-  #         api-level: ${{ matrix.api-level }}
-  #         force-avd-creation: false
-  #         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-  #         disable-animations: false
-  #         script: echo "Generated AVD snapshot for caching."
-  #     - name: Run Instrumented Tests
-  #       uses: reactivecircus/android-emulator-runner@v2
-  #       with:
-  #         api-level: ${{ matrix.api-level }}
-  #         force-avd-creation: false
-  #         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-  #         disable-animations: true
-  #         script: ./gradlew connectedDebugAndroidTest
+  instrumented_tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        api-level: [ 29 ]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Set up JDK 17 for running Gradle
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Setup Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+      - name: Setup AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+      - name: Run Instrumented Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            ./gradlew connectedDebugAndroidTest || GRADLE_EXIT=$?
+            # Kill crashpad_handler to prevent emulator shutdown hang
+            # -f required: process name exceeds pkill's 15-char comm limit
+            # [c] character class prevents pkill from matching its own shell process
+            pkill -f '[c]rashpad_handler' || true
+            sleep 3
+            pkill -f -SIGKILL '[c]rashpad_handler' || true
+            exit ${GRADLE_EXIT:-0}
   jacoco_test_coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Fix instrumented test job

### Description
Re enable the instrumented_tests job that was disabled due to the emulator runner hanging indefinitely during cleanup. 

The root cause is some orphaned crashpad_handler processes that prevent the process tree from exiting (ReactiveCircus/android-emulator-runner#385).

Changes:
- Kill crashpad_handler processes inside the script before the action's cleanup phase runs to avoid the deadlock
- Add timeout-minutes: 30 as a fail fast safety net (tests take about 14min)

note: The pkill uses -f to match the full command line (the process name exceeds Linux's 15 character comm limit) and a [c] character class trick to avoid matching its own shell process

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Verify tests succeed 
