### PR TITLE
NO-TICKET: docs: Add instrumentation README template and generated module docs

### DIFF
--- a/.codex/skills/instrumentation-readme/SKILL.md
+++ b/.codex/skills/instrumentation-readme/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: instrumentation-readme
+description: Generate, update, or review Splunk Android RUM instrumentation README.md files in integration modules using the repository template and guidelines. Use when documenting integration instrumentation modules, telemetry data models, configuration APIs, quick starts, or reviewing whether instrumentation documentation changed with a PR.
+---
+
+# Instrumentation README
+
+Use this skill when creating, updating, or reviewing documentation for Splunk Android RUM instrumentation modules under `integration/`. Generated README files belong at `integration/<module>/README.md`.
+
+## Workflow
+
+1. Read the canonical repository docs:
+   - `docs/instrumentation-readme-guidelines.md`
+   - `docs/instrumentation-readme-template.md`
+2. Inspect the affected module code, tests, public configuration types, extension APIs, annotations, and telemetry constants.
+3. Add or update `integration/<module>/README.md` using the template sections.
+4. Keep the documentation factual. Do not invent behavior, dependencies, public APIs, defaults, telemetry, or setup steps.
+5. If documenting accurately would require changing public API or default behavior, stop and ask for explicit confirmation before changing code.
+
+## Review Use
+
+For instrumentation PRs, check whether behavior, setup, public API, defaults, filtering, fallback behavior, or telemetry changed. If yes, verify `integration/<module>/README.md` was updated according to the repository template and guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,14 @@ To contribute documentation for this project, open a pull request in the
 the [CONTRIBUTING.md](https://github.com/splunk/public-o11y-docs/blob/main/CONTRIBUTING.md)
 guide of the Splunk Observability Cloud documentation for more information.
 
+Instrumentation module README files are generated repository reference
+documentation under `integration/<module>/README.md`. When adding or changing
+instrumentation behavior, update the affected README using the [instrumentation
+README template](docs/instrumentation-readme-template.md) and [instrumentation
+README guidelines](docs/instrumentation-readme-guidelines.md).
+Codex users can use the
+[instrumentation README skill](.codex/skills/instrumentation-readme/SKILL.md).
+
 ## Contributing via Pull Requests
 
 Contributions via Pull Requests (PRs) are much appreciated. Before sending us a

--- a/agents.md
+++ b/agents.md
@@ -72,6 +72,8 @@ For every PR touching runtime code, reviewers (including AI reviewers) must expl
 3. Is the fallback behavior backward compatible and non-breaking for host apps?
 4. Is there a test covering the degraded path?
 
+For instrumentation changes, reviewers must check that `integration/<module>/README.md` was updated from `docs/instrumentation-readme-template.md` and `docs/instrumentation-readme-guidelines.md` when behavior, API, setup, defaults, or telemetry changed.
+
 ---
 
 ## Project Overview

--- a/app/src/main/java/com/splunk/app/App.kt
+++ b/app/src/main/java/com/splunk/app/App.kt
@@ -19,6 +19,7 @@ package com.splunk.app
 import android.app.Application
 import android.os.Build
 import android.os.StrictMode
+import android.view.View
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import com.splunk.rum.integration.agent.api.AgentConfiguration
@@ -182,6 +183,8 @@ class App : Application() {
         val agent = SplunkRum.install(this, agentConfiguration, *moduleConfigurations)
 
         configureAndStartSessionReplay(agent.sessionReplay)
+
+        View.generateViewId()
     }
 
     private fun configureAndStartSessionReplay(sessionReplay: SessionReplay) {

--- a/docs/instrumentation-readme-guidelines.md
+++ b/docs/instrumentation-readme-guidelines.md
@@ -1,0 +1,25 @@
+# Instrumentation README Guidelines
+
+Every instrumentation module should have a generated module-local README at `integration/<module>/README.md` that follows `docs/instrumentation-readme-template.md`.
+
+## Scope
+
+Use these guidelines when adding or updating README files for instrumentation modules under `integration/`.
+
+## Content Rules
+
+- Document implemented behavior only. Inspect the module code, tests, and public API before writing.
+- Keep public API details accurate: configuration defaults, function signatures, extension properties, annotations, interfaces, and Java/Kotlin access patterns where relevant.
+- Clearly state default enabled or disabled behavior and any opt-in requirements.
+- Include runtime requirements, optional API requirements, and graceful fallback behavior.
+- Describe source priority, ignored elements, filters, suppression rules, and deduplication rules when applicable.
+- Document emitted telemetry using exact signal names, attribute names, types, required status, scope, span kind, and duration semantics.
+- Keep examples minimal and compilable in spirit. Do not add setup that is unrelated to the instrumentation.
+- Do not add dependencies or imply dependencies that are not already part of the SDK.
+- Do not change public API or default behavior to make the documentation easier to write.
+
+## Review Expectations
+
+When a PR changes instrumentation behavior, setup, public API, defaults, filtering, fallback behavior, or telemetry, reviewers should check that `integration/<module>/README.md` was added or updated.
+
+If a PR changes instrumentation code but does not update the README, the PR should explain why the change has no documentation impact.

--- a/docs/instrumentation-readme-template.md
+++ b/docs/instrumentation-readme-template.md
@@ -1,0 +1,75 @@
+# <Instrumentation Name> Instrumentation
+
+## Requirements
+
+- <Minimum Android API level and any opt-in lower API support.>
+- <Required AndroidX, Compose, Gradle plugin, or platform APIs.>
+- <Any module-specific setup requirements.>
+
+## Overview
+
+<Describe what this instrumentation tracks and what user-visible SDK behavior it enables.>
+
+Detection sources:
+
+- <Manual API calls, if supported.>
+- <Android framework callbacks or listeners, if used.>
+- <Bytecode instrumentation hooks, registered controllers, platform APIs, or other inputs.>
+
+Detection behavior:
+
+- <Source priority when more than one source can report the same behavior.>
+- <Filtering, ignored elements, suppression rules, or deduplication rules.>
+- <Default enabled or disabled state.>
+- <Fallback or degraded behavior when optional APIs, modules, or runtime conditions are unavailable.>
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    <InstrumentationModuleConfiguration>(
+        isEnabled = true
+    )
+)
+```
+
+```kotlin
+<Minimal manual or advanced usage example, if applicable.>
+```
+
+## API Documentation
+
+### `<PublicConfigurationOrEntryPoint>`
+
+<Short purpose statement.>
+
+```kotlin
+<Constructor, function, property, annotation, or interface signature.>
+```
+
+- `<parameterOrProperty>`: <Behavior, default, and effect.>
+
+### `<PublicFunctionOrType>`
+
+<Repeat for public APIs exposed by the instrumentation. Omit private/internal implementation details unless needed to explain behavior.>
+
+## Telemetry Data Model
+
+<State what telemetry is exported. If the instrumentation does not emit telemetry directly, say what it delegates to.>
+
+| Signal | Name | When emitted |
+|---|---|---|
+| <Span/Event/Metric/Log> | `<name>` | <Condition.> |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `<attribute.name>` | <string/boolean/long/double/OTel type> | <Yes/No> | <Description.> |
+| `<custom attribute>` | any OTel type | No | <When custom attributes are accepted.> |
+
+Resource / scope:
+
+- Instrumentation scope name: `<scope name>`
+- Span kind: `<INTERNAL/CLIENT/SERVER/etc.>`
+- Span duration: `<zero-length/measured duration/etc.>`

--- a/integration/anr/README.md
+++ b/integration/anr/README.md
@@ -1,0 +1,73 @@
+# ANR Detection Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Main thread `Looper` access.
+- App lifecycle services from the OpenTelemetry Android runtime.
+
+## Overview
+
+ANR Detection reports Application Not Responding conditions when the main thread is unresponsive for five consecutive one-second polls.
+
+Detection sources:
+
+- OpenTelemetry Android `AnrInstrumentation`.
+- Main thread polling through a `Handler` posted to the main `Looper`.
+- Application foreground/background lifecycle callbacks.
+
+Detection behavior:
+
+- The module is enabled by default.
+- When disabled, the ANR detector is not installed.
+- ANR spans are marked as errors and include the main thread stack trace from the upstream instrumentation.
+- Splunk adds `component`, `error`, and the latest known app state when available.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    AnrModuleConfiguration(
+        isEnabled = true
+    )
+)
+```
+
+## API Documentation
+
+### `AnrModuleConfiguration`
+
+Configures the ANR module.
+
+```kotlin
+AnrModuleConfiguration(
+    isEnabled: Boolean = true
+)
+```
+
+- `isEnabled`: Enables or disables ANR detection.
+- `name`: Module name reported as `anr`.
+- `attributes`: Module attributes containing `enabled`.
+
+## Telemetry Data Model
+
+The exported telemetry is an error span created by OpenTelemetry Android ANR instrumentation.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `ANR` | Main thread is unresponsive for at least five seconds. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `anr` |
+| `error` | string | Yes | `true` |
+| `android.app.state` | string | No | Last known app state: `created`, `foreground`, or `background`. |
+| `exception.stacktrace` | string | Yes | Main thread stack trace added by OpenTelemetry Android. |
+
+Resource / scope:
+
+- Instrumentation scope name: `io.opentelemetry.anr`
+- Span kind: `INTERNAL`
+- Span status: `ERROR`

--- a/integration/applicationlifecycle/README.md
+++ b/integration/applicationlifecycle/README.md
@@ -1,0 +1,68 @@
+# Application Lifecycle Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Android `Application` lifecycle callbacks.
+
+## Overview
+
+Application Lifecycle tracks app-level state transitions and emits telemetry when the application is created, foregrounded, or backgrounded.
+
+Detection sources:
+
+- `AppStateObserver` callbacks attached to the `Application`.
+- Cached lifecycle events observed before the logger provider is ready.
+
+Detection behavior:
+
+- The module is enabled by default.
+- Events observed before install completes are cached and emitted after install when the module is enabled.
+- When disabled, cached events are cleared and no lifecycle telemetry is emitted.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    ApplicationLifecycleModuleConfiguration(
+        isEnabled = true
+    )
+)
+```
+
+## API Documentation
+
+### `ApplicationLifecycleModuleConfiguration`
+
+Configures app-level lifecycle tracking.
+
+```kotlin
+ApplicationLifecycleModuleConfiguration(
+    isEnabled: Boolean = true
+)
+```
+
+- `isEnabled`: Enables or disables application lifecycle telemetry.
+- `name`: Module name reported as `applicationLifecycle`.
+- `attributes`: Module attributes containing `enabled`.
+
+## Telemetry Data Model
+
+The module emits log records that the SDK exports as zero-length internal spans.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `device.app.lifecycle` | App state changes to created, foreground, or background. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `app-lifecycle` |
+| `android.app.state` | string | Yes | App state: `created`, `foreground`, or `background`. |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/crash/README.md
+++ b/integration/crash/README.md
@@ -1,0 +1,78 @@
+# Crash Reporting Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- JVM uncaught exception handling.
+- App lifecycle services for app state attributes.
+
+## Overview
+
+Crash Reporting captures uncaught exceptions and reports crash telemetry before delegating to the previous uncaught exception handler.
+
+Detection sources:
+
+- OpenTelemetry Android `CrashReporterInstrumentation`.
+- The process default `Thread.UncaughtExceptionHandler`.
+- Application foreground/background lifecycle callbacks.
+
+Detection behavior:
+
+- The module is enabled by default.
+- When disabled, crash reporting is not installed.
+- The first uncaught exception is marked with `component = crash`; additional concurrent exceptions are marked with `component = error`.
+- The crash reporter force flushes the SDK logger provider for up to 10 seconds before delegating to the existing exception handler.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    CrashModuleConfiguration(
+        isEnabled = true
+    )
+)
+```
+
+## API Documentation
+
+### `CrashModuleConfiguration`
+
+Configures crash reporting.
+
+```kotlin
+CrashModuleConfiguration(
+    isEnabled: Boolean = true
+)
+```
+
+- `isEnabled`: Enables or disables crash reporting.
+- `name`: Module name reported as `crash`.
+- `attributes`: Module attributes containing `enabled`.
+
+## Telemetry Data Model
+
+The upstream crash reporter emits a `device.crash` log event. The SDK exports it as an internal span.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `device.crash` | An uncaught exception reaches the default exception handler. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `crash` for the first crash event, `error` for additional concurrent crash details. |
+| `error` | string | Yes | `true` |
+| `android.app.state` | string | No | Last known app state: `created`, `foreground`, or `background`. |
+| `exception.type` | string | Yes | Throwable class name. |
+| `exception.message` | string | No | Throwable message. |
+| `exception.stacktrace` | string | Yes | Throwable stack trace. |
+| `thread.id` | long | Yes | Crashing thread ID. |
+| `thread.name` | string | Yes | Crashing thread name. |
+
+Resource / scope:
+
+- Source log instrumentation scope name: `io.opentelemetry.crash`
+- Exported span instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/customtracking/README.md
+++ b/integration/customtracking/README.md
@@ -1,0 +1,126 @@
+# Custom Tracking Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- `SplunkRum.install(...)` must complete before custom telemetry can be emitted.
+
+## Overview
+
+Custom Tracking lets applications create custom RUM events, workflow spans, and exception spans.
+
+Detection sources:
+
+- Manual calls through `CustomTracking`.
+- Kotlin access through `SplunkRum.instance.customTracking`.
+- Java access through `CustomTracking.getInstance()`.
+
+Detection behavior:
+
+- There is no module configuration for custom tracking.
+- Calls made before the OpenTelemetry SDK is available are logged internally and ignored.
+- Custom events and exceptions are zero-length spans.
+- Workflows return a started span that the application is responsible for ending.
+
+## Quick Start
+
+```kotlin
+SplunkRum.instance.customTracking.trackCustomEvent("checkout.started")
+```
+
+```kotlin
+val workflow = SplunkRum.instance.customTracking.trackWorkflow("checkout")
+try {
+    // application work
+} finally {
+    workflow?.end()
+}
+```
+
+```kotlin
+SplunkRum.instance.customTracking.trackException(exception)
+```
+
+## API Documentation
+
+### `CustomTracking`
+
+Entry point for manual custom telemetry.
+
+```kotlin
+CustomTracking.instance
+```
+
+- Kotlin: `CustomTracking.instance` or `SplunkRum.instance.customTracking`.
+- Java: `CustomTracking.getInstance()`.
+
+### `SplunkRum.customTracking`
+
+Kotlin extension property for accessing custom tracking from a `SplunkRum` instance.
+
+```kotlin
+val SplunkRum.customTracking: CustomTracking
+```
+
+### `CustomTracking.trackCustomEvent(...)`
+
+Records a custom event as a zero-length span.
+
+```kotlin
+fun trackCustomEvent(
+    name: String,
+    attributes: Attributes = Attributes.empty()
+)
+```
+
+- `name`: Span name for the custom event.
+- `attributes`: Optional OpenTelemetry attributes attached to the span.
+
+### `CustomTracking.trackWorkflow(...)`
+
+Starts a span for a named workflow.
+
+```kotlin
+fun trackWorkflow(workflowName: String): Span?
+```
+
+- `workflowName`: Span name and `workflow.name` attribute value.
+- Returns a started span, or `null` if the SDK tracer is unavailable.
+
+### `CustomTracking.trackException(...)`
+
+Records an exception as a zero-length error span and attaches exception details using `Span.recordException(...)`.
+
+```kotlin
+fun trackException(
+    throwable: Throwable,
+    attributes: Attributes? = null
+)
+```
+
+- `throwable`: Exception to report.
+- `attributes`: Optional OpenTelemetry attributes attached before exception recording.
+
+## Telemetry Data Model
+
+The exported telemetry is custom spans created from manual API calls.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `<custom event name>` | `trackCustomEvent(...)` is called. |
+| Span | `<workflow name>` | `trackWorkflow(...)` is called. |
+| Span | `<throwable simple class name>` | `trackException(...)` is called. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `custom-event`, `custom-workflow`, or `error`. |
+| `workflow.name` | string | Yes for workflows | Workflow name passed to `trackWorkflow(...)`. |
+| `error` | string | Yes for exceptions | `true` |
+| `<custom attribute>` | any OTel type | No | Attributes supplied by the application. |
+| `<exception attribute>` | string | Yes for exceptions | Exception attributes added by `Span.recordException(...)`. |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length for custom events and exceptions; application-controlled for workflows

