### PR TITLE
DEMRUM-5770: Add explicit-stack error tracking API

### DIFF
--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/internal/GlobalRumConstants.kt
@@ -75,6 +75,9 @@ object GlobalRumConstants {
      * Error attribute keys.
      */
     val ERROR_KEY: AttributeKey<String> = AttributeKey.stringKey("error")
+    val EXCEPTION_TYPE_KEY: AttributeKey<String> = AttributeKey.stringKey("exception.type")
+    val EXCEPTION_MESSAGE_KEY: AttributeKey<String> = AttributeKey.stringKey("exception.message")
+    val EXCEPTION_STACKTRACE_KEY: AttributeKey<String> = AttributeKey.stringKey("exception.stacktrace")
 
     /**
      * Network headers.

--- a/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
+++ b/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
@@ -23,7 +23,6 @@ import com.splunk.rum.common.otel.internal.GlobalRumConstants
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.semconv.ExceptionAttributes
 import java.time.Instant
 
 class CustomTracking internal constructor() {
@@ -107,11 +106,11 @@ class CustomTracking internal constructor() {
             .setAllAttributes(attributes)
             .setAttribute(GlobalRumConstants.COMPONENT_KEY, GlobalRumConstants.COMPONENT_ERROR)
             .setAttribute(GlobalRumConstants.ERROR_KEY, RumConstants.ERROR_TRUE_VALUE)
-            .setAttribute(ExceptionAttributes.EXCEPTION_TYPE, type)
-            .setAttribute(ExceptionAttributes.EXCEPTION_MESSAGE, message)
+            .setAttribute(GlobalRumConstants.EXCEPTION_TYPE_KEY, type)
+            .setAttribute(GlobalRumConstants.EXCEPTION_MESSAGE_KEY, message)
 
         stacktrace?.let {
-            spanBuilder.setAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE, it)
+            spanBuilder.setAttribute(GlobalRumConstants.EXCEPTION_STACKTRACE_KEY, it)
         }
 
         spanBuilder.createZeroLengthSpan()

--- a/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
+++ b/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
@@ -23,6 +23,7 @@ import com.splunk.rum.common.otel.internal.GlobalRumConstants
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.semconv.ExceptionAttributes
 import java.time.Instant
 
 class CustomTracking internal constructor() {
@@ -85,6 +86,35 @@ class CustomTracking internal constructor() {
             .startSpan()
             .recordException(throwable)
             .end(timestamp)
+    }
+
+    /**
+     * Add a custom error to RUM monitoring with an explicit stacktrace. This can be useful for
+     * tracking errors from runtimes that do not expose JVM [Throwable] instances.
+     *
+     * This event will be turned into a Span and sent to the RUM ingest along with other,
+     * auto-generated spans.
+     *
+     * @param type The error type.
+     * @param message The error message.
+     * @param stacktrace The error stacktrace, if available.
+     * @param attributes Any [Attributes] to associate with the event.
+     */
+    @JvmOverloads
+    fun trackError(type: String, message: String, stacktrace: String?, attributes: Attributes = Attributes.empty()) {
+        val tracer = getTracer() ?: return
+        val spanBuilder = tracer.spanBuilder(type)
+            .setAllAttributes(attributes)
+            .setAttribute(GlobalRumConstants.COMPONENT_KEY, GlobalRumConstants.COMPONENT_ERROR)
+            .setAttribute(GlobalRumConstants.ERROR_KEY, RumConstants.ERROR_TRUE_VALUE)
+            .setAttribute(ExceptionAttributes.EXCEPTION_TYPE, type)
+            .setAttribute(ExceptionAttributes.EXCEPTION_MESSAGE, message)
+
+        stacktrace?.let {
+            spanBuilder.setAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE, it)
+        }
+
+        spanBuilder.createZeroLengthSpan()
     }
 
     /**


### PR DESCRIPTION
Adds `CustomTracking.trackError(type, message, stacktrace, attributes)` for reporting non-JVM errors from hybrid runtimes.

The new API emits an error span with RUM error metadata, sets `exception.type`, `exception.message`, and optional `exception.stacktrace`, and preserves caller-provided attributes.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI