### PR TITLE
DEMRUM-3430: Updated LoggerSpanExporter

### DIFF
--- a/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/exporter/LoggerSpanExporter.kt
+++ b/integration/agent/api/src/main/java/com/splunk/rum/integration/agent/api/exporter/LoggerSpanExporter.kt
@@ -20,6 +20,8 @@ import com.splunk.android.common.logger.Logger
 import com.splunk.android.common.utils.extensions.forEachFast
 import com.splunk.rum.common.otel.extensions.joinToString
 import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.EventData
+import io.opentelemetry.sdk.trace.data.LinkData
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import java.util.concurrent.atomic.AtomicBoolean
@@ -37,19 +39,55 @@ internal class LoggerSpanExporter : SpanExporter {
             val instrumentationScopeInfo = span.instrumentationScopeInfo
 
             Logger.i(TAG) {
-                "name=${span.name}, " +
-                    "traceId=${span.traceId}, " +
-                    "spanId=${span.spanId}, " +
-                    "parentSpanId=${span.parentSpanId}, " +
-                    "kind=${span.kind}, " +
-                    "resources=${span.resource.attributes.joinToString(", ", "[", "]")}, " +
-                    "attributes=${span.attributes.joinToString(", ", "[", "]")}, " +
-                    "instrumentationScopeInfo.name=${instrumentationScopeInfo.name}, " +
-                    "instrumentationScopeInfo.version=${instrumentationScopeInfo.version}"
+                buildString {
+                    append("name=${span.name}, ")
+                    append("traceId=${span.traceId}, ")
+                    append("spanId=${span.spanId}, ")
+                    append("parentSpanId=${span.parentSpanId}, ")
+                    append("kind=${span.kind}, ")
+                    append("startEpochNanos=${span.startEpochNanos}, ")
+                    append("endEpochNanos=${span.endEpochNanos}, ")
+                    append("durationNanos=${span.endEpochNanos - span.startEpochNanos}, ")
+                    append("status.code=${span.status.statusCode}, ")
+                    append("status.description=${span.status.description}, ")
+                    append("resources=${span.resource.attributes.joinToString(", ", "[", "]")}, ")
+                    append("attributes=${span.attributes.joinToString(", ", "[", "]")}, ")
+                    append("totalAttributeCount=${span.totalAttributeCount}, ")
+                    append("events=${formatEvents(span.events)}, ")
+                    append("totalRecordedEvents=${span.totalRecordedEvents}, ")
+                    append("links=${formatLinks(span.links)}, ")
+                    append("totalRecordedLinks=${span.totalRecordedLinks}, ")
+                    append("instrumentationScopeInfo.name=${instrumentationScopeInfo.name}, ")
+                    append("instrumentationScopeInfo.version=${instrumentationScopeInfo.version}")
+                }
             }
         }
 
         return CompletableResultCode.ofSuccess()
+    }
+
+    private fun formatEvents(events: List<EventData>): String = buildString {
+        append("[")
+        events.forEachIndexed { index, event ->
+            append("{name=${event.name}")
+            append(", epochNanos=${event.epochNanos}")
+            append(", attributes=${event.attributes.joinToString(", ", "[", "]")}")
+            append("}")
+            if (index < events.size - 1) append(", ")
+        }
+        append("]")
+    }
+
+    private fun formatLinks(links: List<LinkData>): String = buildString {
+        append("[")
+        links.forEachIndexed { index, link ->
+            append("{traceId=${link.spanContext.traceId}")
+            append(", spanId=${link.spanContext.spanId}")
+            append(", attributes=${link.attributes.joinToString(", ", "[", "]")}")
+            append("}")
+            if (index < links.size - 1) append(", ")
+        }
+        append("]")
     }
 
     override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()


### PR DESCRIPTION
## Enhance LoggerSpanExporter to log all SpanData fields

### Description

- Added `startEpochNanos`, `endEpochNanos`, and computed `durationNanos` to span log output
- Added `status.code` and `status.description` for span status visibility
- Added full event logging (name, timestamp, and attributes for each event) to surface exception.* attributes
- Added full link logging (traceId, spanId, and attributes for each link)
- Added `totalRecordedEvents`, `totalRecordedLinks`, and `totalAttributeCount` counters to detect truncation
- Refactored string building to use buildString with extracted `formatEvents()` and `formatLinks()` helper methods

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Verify these new fields exist in the logcat when running sample app, check LoggerSpanExporter logs