### PR TITLE
NO-TICKET: Change gradle dependency to compileOnly in mapping file plugin

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,6 +13,7 @@ object Dependencies {
     const val jacocoVersion = "0.8.14"
 
     const val gradle = "com.android.tools.build:gradle:$gradleVersion"
+    const val gradleApi = "com.android.tools.build:gradle-api:$gradleVersion"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     const val ktlint = "com.pinterest.ktlint:ktlint-cli:$ktlintVersion"
     const val jacoco = "org.jacoco:org.jacoco.core:$jacocoVersion"

--- a/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
@@ -27,7 +27,7 @@ gradlePlugin {
 
 dependencies {
     implementation(gradleApi())
-    compileOnly(Dependencies.gradle)
+    compileOnly(Dependencies.gradleApi)
 }
 
 configureGradlePluginSigning()

--- a/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
+++ b/instrumentation/buildtime/mapping-file/plugin/build.gradle.kts
@@ -27,7 +27,7 @@ gradlePlugin {
 
 dependencies {
     implementation(gradleApi())
-    implementation(Dependencies.gradle)
+    compileOnly(Dependencies.gradle)
 }
 
 configureGradlePluginSigning()

--- a/instrumentation/buildtime/mapping-file/plugin/src/main/kotlin/com/splunk/rum/mappingfile/plugin/MappingFilePlugin.kt
+++ b/instrumentation/buildtime/mapping-file/plugin/src/main/kotlin/com/splunk/rum/mappingfile/plugin/MappingFilePlugin.kt
@@ -20,7 +20,6 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.VariantOutputConfiguration
-import com.android.build.gradle.AppPlugin
 import com.splunk.rum.mappingfile.plugin.utils.SplunkLogger
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -40,7 +39,7 @@ class MappingFilePlugin : Plugin<Project> {
         extension = project.extensions.create("splunkRum", SplunkRumExtension::class.java)
         logger.debug("Setup", "Created splunkRum extension")
 
-        project.plugins.withType(AppPlugin::class.java) {
+        project.plugins.withId("com.android.application") {
             logger.debug("Setup", "Found Android application plugin")
 
             val androidComponents = project.extensions.getByType(


### PR DESCRIPTION
### Description

- Changed the AGP dependency in the mapping file plugin from `implementation` to `compileOnly`, so the plugin no longer forces AGP 8.6.0 on consumer projects. 

- This allows the plugin to work with older AGP versions like 8.1.1


### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Verify plugin builds successfully with `compileOnly`
- Tested on a sample app with AGP 8.1.1 + Gradle 8.0. Saw that build ID injection and upload task both ran correctly

