### PR TITLE
DEMRUM-5130: Sampling rate fix

### DIFF
--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
@@ -103,32 +103,40 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
             return
         }
 
-        if (moduleConfiguration.samplingRate < Math.random()) {
+        val sampledOut = moduleConfiguration.samplingRate < Math.random()
+
+        if (sampledOut) {
             Logger.d(TAG) {
                 "onSessionChange() - Session replay for session '$currentSessionId' is disabled due to sampling rate"
             }
 
-            SplunkSessionReplay.instance.stop()
+            if (runtimeState.isRecordingRequested && !runtimeState.isSessionDisabledBySampling) {
+                SplunkSessionReplay.instance.stop()
+            }
 
             runtimeState.isSessionDisabledBySampling = true
             runtimeState.statusOverride = Status.NotRecording(
                 cause = Status.NotRecording.Cause.DISABLED_BY_SAMPLING
             )
-        } else {
-            runtimeState.isSessionDisabledBySampling = false
 
-            if ((runtimeState.statusOverride as? Status.NotRecording)?.cause ==
-                Status.NotRecording.Cause.DISABLED_BY_SAMPLING
-            ) {
-                runtimeState.statusOverride = null
-            }
+            return
+        }
 
-            if (runtimeState.pendingStart) {
-                runtimeState.pendingStart = false
+        val wasSampledOut = runtimeState.isSessionDisabledBySampling
+        runtimeState.isSessionDisabledBySampling = false
+
+        if ((runtimeState.statusOverride as? Status.NotRecording)?.cause ==
+            Status.NotRecording.Cause.DISABLED_BY_SAMPLING
+        ) {
+            runtimeState.statusOverride = null
+        }
+
+        when {
+            wasSampledOut && runtimeState.isRecordingRequested ->
                 SessionReplay.instance.start()
-            } else {
+            runtimeState.isRecordingRequested ->
                 SessionReplay.instance.newDataChunk()
-            }
+            else -> Unit
         }
     }
 
@@ -201,7 +209,7 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
     internal data class RuntimeState(
         var moduleConfiguration: SessionReplayModuleConfiguration? = null,
         var statusOverride: Status? = null,
-        var pendingStart: Boolean = false,
+        var isRecordingRequested: Boolean = false,
         var isSessionDisabledBySampling: Boolean = false
     )
 }

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
@@ -110,13 +110,25 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
 
             SplunkSessionReplay.instance.stop()
 
+            runtimeState.isSessionDisabledBySampling = true
             runtimeState.statusOverride = Status.NotRecording(
                 cause = Status.NotRecording.Cause.DISABLED_BY_SAMPLING
             )
-        } else if (runtimeState.pendingStart) {
-            SessionReplay.instance.start()
         } else {
-            SessionReplay.instance.newDataChunk()
+            runtimeState.isSessionDisabledBySampling = false
+
+            if ((runtimeState.statusOverride as? Status.NotRecording)?.cause ==
+                Status.NotRecording.Cause.DISABLED_BY_SAMPLING
+            ) {
+                runtimeState.statusOverride = null
+            }
+
+            if (runtimeState.pendingStart) {
+                runtimeState.pendingStart = false
+                SessionReplay.instance.start()
+            } else {
+                SessionReplay.instance.newDataChunk()
+            }
         }
     }
 
@@ -189,6 +201,7 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
     internal data class RuntimeState(
         var moduleConfiguration: SessionReplayModuleConfiguration? = null,
         var statusOverride: Status? = null,
-        var pendingStart: Boolean = false
+        var pendingStart: Boolean = false,
+        var isSessionDisabledBySampling: Boolean = false
     )
 }

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
@@ -111,7 +111,7 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
             }
 
             if (runtimeState.isRecordingRequested && !runtimeState.isSessionDisabledBySampling) {
-                SplunkSessionReplay.instance.stop()
+                SessionReplay.instance.stop()
             }
 
             runtimeState.isSessionDisabledBySampling = true

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/SessionReplay.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/SessionReplay.kt
@@ -72,9 +72,7 @@ class SessionReplay internal constructor(private val runtimeState: SessionReplay
             return
         }
 
-        if ((runtimeState.statusOverride as? Status.NotRecording)?.cause ==
-            Status.NotRecording.Cause.DISABLED_BY_SAMPLING
-        ) {
+        if (runtimeState.isSessionDisabledBySampling) {
             Logger.w(TAG, "start() - Session replay is disabled by sampling")
             runtimeState.pendingStart = true
             return
@@ -88,11 +86,9 @@ class SessionReplay internal constructor(private val runtimeState: SessionReplay
      * Stops recording of a user activity.
      */
     fun stop() {
-        if ((runtimeState.statusOverride as? Status.NotRecording)?.cause ==
-            Status.NotRecording.Cause.DISABLED_BY_SAMPLING
-        ) {
-            runtimeState.statusOverride = null
+        if (runtimeState.isSessionDisabledBySampling) {
             runtimeState.pendingStart = false
+            return
         }
 
         CommonSessionReplay.instance.stop()

--- a/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/SessionReplay.kt
+++ b/integration/sessionreplay/src/main/java/com/splunk/rum/integration/sessionreplay/api/SessionReplay.kt
@@ -72,9 +72,10 @@ class SessionReplay internal constructor(private val runtimeState: SessionReplay
             return
         }
 
+        runtimeState.isRecordingRequested = true
+
         if (runtimeState.isSessionDisabledBySampling) {
             Logger.w(TAG, "start() - Session replay is disabled by sampling")
-            runtimeState.pendingStart = true
             return
         }
 
@@ -86,8 +87,9 @@ class SessionReplay internal constructor(private val runtimeState: SessionReplay
      * Stops recording of a user activity.
      */
     fun stop() {
+        runtimeState.isRecordingRequested = false
+
         if (runtimeState.isSessionDisabledBySampling) {
-            runtimeState.pendingStart = false
             return
         }
 


### PR DESCRIPTION
## Title: Fix Session Replay starting despite samplingRate = 0

### Description

Fixed a bug where Session Replay could record even when the session was rejected by sampling.
Cause: `stop()` cleared `statusOverride` and `pendingStart`, erasing the sampling decision, so the next `start()` no longer detected `DISABLED_BY_SAMPLING` and started recording.
Added a dedicated `RuntimeState.isSessionDisabledBySampling` flag owned exclusively by `processSessionChange()`. Public `start()` / `stop()` only read it.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

1. Configure Session Replay with samplingRate = 0f in the sample app.
2. Call start() → stop() → start().
3. Expected: no Session Replay data is emitted; both start() calls log disabled by sampling.
4. Repeat with samplingRate = 1f to confirm the happy path still works.