### PR TITLE
NO-TICKET: Streamline navigation module init

### DIFF
--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -51,6 +51,15 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
     private val emitter = NavigationEventEmitter()
     private var screenChangeDetector: ScreenChangeDetector? = null
 
+    private val isNavigationAvailable: Boolean by lazy {
+        try {
+            Class.forName("androidx.navigation.NavDestination")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        }
+    }
+
     private val activityLifecycleCallbacksAdapter = object : ActivityLifecycleCallbacksAdapter {
         override fun onActivityResumed(activity: Activity) {
             currentActivityReference = WeakReference(activity)
@@ -106,7 +115,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             }
         }
 
-        if (isNavigationAvailable()) {
+        if (isNavigationAvailable) {
             Navigation.instance.composeTracker = ComposeNavigationTracker(
                 screenChangeDetector = detector,
                 processor = moduleConfiguration.navigationEventProcessor
@@ -115,7 +124,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         } else {
             Logger.d(
                 TAG,
-                "androidx.navigation.NavDestination.getRoute not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+"
+                "androidx.navigation.NavDestination not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+"
             )
         }
 
@@ -155,14 +164,6 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         }
 
         application.registerActivityLifecycleCallbacks(fragmentActivityCallback)
-    }
-
-    private fun isNavigationAvailable(): Boolean = try {
-        Class.forName("androidx.navigation.NavDestination")
-            .getMethod("getRoute")
-        true
-    } catch (_: Exception) {
-        false
     }
 
     private val navigationListener = object : Navigation.Listener {

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -72,14 +72,27 @@ internal class ComposeNavigationTracker(
         screenChangeDetector.clearComposeRoute()
     }
 
+    private var routeApiAvailable = true
+
     private fun handleDestinationChanged(destination: NavDestination, arguments: Bundle?) {
+        if (!routeApiAvailable) return
         if (destination is NavGraph) return
         if (destination.navigatorName == NAVIGATOR_NAME_DIALOG) return
 
-        val screenName = destination.route ?: return
+        val screenName = try {
+            destination.route
+        } catch (e: LinkageError) {
+            routeApiAvailable = false
+            Logger.w(TAG, "NavDestination.route not available, disabling Compose tracking: ${e.message}")
+            return
+        } ?: return
 
         val attrMap = extractArguments(arguments)
-        destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+        try {
+            destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+        } catch (_: LinkageError) {
+            // guarded by the flag above on next call
+        }
 
         if (processor != null) {
             val event = NavigationEvent(


### PR DESCRIPTION
- Cache `isNavigationAvailable` as a by lazy property and remove the unnecessary` getMethod("getRoute")` reflection call that was causing main-thread blocking during` SplunkRum.install()`
- `getRoute() `has been on `NavDestination` since navigation 2.4.0 (4+ years); `Class.forName() `alone should be sufficient to confirm availability

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Ensure navigation module and jetpack compose support still works