--- a/integration/httpurlconnection-auto/README.md
+++ b/integration/httpurlconnection-auto/README.md
@@ -1,0 +1,95 @@
+# HttpURLConnection Auto Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- The `com.splunk.rum-httpurlconnection-auto-plugin` Gradle plugin for bytecode hooks.
+- Java `HttpURLConnection` or `URLConnection` requests.
+
+## Overview
+
+HttpURLConnection Auto Instrumentation tracks HTTP client requests made through `HttpURLConnection` and enriches them with Splunk RUM HTTP attributes.
+
+Detection sources:
+
+- Build-time instrumentation from the `com.splunk.rum-httpurlconnection-auto-plugin` Gradle plugin.
+- Runtime OpenTelemetry `HttpUrlInstrumentation`.
+- `Content-Length` request and response headers.
+- `Server-Timing` response headers containing server trace context.
+
+Detection behavior:
+
+- The module is enabled by default, but automatic request tracking requires the Gradle plugin.
+- When disabled, runtime HTTP instrumentation is not configured.
+- Captured request and response headers are opt-in through configuration.
+- Unknown payload sizes, including negative HTTP length values, are omitted.
+- The last valid `Server-Timing` trace context value observed on the response is attached.
+
+## Quick Start
+
+Apply the Gradle plugin:
+
+```kotlin
+plugins {
+    id("com.splunk.rum-httpurlconnection-auto-plugin")
+}
+```
+
+Configure the module:
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    HttpURLModuleConfiguration(
+        isEnabled = true,
+        capturedRequestHeaders = listOf("x-request-id"),
+        capturedResponseHeaders = listOf("server-timing")
+    )
+)
+```
+
+## API Documentation
+
+### `HttpURLModuleConfiguration`
+
+Configures automatic `HttpURLConnection` request tracking.
+
+```kotlin
+HttpURLModuleConfiguration(
+    isEnabled: Boolean = true,
+    capturedRequestHeaders: List<String> = emptyList(),
+    capturedResponseHeaders: List<String> = emptyList()
+)
+```
+
+- `isEnabled`: Enables or disables runtime `HttpURLConnection` instrumentation.
+- `capturedRequestHeaders`: Request headers to capture as normalized `http.request.header.<name>` attributes.
+- `capturedResponseHeaders`: Response headers to capture as normalized `http.response.header.<name>` attributes.
+- `name`: Module name reported as `httpURLConnection`.
+- `attributes`: Module attributes containing `enabled`, `requestHeaders`, and `responseHeaders`.
+
+## Telemetry Data Model
+
+The exported telemetry is HTTP client spans created by OpenTelemetry `HttpUrlInstrumentation`.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `<HTTP method>` | A bytecode-instrumented `HttpURLConnection` request is executed. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `http` |
+| `http.request.body.size` | long | No | Request `Content-Length` when known and non-negative. |
+| `http.response.body.size` | long | No | Response `Content-Length` when known and non-negative. |
+| `link.traceId` | string | No | Server trace ID parsed from `Server-Timing`. |
+| `link.spanId` | string | No | Server span ID parsed from `Server-Timing`. |
+| `http.request.header.<name>` | string | No | Captured request header values. |
+| `http.response.header.<name>` | string | No | Captured response header values. |
+| `<HTTP semantic convention attribute>` | OTel type | Yes | Standard HTTP client attributes added by OpenTelemetry. |
+
+Resource / scope:
+
+- Instrumentation scope name: `io.opentelemetry.android.http-url-connection`
+- Span kind: `CLIENT`
+- Span duration: request duration

--- a/integration/interactions/README.md
+++ b/integration/interactions/README.md
@@ -1,0 +1,78 @@
+# User Interaction Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Session recording interaction and frame capture runtime.
+- Compose UI is optional; Compose element identification is installed only when Compose UI is present.
+
+## Overview
+
+User Interaction Instrumentation reports selected user actions and rage tap frustration events.
+
+Detection sources:
+
+- Session recording `Interactions` listeners.
+- Session recording `FrameCapturer` wireframes used to resolve target paths.
+- Optional Compose modifiers inserted through internal Compose element identification.
+
+Detection behavior:
+
+- The module is enabled by default.
+- When disabled, attached listeners stay registered but do not emit telemetry.
+- Pointer events, rage taps in the normal interaction stream, non-final continuous touch events, orientation changes, and swipe gestures are filtered from `action` telemetry.
+- Rage taps are emitted separately as `frustration` telemetry.
+- Target XPath values are built from the target element path and may include user-provided IDs when available.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    InteractionsModuleConfiguration(
+        isEnabled = true
+    )
+)
+```
+
+## API Documentation
+
+### `InteractionsModuleConfiguration`
+
+Configures user interaction telemetry.
+
+```kotlin
+InteractionsModuleConfiguration(
+    isEnabled: Boolean = true
+)
+```
+
+- `isEnabled`: Enables or disables emitted interaction and frustration telemetry.
+- `name`: Module name reported as `interactions`.
+- `attributes`: Module attributes containing `enabled`.
+
+## Telemetry Data Model
+
+The module emits log records that the SDK exports as zero-length internal spans.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `action` | A supported user interaction is observed. |
+| Span | `frustration` | A rage tap interaction is observed. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `ui` for `action`, `user-interaction` for `frustration`. |
+| `action.name` | string | Yes for `action` | One of `focus`, `soft_keyboard`, `phone_button`, `double_tap`, `long_press`, `pinch`, `rotation`, or `tap`. |
+| `target.type` | string | Yes for `action` | Target view ID when available, otherwise an empty string. |
+| `target_xpath` | string | No | XPath-like target path for targetable interactions. |
+| `target_element` | string | No | Target element type name for targetable interactions. |
+| `frustration_type` | string | Yes for `frustration` | `rage` |
+| `interaction_type` | string | Yes for `frustration` | `tap` |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/lifecycle/README.md
+++ b/integration/lifecycle/README.md
@@ -1,0 +1,129 @@
+# UI Lifecycle Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Android `Application.ActivityLifecycleCallbacks`.
+- AndroidX Fragment APIs for Fragment lifecycle tracking.
+
+## Overview
+
+UI Lifecycle Instrumentation tracks Activity and Fragment lifecycle transitions and emits `app.ui.lifecycle` telemetry.
+
+Detection sources:
+
+- Activity lifecycle callbacks registered on the `Application`.
+- AndroidX Fragment lifecycle callbacks registered for `FragmentActivity` instances.
+- API 29+ pre/post Activity callbacks when available.
+
+Detection behavior:
+
+- The module is enabled by default.
+- Only configured `allowedEvents` are emitted.
+- The default event set is `MAIN_LIFECYCLE_EVENTS`.
+- Events observed before install completes are cached and emitted after install.
+- If the logger provider is unavailable after install, the event is skipped.
+- Fragment callbacks are registered on Activity create for API 21-28 and Activity pre-create for API 29+.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    LifecycleModuleConfiguration(
+        isEnabled = true,
+        allowedEvents = LifecycleModuleConfiguration.MAIN_LIFECYCLE_EVENTS
+    )
+)
+```
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    LifecycleModuleConfiguration(
+        allowedEvents = LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS
+    )
+)
+```
+
+## API Documentation
+
+### `LifecycleModuleConfiguration`
+
+Configures Activity and Fragment lifecycle telemetry.
+
+```kotlin
+LifecycleModuleConfiguration(
+    isEnabled: Boolean = true,
+    allowedEvents: Set<LifecycleAction> = MAIN_LIFECYCLE_EVENTS
+)
+```
+
+- `isEnabled`: Enables or disables lifecycle telemetry.
+- `allowedEvents`: Lifecycle actions that should be emitted.
+- `name`: Module name reported as `lifecycle`.
+- `attributes`: Module attributes containing `enabled` and `allowedEvents`.
+
+### `LifecycleModuleConfiguration.MAIN_LIFECYCLE_EVENTS`
+
+Default event set.
+
+```kotlin
+val MAIN_LIFECYCLE_EVENTS: Set<LifecycleAction>
+```
+
+Contains `CREATED`, `STARTED`, `RESUMED`, `PAUSED`, `STOPPED`, `DESTROYED`, `ATTACHED`, `VIEW_CREATED`, `VIEW_DESTROYED`, and `DETACHED`.
+
+### `LifecycleModuleConfiguration.PRE_POST_LIFECYCLE_EVENTS`
+
+Pre/post Activity event set.
+
+```kotlin
+val PRE_POST_LIFECYCLE_EVENTS: Set<LifecycleAction>
+```
+
+Contains API 29+ Activity pre/post lifecycle actions and `PRE_ATTACHED`.
+
+### `LifecycleModuleConfiguration.ALL_LIFECYCLE_EVENTS`
+
+All lifecycle actions.
+
+```kotlin
+val ALL_LIFECYCLE_EVENTS: Set<LifecycleAction>
+```
+
+Equivalent to all `LifecycleAction` enum values.
+
+### `LifecycleAction`
+
+Lifecycle action values emitted as `lifecycle.action`.
+
+```kotlin
+enum class LifecycleAction(val attributeValue: String)
+```
+
+Values include `CREATED`, `STARTED`, `RESUMED`, `PAUSED`, `STOPPED`, `DESTROYED`, pre/post Activity variants, and Fragment-specific `ATTACHED`, `DETACHED`, `VIEW_CREATED`, and `VIEW_DESTROYED`.
+
+## Telemetry Data Model
+
+The module emits log records that the SDK exports as zero-length internal spans.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `app.ui.lifecycle` | A configured Activity or Fragment lifecycle action is observed. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `ui` |
+| `element.type` | string | Yes | `Activity` or `Fragment`. |
+| `element.name` | string | Yes | Simple class name. |
+| `element.id` | string | Yes | Fully qualified class name. |
+| `lifecycle.action` | string | Yes | Lifecycle action value such as `created`, `resumed`, or `view_destroyed`. |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/navigation/README.md
+++ b/integration/navigation/README.md
@@ -1,0 +1,214 @@
+# Navigation Detection Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- AndroidX Fragment APIs for automatic Fragment tracking.
+- AndroidX Navigation 2.4.0+ for Compose navigation tracking.
+
+## Overview
+
+Navigation Detection tracks visible screen changes and emits a RUM navigation event when the current screen changes.
+
+Detection sources:
+
+- Manual calls through `Navigation.track(...)`.
+- Activity resume and pause callbacks.
+- Fragment resume and pause callbacks.
+- Jetpack Compose `NavController` destination changes.
+
+Detection behavior:
+
+- The module is enabled by default, but automatic Activity and Fragment tracking is disabled by default.
+- Visible screen priority is Compose route, then Fragment, then Activity.
+- Screen names are resolved from `@NavigationElement`, then `@RumScreenName`, then the class simple name.
+- `DialogFragment`, AndroidX `NavHost` implementations, and elements annotated with `isIgnored = true` are ignored.
+- Compose destinations ignore `NavGraph` containers, dialog destinations, and internal navigation arguments.
+- Compose events are deduplicated by screen name and attributes, so the same route template with different arguments still emits.
+- Events observed before install completes are cached and emitted after install.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    NavigationModuleConfiguration(
+        isEnabled = true,
+        isAutomatedTrackingEnabled = true
+    )
+)
+```
+
+```kotlin
+SplunkRum.instance.navigation.track("checkout")
+```
+
+```kotlin
+val navController = rememberNavController()
+SplunkRum.instance.navigation.registerNavController(navController)
+```
+
+```kotlin
+@NavigationElement(name = "Checkout")
+class CheckoutActivity : AppCompatActivity()
+```
+
+## API Documentation
+
+### `NavigationModuleConfiguration`
+
+Configures navigation tracking.
+
+```kotlin
+NavigationModuleConfiguration(
+    isEnabled: Boolean = true,
+    isAutomatedTrackingEnabled: Boolean = false,
+    navigationEventProcessor: NavigationEventProcessor? = null
+)
+```
+
+- `isEnabled`: Enables or disables navigation tracking. When disabled, manual tracking and Compose tracking are detached.
+- `isAutomatedTrackingEnabled`: Enables automatic Activity and Fragment screen detection.
+- `navigationEventProcessor`: Optional processor for transforming or suppressing Compose route events.
+- `name`: Module name reported as `navigation`.
+- `attributes`: Module attributes containing `enabled` and `isAutomatedTrackingEnabled`.
+
+### `Navigation`
+
+Entry point for manual navigation tracking and Compose `NavController` registration.
+
+```kotlin
+Navigation.instance
+```
+
+- Kotlin: `Navigation.instance` or `SplunkRum.instance.navigation`.
+- Java: `Navigation.getInstance()`.
+
+### `SplunkRum.navigation`
+
+Kotlin extension property for accessing navigation tracking from a `SplunkRum` instance.
+
+```kotlin
+val SplunkRum.navigation: Navigation
+```
+
+### `Navigation.track(...)`
+
+Records a manual navigation event.
+
+```kotlin
+fun track(
+    screenName: String,
+    attributes: Attributes = Attributes.empty()
+)
+```
+
+- `screenName`: Screen name to report.
+- `attributes`: Optional OpenTelemetry attributes attached to the emitted event.
+
+### `Navigation.registerNavController(...)`
+
+Registers one Jetpack Compose `NavController` for automatic route tracking.
+
+```kotlin
+fun registerNavController(navController: NavController)
+```
+
+- `navController`: Controller whose destination changes should be tracked.
+
+Only one controller is tracked at a time. Registering a new controller replaces the previous one. Passing the same controller again is a no-op.
+
+### `Navigation.unregisterNavController(...)`
+
+Unregisters a previously registered Jetpack Compose `NavController`.
+
+```kotlin
+fun unregisterNavController(navController: NavController)
+```
+
+- `navController`: Controller to unregister.
+
+The destination listener is removed only when the supplied controller is the currently registered controller.
+
+### `NavigationEventProcessor`
+
+Processes Compose route navigation events before they are emitted.
+
+```kotlin
+fun interface NavigationEventProcessor {
+    fun process(event: NavigationEvent): NavigationEvent?
+}
+```
+
+Return the event to emit it, modify it before emission, or return `null` to suppress it.
+
+### `NavigationEvent`
+
+Mutable event object passed to `NavigationEventProcessor`.
+
+```kotlin
+class NavigationEvent(
+    var name: String,
+    val attributes: MutableMap<String, String>,
+    val sourceType: SourceType
+)
+```
+
+- `name`: Screen name to emit. Processors can modify this value.
+- `attributes`: String attributes to emit. Processors can add, remove, or change entries.
+- `sourceType`: Event origin.
+
+### `NavigationEvent.SourceType`
+
+Identifies the source of a navigation event.
+
+```kotlin
+enum class SourceType {
+    ACTIVITY,
+    FRAGMENT,
+    COMPOSE_ROUTE
+}
+```
+
+### `@NavigationElement`
+
+Overrides or ignores Activity and Fragment screen detection.
+
+```kotlin
+@NavigationElement(name = "Checkout", isIgnored = false)
+```
+
+`@NavigationElement` takes precedence over `@RumScreenName`.
+
+### `@RumScreenName`
+
+Legacy annotation for overriding or ignoring Activity and Fragment screen detection.
+
+```kotlin
+@RumScreenName(name = "Checkout", isIgnored = false)
+```
+
+## Telemetry Data Model
+
+The module emits log records that the SDK exports as zero-length internal spans.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `app.ui.navigation` | Visible screen changes. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `ui` |
+| `navigation.name` | string | Yes | Destination screen name. |
+| `screen.name` | string | Yes | Current screen name. |
+| `last.screen.name` | string | No | Previous screen name when known. |
+| `nav.graph` | string | No | Compose parent graph route. |
+| `<route argument>` | string | No | Compose route argument. |
+| `<custom attribute>` | any OTel type | No | Manual tracking attribute. |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/networkmonitor/README.md
+++ b/integration/networkmonitor/README.md
@@ -1,0 +1,76 @@
+# Network Monitor Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Android network state services from the OpenTelemetry Android runtime.
+
+## Overview
+
+Network Monitor tracks network connectivity changes and keeps current network attributes available for spans emitted by the SDK.
+
+Detection sources:
+
+- OpenTelemetry Android `NetworkChangeInstrumentation`.
+- OpenTelemetry Android `CurrentNetworkProvider` network change callbacks.
+- Application foreground/background lifecycle callbacks.
+
+Detection behavior:
+
+- The module is enabled by default.
+- Network change events are emitted only while the app is foregrounded.
+- Current network attributes are stored as global span attributes and updated on network changes.
+- `network.connection.type` is initialized to `unavailable` so spans have a default value before the first network callback.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    NetworkMonitorModuleConfiguration(
+        isEnabled = true
+    )
+)
+```
+
+## API Documentation
+
+### `NetworkMonitorModuleConfiguration`
+
+Configures network monitoring.
+
+```kotlin
+NetworkMonitorModuleConfiguration(
+    isEnabled: Boolean = true
+)
+```
+
+- `isEnabled`: Enables or disables network change telemetry and global network attributes.
+- `name`: Module name reported as `networkMonitor`.
+- `attributes`: Module attributes containing `enabled`.
+
+## Telemetry Data Model
+
+The upstream instrumentation emits network change log records that the SDK exports as zero-length internal spans. The module also adds current network attributes to other spans through the global attribute processor.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `network.change` | Network state changes while the app is foregrounded. |
+| Span attributes | N/A | Added to SDK spans after the current network state is known. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `network.status` | string | Yes for `network.change` | `available` or `lost`. |
+| `network.connection.type` | string | Yes | Current network state, initialized as `unavailable`. |
+| `network.connection.subtype` | string | No | Current network subtype. |
+| `network.carrier.name` | string | No | Mobile carrier name. |
+| `network.carrier.mcc` | string | No | Mobile country code. |
+| `network.carrier.mnc` | string | No | Mobile network code. |
+| `network.carrier.icc` | string | No | Carrier ISO country code. |
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum` for exported network change spans
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/okhttp3-auto/README.md
+++ b/integration/okhttp3-auto/README.md
@@ -1,0 +1,95 @@
+# OkHttp3 Auto Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- The `com.splunk.rum-okhttp3-auto-plugin` Gradle plugin for bytecode hooks.
+- OkHttp 3.x compatible clients.
+
+## Overview
+
+OkHttp3 Auto Instrumentation tracks OkHttp client requests without manually wrapping each client.
+
+Detection sources:
+
+- Build-time instrumentation from the `com.splunk.rum-okhttp3-auto-plugin` Gradle plugin.
+- Runtime OpenTelemetry OkHttp instrumentation.
+- `Content-Length` request and response headers.
+- `Server-Timing` response headers containing server trace context.
+
+Detection behavior:
+
+- The module is enabled by default, but automatic request tracking requires the Gradle plugin.
+- When disabled, runtime OkHttp auto-instrumentation is not configured.
+- Captured request and response headers are opt-in through configuration.
+- Unknown payload sizes, including negative HTTP length values, are omitted.
+- Server trace context is parsed from valid `Server-Timing` response headers.
+
+## Quick Start
+
+Apply the Gradle plugin:
+
+```kotlin
+plugins {
+    id("com.splunk.rum-okhttp3-auto-plugin")
+}
+```
+
+Configure the module:
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    OkHttp3AutoModuleConfiguration(
+        isEnabled = true,
+        capturedRequestHeaders = listOf("x-request-id"),
+        capturedResponseHeaders = listOf("server-timing")
+    )
+)
+```
+
+## API Documentation
+
+### `OkHttp3AutoModuleConfiguration`
+
+Configures automatic OkHttp request tracking.
+
+```kotlin
+OkHttp3AutoModuleConfiguration(
+    isEnabled: Boolean = true,
+    capturedRequestHeaders: List<String> = emptyList(),
+    capturedResponseHeaders: List<String> = emptyList()
+)
+```
+
+- `isEnabled`: Enables or disables runtime OkHttp auto-instrumentation.
+- `capturedRequestHeaders`: Request headers to capture as normalized `http.request.header.<name>` attributes.
+- `capturedResponseHeaders`: Response headers to capture as normalized `http.response.header.<name>` attributes.
+- `name`: Module name reported as `okHttp3-auto`.
+- `attributes`: Module attributes containing `enabled`, `requestHeaders`, and `responseHeaders`.
+
+## Telemetry Data Model
+
+The exported telemetry is HTTP client spans created by OpenTelemetry OkHttp instrumentation.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `<HTTP method>` | A bytecode-instrumented OkHttp request is executed. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `http` |
+| `http.request.body.size` | long | No | Request `Content-Length` when known and non-negative. |
+| `http.response.body.size` | long | No | Response `Content-Length` when known and non-negative. |
+| `link.traceId` | string | No | Server trace ID parsed from `Server-Timing`. |
+| `link.spanId` | string | No | Server span ID parsed from `Server-Timing`. |
+| `http.request.header.<name>` | string | No | Captured request header values. |
+| `http.response.header.<name>` | string | No | Captured response header values. |
+| `<HTTP semantic convention attribute>` | OTel type | Yes | Standard HTTP client attributes added by OpenTelemetry. |
+
+Resource / scope:
+
+- Instrumentation scope name: `io.opentelemetry.okhttp-3.0`
+- Span kind: `CLIENT`
+- Span duration: request duration

--- a/integration/okhttp3-common/README.md
+++ b/integration/okhttp3-common/README.md
@@ -1,0 +1,81 @@
+# OkHttp3 Common Instrumentation Support
+
+## Requirements
+
+- OkHttp 3.x compatible request and response types.
+- OpenTelemetry instrumentation API.
+- Used by `integration/okhttp3-auto` and `integration/okhttp3-manual`.
+
+## Overview
+
+OkHttp3 Common provides the shared attribute extractor used by automatic and manual OkHttp instrumentation.
+
+Detection sources:
+
+- OkHttp `Interceptor.Chain` request data.
+- OkHttp `Response` header data.
+- `Content-Length` request and response headers.
+- `Server-Timing` response headers containing server trace context.
+
+Detection behavior:
+
+- This module is not installed independently through `SplunkRum.install(...)`.
+- The auto and manual OkHttp modules attach `OkHttp3AdditionalAttributesExtractor` to their OpenTelemetry instrumentation.
+- Unknown payload sizes, including negative HTTP length values, are omitted.
+- Server trace context is parsed from valid `Server-Timing` response headers.
+
+## Quick Start
+
+This module is used by the OkHttp instrumentation modules:
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    OkHttp3AutoModuleConfiguration()
+)
+```
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    OkHttp3ManualModuleConfiguration()
+)
+```
+
+## API Documentation
+
+### `OkHttp3AdditionalAttributesExtractor`
+
+Adds Splunk RUM HTTP attributes to OpenTelemetry OkHttp spans.
+
+```kotlin
+class OkHttp3AdditionalAttributesExtractor :
+    AttributesExtractor<Interceptor.Chain, Response>
+```
+
+- `onStart(...)`: Adds `component = http`.
+- `onEnd(...)`: Adds request size, response size, and server trace context attributes when available.
+
+## Telemetry Data Model
+
+This support module does not emit telemetry by itself. It enriches spans emitted by OkHttp auto and manual instrumentation.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| N/A | N/A | No standalone telemetry. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes when extractor is used | `http` |
+| `http.request.body.size` | long | No | Request `Content-Length` when known and non-negative. |
+| `http.response.body.size` | long | No | Response `Content-Length` when known and non-negative. |
+| `link.traceId` | string | No | Server trace ID parsed from `Server-Timing`. |
+| `link.spanId` | string | No | Server span ID parsed from `Server-Timing`. |
+
+Resource / scope:
+
+- Instrumentation scope name: determined by the consuming OkHttp instrumentation
+- Span kind: determined by the consuming OkHttp instrumentation
+- Span duration: determined by the consuming OkHttp instrumentation

--- a/integration/okhttp3-manual/README.md
+++ b/integration/okhttp3-manual/README.md
@@ -1,0 +1,118 @@
+# OkHttp3 Manual Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- OkHttp 3.x compatible clients.
+- Application code must use the returned `Call.Factory`.
+
+## Overview
+
+OkHttp3 Manual Instrumentation tracks OkHttp requests by wrapping an existing `OkHttpClient` as an instrumented `Call.Factory`.
+
+Detection sources:
+
+- Manual calls to `OkHttpManualInstrumentation.buildOkHttpCallFactory(...)`.
+- OpenTelemetry `OkHttpTelemetry` interceptors added to the wrapped client.
+- `Content-Length` request and response headers.
+- `Server-Timing` response headers containing server trace context.
+
+Detection behavior:
+
+- There is no `isEnabled` flag on the manual module configuration.
+- The module creates `OkHttpTelemetry` during install.
+- If manual instrumentation is used before initialization, the original `OkHttpClient` is returned and a warning is logged.
+- Captured request and response headers are opt-in through configuration.
+- Unknown payload sizes, including negative HTTP length values, are omitted.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    OkHttp3ManualModuleConfiguration(
+        capturedRequestHeaders = listOf("x-request-id"),
+        capturedResponseHeaders = listOf("server-timing")
+    )
+)
+```
+
+```kotlin
+val client = OkHttpClient.Builder().build()
+val callFactory = SplunkRum.instance.okHttpManualInstrumentation
+    .buildOkHttpCallFactory(client)
+```
+
+## API Documentation
+
+### `OkHttp3ManualModuleConfiguration`
+
+Configures manual OkHttp request tracking.
+
+```kotlin
+OkHttp3ManualModuleConfiguration(
+    capturedRequestHeaders: List<String> = emptyList(),
+    capturedResponseHeaders: List<String> = emptyList()
+)
+```
+
+- `capturedRequestHeaders`: Request headers to capture as normalized `http.request.header.<name>` attributes.
+- `capturedResponseHeaders`: Response headers to capture as normalized `http.response.header.<name>` attributes.
+- `name`: Module name reported as `okHttp3-manual`.
+- `attributes`: Module attributes containing `requestHeaders` and `responseHeaders`.
+
+### `OkHttpManualInstrumentation`
+
+Entry point for wrapping OkHttp clients.
+
+```kotlin
+OkHttpManualInstrumentation.instance
+```
+
+- Kotlin: `OkHttpManualInstrumentation.instance` or `SplunkRum.instance.okHttpManualInstrumentation`.
+- Java: `OkHttpManualInstrumentation.getInstance()`.
+
+### `SplunkRum.okHttpManualInstrumentation`
+
+Kotlin extension property for accessing manual OkHttp instrumentation from a `SplunkRum` instance.
+
+```kotlin
+val SplunkRum.okHttpManualInstrumentation: OkHttpManualInstrumentation
+```
+
+### `OkHttpManualInstrumentation.buildOkHttpCallFactory(...)`
+
+Wraps an `OkHttpClient` with OpenTelemetry interceptors.
+
+```kotlin
+fun buildOkHttpCallFactory(client: OkHttpClient): Call.Factory
+```
+
+- `client`: Base OkHttp client.
+- Returns an instrumented `Call.Factory`, or the original client when manual instrumentation is not initialized.
+
+## Telemetry Data Model
+
+The exported telemetry is HTTP client spans created by OpenTelemetry OkHttp instrumentation.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `<HTTP method>` | A request is executed through the instrumented `Call.Factory`. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `http` |
+| `http.request.body.size` | long | No | Request `Content-Length` when known and non-negative. |
+| `http.response.body.size` | long | No | Response `Content-Length` when known and non-negative. |
+| `link.traceId` | string | No | Server trace ID parsed from `Server-Timing`. |
+| `link.spanId` | string | No | Server span ID parsed from `Server-Timing`. |
+| `http.request.header.<name>` | string | No | Captured request header values. |
+| `http.response.header.<name>` | string | No | Captured response header values. |
+| `<HTTP semantic convention attribute>` | OTel type | Yes | Standard HTTP client attributes added by OpenTelemetry. |
+
+Resource / scope:
+
+- Instrumentation scope name: `io.opentelemetry.okhttp-3.0`
+- Span kind: `CLIENT`
+- Span duration: request duration

--- a/integration/sessionreplay/README.md
+++ b/integration/sessionreplay/README.md
@@ -1,0 +1,280 @@
+# Session Replay Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Session recording runtime.
+- Compose UI is optional; Compose element identification is installed only when Compose UI is present.
+- A session replay endpoint must be available before buffered replay data can upload.
+
+## Overview
+
+Session Replay records user sessions and exports replay data chunks that can be uploaded to the Splunk session replay endpoint.
+
+Detection sources:
+
+- Manual calls through `SessionReplay.start()` and `SessionReplay.stop()`.
+- Session changes from the agent session manager.
+- Session recording `DataListener` callbacks.
+- Optional Compose `Modifier.sessionReplay(...)` metadata.
+
+Detection behavior:
+
+- The module is enabled by default.
+- `samplingRate` defaults to `0.2f`; sampled-out sessions cannot record.
+- Recording must be requested with `SessionReplay.start()`.
+- If a new sampled-in session starts while recording was requested, recording starts or a new data chunk is created.
+- If a session is sampled out while recording was requested, recording stops and status reports `DISABLED_BY_SAMPLING`.
+- `WebView` is not sensitive by default for Splunk agents.
+- Session replay data is specially buffered and uploaded by the log exporter instead of being converted into normal span telemetry.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    SessionReplayModuleConfiguration(
+        isEnabled = true,
+        samplingRate = 0.2f
+    )
+)
+```
+
+```kotlin
+SplunkRum.instance.sessionReplay.start()
+```
+
+```kotlin
+SplunkRum.instance.sessionReplay.stop()
+```
+
+```kotlin
+Modifier.sessionReplay(
+    id = "checkout-button",
+    isSensitive = false
+)
+```
+
+## API Documentation
+
+### `SessionReplayModuleConfiguration`
+
+Configures session replay.
+
+```kotlin
+SessionReplayModuleConfiguration(
+    isEnabled: Boolean = true,
+    samplingRate: Float = 0.2f
+)
+```
+
+- `isEnabled`: Enables session replay so recording can be started.
+- `samplingRate`: Session sampling rate. `0f` records no sessions, `1f` records all sessions, and `0.2f` records about one fifth of sessions.
+- `name`: Module name reported as `sessionReplay`.
+- `attributes`: Module attributes containing `enabled` and `samplingRate`.
+
+### `SessionReplay`
+
+Entry point for controlling recording and accessing replay state.
+
+```kotlin
+SessionReplay.instance
+```
+
+- Kotlin: `SessionReplay.instance` or `SplunkRum.instance.sessionReplay`.
+- Java: `SessionReplay.getInstance()`.
+- Must be accessed after `SplunkRum.install(...)` creates the session replay instance.
+
+### `SplunkRum.sessionReplay`
+
+Kotlin extension property for accessing session replay from a `SplunkRum` instance.
+
+```kotlin
+val SplunkRum.sessionReplay: SessionReplay
+```
+
+### `SessionReplay.start()`
+
+Starts recording user activity when the module is enabled, the Android API level is supported, and the current session is sampled in.
+
+```kotlin
+fun start()
+```
+
+If recording cannot start because the module is disabled, the API level is below the agent runtime floor, or the session is sampled out, the SDK logs internally and updates state where applicable.
+
+### `SessionReplay.stop()`
+
+Stops recording user activity.
+
+```kotlin
+fun stop()
+```
+
+### `SessionReplay.preferences`
+
+Preferred session replay configuration.
+
+```kotlin
+val preferences: Preferences
+```
+
+### `Preferences.renderingMode`
+
+Preferred screen data rendering mode.
+
+```kotlin
+var renderingMode: RenderingMode?
+```
+
+### `SessionReplay.state`
+
+Current session replay state.
+
+```kotlin
+val state: State
+```
+
+### `State`
+
+Read-only current state.
+
+```kotlin
+class State
+```
+
+- `status`: Current `Status`.
+- `samplingRate`: Active module sampling rate.
+- `renderingMode`: Current `RenderingMode`.
+
+### `Status`
+
+Recording status.
+
+```kotlin
+sealed interface Status
+```
+
+- `Status.Recording`: The SDK is recording.
+- `Status.NotRecording`: The SDK is not recording.
+- `Status.NotRecording.Cause`: `NOT_STARTED`, `STOPPED`, `BELOW_MIN_SDK_VERSION`, `STORAGE_LIMIT_REACHED`, `INTERNAL_ERROR`, or `DISABLED_BY_SAMPLING`.
+- `isRecording`: `true` when the status is `Recording`.
+
+### `RenderingMode`
+
+Screen data rendering mode.
+
+```kotlin
+enum class RenderingMode {
+    NATIVE,
+    WIREFRAME_ONLY
+}
+```
+
+- `NATIVE`: Records screen images with sensitive areas hidden.
+- `WIREFRAME_ONLY`: Records wireframe screen data.
+
+### `SessionReplay.sensitivity`
+
+Sensitivity configuration for native rendering mode.
+
+```kotlin
+val sensitivity: Sensitivity
+```
+
+### `Sensitivity`
+
+Configures whether views are covered in replay data.
+
+```kotlin
+fun <T : View> setViewInstanceSensitivity(view: T, isSensitive: Boolean?)
+fun <T : View> setViewClassSensitivity(clazz: Class<T>, isSensitive: Boolean?)
+fun <T : View> getViewInstanceSensitivity(view: T): Boolean?
+fun <T : View> getViewClassSensitivity(clazz: Class<T>): Boolean?
+```
+
+- Instance sensitivity overrides class sensitivity.
+- `EditText` is sensitive by default.
+- `null` clears the override for that instance or class.
+
+### Sensitivity Extensions
+
+Kotlin-only helpers for sensitivity configuration.
+
+```kotlin
+var View.isSensitive: Boolean?
+var <T : View> KClass<T>.isSensitive: Boolean?
+var <T : View> Class<T>.isSensitive: Boolean?
+```
+
+### `Modifier.sessionReplay(...)`
+
+Adds session replay metadata to a Compose modifier.
+
+```kotlin
+fun Modifier.sessionReplay(
+    id: String? = null,
+    isSensitive: Boolean? = null,
+    positionInList: Int? = null
+): Modifier
+```
+
+- `id`: Optional stable element ID.
+- `isSensitive`: Optional sensitivity override.
+- `positionInList`: Optional list position for target path metadata.
+
+### `SessionReplay.recordingMask`
+
+Manual rectangular mask configuration for native rendering mode.
+
+```kotlin
+var recordingMask: RecordingMask?
+```
+
+### `RecordingMask`
+
+Defines screen-space rectangles to cover or uncover.
+
+```kotlin
+data class RecordingMask(
+    val elements: List<RecordingMask.Element>
+)
+```
+
+```kotlin
+RecordingMask.Element(
+    rect: Rect,
+    type: RecordingMask.Element.Type = COVERING
+)
+```
+
+- `COVERING`: Covers the rectangle.
+- `ERASING`: Uncovers the rectangle.
+
+## Telemetry Data Model
+
+Session replay exports replay data as log payloads through special session replay upload handling. It also emits one recording marker event per recorded session, which the SDK exports as a zero-length internal span.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Log payload | `session_replay_data` | A session replay data chunk is produced. |
+| Span | `splunk.sessionReplay.isRecording` | The first replay data chunk for a session is accepted. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `rr-web.total-chunks` | double | Yes for replay data | Total chunks in the emitted segment. Current value is `1.0`. |
+| `rr-web.chunk` | double | Yes for replay data | Chunk index in the emitted segment. Current value is `1.0`. |
+| `rr-web.event` | long | Yes for replay data | Event index for the replay data. |
+| `rr-web.offset` | double | Yes for replay data | Offset for the replay data. |
+| `segmentMetadata` | string | Yes for replay data | Serialized replay segment metadata. |
+| `component` | string | Yes for recording marker | `session.replay` |
+| `splunk.sessionReplay` | string | Yes for recording marker | `splunk` |
+| `session.id` | string | Yes for recording marker | Session ID associated with the replay recording. |
+
+Resource / scope:
+
+- Replay data instrumentation scope name: `SessionReplayDataScopeName`
+- Recording marker instrumentation scope name: `SplunkRum`
+- Recording marker span kind: `INTERNAL`
+- Recording marker span duration: zero-length

--- a/integration/slowrendering/README.md
+++ b/integration/slowrendering/README.md
@@ -1,0 +1,78 @@
+# Slow and Frozen Rendering Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Slow and frozen rendering detection itself requires Android API level 24+ because it uses `Window.OnFrameMetricsAvailableListener`.
+- Core library desugaring for `java.time.Duration` on Android API levels below 26.
+
+## Overview
+
+Slow and Frozen Rendering Instrumentation reports UI frames that exceed slow or frozen rendering thresholds.
+
+Detection sources:
+
+- OpenTelemetry Android `SlowRenderingInstrumentation`.
+- Activity resume and pause callbacks.
+- Android frame metrics from each resumed Activity window.
+
+Detection behavior:
+
+- The module is enabled by default.
+- Slow frames are draw durations greater than 16 ms.
+- Frozen frames are draw durations greater than 700 ms.
+- First draw frames are ignored.
+- Metrics are polled every `interval`, defaulting to one second.
+- Below Android API level 24, the upstream detector logs that the platform is unsupported and does not install frame metrics collection.
+- If `interval` is not positive, the upstream detector logs an error and keeps its current interval.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    SlowRenderingModuleConfiguration(
+        isEnabled = true,
+        interval = Duration.ofSeconds(1)
+    )
+)
+```
+
+## API Documentation
+
+### `SlowRenderingModuleConfiguration`
+
+Configures slow and frozen rendering detection.
+
+```kotlin
+SlowRenderingModuleConfiguration(
+    isEnabled: Boolean = true,
+    interval: Duration = Duration.ofSeconds(1)
+)
+```
+
+- `isEnabled`: Enables or disables slow and frozen rendering detection.
+- `interval`: Polling interval for frame metrics.
+- `name`: Module name reported as `slowrendering`.
+- `attributes`: Module attributes containing `enabled` and `interval`.
+
+## Telemetry Data Model
+
+The exported telemetry is zero-length spans created by OpenTelemetry Android slow rendering instrumentation.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `slowRenders` | One or more frames exceed 16 ms and do not exceed 700 ms during a polling window. |
+| Span | `frozenRenders` | One or more frames exceed 700 ms during a polling window. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `count` | long | Yes | Number of slow or frozen frames in the polling window. |
+| `activity.name` | string | Yes | Short flattened Activity component name. |
+
+Resource / scope:
+
+- Instrumentation scope name: `io.opentelemetry.slow-rendering`
+- Span kind: `INTERNAL`
+- Span duration: zero-length

--- a/integration/startup/README.md
+++ b/integration/startup/README.md
@@ -1,0 +1,79 @@
+# App Startup Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- The startup runtime `ContentProvider` must initialize before the first Activity draw.
+- Android Activity lifecycle callbacks and root view draw/pre-draw callbacks.
+
+## Overview
+
+App Startup Instrumentation measures cold, warm, and hot application starts and emits startup spans.
+
+Detection sources:
+
+- Startup runtime `ContentProvider`.
+- `ApplicationStartupTimekeeper` Activity lifecycle callbacks.
+- First root view draw or pre-draw callback, depending on Android API level.
+- Module initialization timing recorded by the agent.
+
+Detection behavior:
+
+- The module is always reported as enabled through `StartupModuleConfiguration`.
+- Only one startup event is reported per process initialization.
+- Cold start duration is measured from process start to first draw.
+- Warm start duration is measured from first Activity create to first draw.
+- Hot start duration is measured from first Activity start to first draw.
+- Startup events observed before the module listener is attached are cached and delivered later.
+- The app start span sets `screen.name` to `unknown` so startup telemetry is not associated with a visible screen.
+
+## Quick Start
+
+```kotlin
+SplunkRum.install(
+    this,
+    agentConfiguration,
+    StartupModuleConfiguration()
+)
+```
+
+The startup module is included by default when the agent installs its default module set.
+
+## API Documentation
+
+### `StartupModuleConfiguration`
+
+Configures startup instrumentation.
+
+```kotlin
+StartupModuleConfiguration()
+```
+
+- `name`: Module name reported as `startup`.
+- `attributes`: Module attributes containing `enabled = true`.
+
+## Telemetry Data Model
+
+The exported telemetry is startup spans created by the Splunk RUM tracer.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| Span | `AppStart` | The first cold, warm, or hot startup event is measured. |
+| Span | `SplunkRum.initialize` | Agent module initialization timing is reported as a child of `AppStart`. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| `component` | string | Yes | `appstart` |
+| `screen.name` | string | Yes | `unknown` |
+| `start.type` | string | Yes on `AppStart` | `cold`, `warm`, or `hot`. |
+| `config_settings` | string | Yes on `SplunkRum.initialize` | Serialized module configuration settings. |
+
+Span events:
+
+- `<module>_initialized`: Initialization duration event added to `SplunkRum.initialize` for each initialized module.
+
+Resource / scope:
+
+- Instrumentation scope name: `SplunkRum`
+- Span kind: `INTERNAL`
+- Span duration: measured startup or initialization duration

--- a/integration/webview/README.md
+++ b/integration/webview/README.md
@@ -1,0 +1,84 @@
+# WebView Instrumentation
+
+## Requirements
+
+- Android API level 24+ by default, or API level 21+ with `AgentConfiguration.forceEnableOnLowerApi = true`.
+- Android `WebView`.
+- Browser RUM JavaScript running inside the WebView must know how to read the injected `SplunkRumNative` object.
+
+## Overview
+
+WebView Instrumentation links native Android RUM sessions with Browser RUM running inside a WebView.
+
+Detection sources:
+
+- Manual calls to `WebViewNativeBridge.integrateWithBrowserRum(...)`.
+- JavaScript interface methods exposed through `SplunkRumNative`.
+- Current native session state and metadata from `SplunkRum.instance.session`.
+
+Detection behavior:
+
+- There is no module configuration for WebView integration.
+- The bridge injects a JavaScript object named `SplunkRumNative`.
+- The injected object exposes the current native session ID and serialized native session metadata.
+- This module does not emit telemetry directly; it exposes native session context to Browser RUM.
+
+## Quick Start
+
+```kotlin
+SplunkRum.instance.webViewNativeBridge.integrateWithBrowserRum(webView)
+```
+
+## API Documentation
+
+### `WebViewNativeBridge`
+
+Entry point for integrating native RUM with Browser RUM in a WebView.
+
+```kotlin
+WebViewNativeBridge.instance
+```
+
+- Kotlin: `WebViewNativeBridge.instance` or `SplunkRum.instance.webViewNativeBridge`.
+- Java: `WebViewNativeBridge.getInstance()`.
+
+### `SplunkRum.webViewNativeBridge`
+
+Kotlin extension property for accessing the WebView bridge from a `SplunkRum` instance.
+
+```kotlin
+val SplunkRum.webViewNativeBridge: WebViewNativeBridge
+```
+
+### `WebViewNativeBridge.integrateWithBrowserRum(...)`
+
+Injects the native RUM JavaScript interface into a WebView.
+
+```kotlin
+fun integrateWithBrowserRum(webView: WebView)
+```
+
+- `webView`: WebView that should expose native RUM session context to Browser RUM.
+
+The injected JavaScript object is named `SplunkRumNative` and exposes:
+
+- `nativeSessionId`: Current native session ID.
+- `nativeSessionMetadata`: Current native session metadata serialized as JSON.
+
+## Telemetry Data Model
+
+This module does not emit telemetry directly. Browser RUM can use the injected native session context to correlate WebView activity with the native Android RUM session.
+
+| Signal | Name | When emitted |
+|---|---|---|
+| N/A | N/A | No standalone telemetry. |
+
+| Attribute | Type | Required | Description |
+|---|---|---:|---|
+| N/A | N/A | N/A | No standalone telemetry attributes. |
+
+Resource / scope:
+
+- Instrumentation scope name: N/A
+- Span kind: N/A
+- Span duration: N/A


### PR DESCRIPTION
Adds a shared instrumentation `README` template, guidelines, and Codex skill for generating consistent module documentation. Generates `README` files for all `integration/<module>` instrumentations and links the process from `CONTRIBUTING.md` and `agents.md` so future instrumentation changes include matching documentation updates.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI