### PR TITLE
NO-TICKET: Disable renovate bot for a dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,16 @@
       "enabled": false
     },
     {
+      "description": "Disable dependencies updates",
+      "matchPackageNames": [
+        "androidx.activity:activity-compose",
+        "androidx.activity:activity-ktx",
+        "androidx.annotation:annotation",
+        "androidx.compose.material:material"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Quarterly updates for app/**",
       "matchPaths": ["app/**"],
       "extends": ["schedule:quarterly"]


### PR DESCRIPTION
## Title: Disable renovate bot for a dependencies

### Description

Disable renovate bot for the following dependencies because of minSdk and Kotlin requirements
- androidx.activity:activity-compose
- androidx.activity:activity-ktx
- androidx.annotation:annotation
- androidx.compose.material:material

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI