### PR TITLE
NO-TICKET: Fix sast scan reference

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
-  - project: 'prodsec/scp-scanning/gitlab-checkmarx'
-    ref: latest
-    file: '/templates/.sast_scan.yml'
+  - project: 'ci-cd/templates'
+    ref: main
+    file: '/prodsec/.sast-scan.yml'
   - project: 'ci-cd/templates'
     ref: main
     file: '/prodsec/.oss-scan.yml'


### PR DESCRIPTION
## Title: Use official ProdSec SAST scan template in CI

### Description

- Repointed the SAST `include` in `.gitlab-ci.yml` from the unofficial/outdated template (`prodsec/scp-scanning/gitlab-checkmarx` → `/templates/.sast_scan.yml`, `ref: latest`) to the official ProdSec template (`ci-cd/templates` → `/prodsec/.sast-scan.yml`, `ref: main`).
- Updated the `ref` from `latest` to `main` to match the new project's default branch (consistent with the existing `oss-scan` include, which already uses `ci-cd/templates` @ `main`).
- Left the `sast-scan` job unchanged: the official template still exposes the `.sast_scan` anchor, so `extends: .sast_scan` and the existing variables remain valid.

**Context / background:**

- This resolves a HIGH severity SAST finding from the `detect-unofficial-sast-template` rule coming from a prodSec ticket. It's a CI/CD configuration finding, not a code vulnerability as the pipeline was referencing an outdated SAST scan template.
- The required coordinates come directly from the ticket's remediation text

**Notes:**

- `SAST_SCANNER: "Semgrep"` is not referenced by the official template (effectively a no-op); kept for now to minimize the change.
- The official template hardcodes `allow_failure: true`, so this job does not block the pipeline on findings even with `alert_mode: "policy"`. Making SAST a hard gate is out of scope for this ticket and would need a separate follow-up with ProdSec.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI
