### PR TITLE
NO-TICKET: Support custom timestamps for tracked errors

### DIFF
--- a/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
+++ b/integration/customtracking/src/main/kotlin/com/splunk/rum/integration/customtracking/CustomTracking.kt
@@ -24,6 +24,7 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 class CustomTracking internal constructor() {
 
@@ -97,10 +98,18 @@ class CustomTracking internal constructor() {
      * @param type The error type.
      * @param message The error message.
      * @param stacktrace The error stacktrace, if available.
+     * @param timestamp The timestamp of the error in milliseconds since the Unix epoch. If `null`,
+     * the current time will be used.
      * @param attributes Any [Attributes] to associate with the event.
      */
     @JvmOverloads
-    fun trackError(type: String, message: String, stacktrace: String?, attributes: Attributes = Attributes.empty()) {
+    fun trackError(
+        type: String,
+        message: String,
+        stacktrace: String?,
+        timestamp: Long? = null,
+        attributes: Attributes = Attributes.empty()
+    ) {
         val tracer = getTracer() ?: return
         val spanBuilder = tracer.spanBuilder(type)
             .setAllAttributes(attributes)
@@ -113,7 +122,11 @@ class CustomTracking internal constructor() {
             spanBuilder.setAttribute(GlobalRumConstants.EXCEPTION_STACKTRACE_KEY, it)
         }
 
-        spanBuilder.createZeroLengthSpan()
+        if (timestamp == null) {
+            spanBuilder.createZeroLengthSpan()
+        } else {
+            spanBuilder.createZeroLengthSpan(timestamp, TimeUnit.MILLISECONDS)
+        }
     }
 
     /**


### PR DESCRIPTION
Adds an optional millisecond epoch timestamp to `CustomTracking.trackError`, falling back to the current time when omitted. When provided, the timestamp is used for the zero-length error span.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI