### PR TITLE
DEMRUM-6004: Remove the unused otel dependency bringing in Jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ referenced by upstream OpenTelemetry:
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 ```
 
+The SDK also suppresses missing-class warnings for optional Jackson types referenced by the
+upstream OTLP exporter JSON marshaler. Splunk export uses protobuf marshalers, so these classes are
+not required at runtime:
+
+```pro
+-dontwarn com.fasterxml.jackson.core.JsonFactory
+-dontwarn com.fasterxml.jackson.core.JsonGenerator
+```
+
 ## Troubleshooting
 
 For troubleshooting issues with the Splunk OpenTelemetry instrumentation of Android, see

--- a/common/otel/consumer-rules.pro
+++ b/common/otel/consumer-rules.pro
@@ -3,6 +3,7 @@
 -dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 
-# OpenTelemetry OTLP exporter references Jackson classes that are optional on Android.
-# Splunk export uses protobuf marshalers; jackson-core is not required at runtime.
--dontwarn com.fasterxml.jackson.core.**
+# OpenTelemetry OTLP exporter references these Jackson classes that are optional on Android.
+# Splunk export uses protobuf marshalers; these are not required.
+-dontwarn com.fasterxml.jackson.core.JsonFactory
+-dontwarn com.fasterxml.jackson.core.JsonGenerator

--- a/common/otel/consumer-rules.pro
+++ b/common/otel/consumer-rules.pro
@@ -2,3 +2,7 @@
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+
+# OpenTelemetry OTLP exporter references Jackson classes that are optional on Android.
+# Splunk export uses protobuf marshalers; jackson-core is not required at runtime.
+-dontwarn com.fasterxml.jackson.core.**

--- a/integration/crash/build.gradle.kts
+++ b/integration/crash/build.gradle.kts
@@ -29,7 +29,9 @@ dependencies {
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
 
-    implementation(Dependencies.Otel.androidCrashInstrumentation)
+    implementation(Dependencies.Otel.androidCrashInstrumentation) {
+        exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-extension-incubator")
+    }
 
     implementation(Dependencies.Otel.instrumentationApi)
 

--- a/integration/networkmonitor/build.gradle.kts
+++ b/integration/networkmonitor/build.gradle.kts
@@ -28,7 +28,9 @@ dependencies {
 
     implementation(project(":integration:agent:internal"))
 
-    implementation(Dependencies.Otel.androidNetworkMonitorInstrumentation)
+    implementation(Dependencies.Otel.androidNetworkMonitorInstrumentation) {
+        exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-extension-incubator")
+    }
     implementation(Dependencies.Otel.androidServices)
     implementation(Dependencies.Otel.androidCommon)
 


### PR DESCRIPTION

### Description

- Remove the unused opentelemetry-sdk-extension-incubator transitive dependency from crash and network monitor instrumentation, which eliminates jackson-core from the SDK runtime classpath. 
- Add consumer ProGuard rules so R8 ignores optional Jackson references in the OTLP exporter (Splunk export uses protobuf marshalers, not JSON).

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Build and run the SDK.
- Test crash and network monitor instrumentations work fine.
- Test upload works as expected. 
