### PR TITLE
NO-TICKET: Streamline and defer navigation module init

### DIFF
--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
@@ -19,12 +19,15 @@ package com.splunk.rum.integration.navigation
 import androidx.navigation.NavController
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.integration.navigation.automatic.ComposeNavigationTracker
+import com.splunk.rum.integration.navigation.automatic.ScreenChangeDetector
 import io.opentelemetry.api.common.Attributes
 
 class Navigation internal constructor() {
 
     internal var listener: Listener? = null
     internal var composeTracker: ComposeNavigationTracker? = null
+    private var pendingDetector: ScreenChangeDetector? = null
+    private var pendingProcessor: NavigationEventProcessor? = null
 
     /**
      * Record a navigation to [screenName] with optional [attributes] (manual tracking).
@@ -44,12 +47,34 @@ class Navigation internal constructor() {
      * Call this after [NavController] is created (e.g. in your Activity's `setContent` block).
      */
     fun registerNavController(navController: NavController) {
-        val tracker = composeTracker
-        if (tracker == null) {
+        val tracker = composeTracker ?: createTrackerIfConfigured() ?: run {
             Logger.w(TAG, "Navigation module not installed. Cannot register NavController.")
             return
         }
         tracker.register(navController)
+    }
+
+    internal fun setTrackerConfig(detector: ScreenChangeDetector, processor: NavigationEventProcessor?) {
+        pendingDetector = detector
+        pendingProcessor = processor
+    }
+
+    internal fun clearTrackerConfig() {
+        pendingDetector = null
+        pendingProcessor = null
+    }
+
+    private fun createTrackerIfConfigured(): ComposeNavigationTracker? {
+        val detector = pendingDetector ?: return null
+        val tracker = ComposeNavigationTracker(
+            screenChangeDetector = detector,
+            processor = pendingProcessor
+        )
+        composeTracker = tracker
+        pendingDetector = null
+        pendingProcessor = null
+        Logger.d(TAG, "ComposeNavigationTracker initialized")
+        return tracker
     }
 
     /**

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
@@ -67,7 +67,10 @@ class Navigation internal constructor() {
     private fun createTrackerIfConfigured(): ComposeNavigationTracker? {
         val detector = pendingDetector ?: return null
         if (!isRouteApiAvailable) {
-            Logger.d(TAG, "NavDestination.getRoute() not available (requires navigation 2.4.0+), Compose tracking disabled")
+            Logger.d(
+                TAG,
+                "NavDestination.getRoute() not available (requires navigation 2.4.0+), Compose tracking disabled"
+            )
             pendingDetector = null
             pendingProcessor = null
             return null

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
@@ -66,15 +66,6 @@ class Navigation internal constructor() {
 
     private fun createTrackerIfConfigured(): ComposeNavigationTracker? {
         val detector = pendingDetector ?: return null
-        if (!isRouteApiAvailable) {
-            Logger.d(
-                TAG,
-                "NavDestination.getRoute() not available (requires navigation 2.4.0+), Compose tracking disabled"
-            )
-            pendingDetector = null
-            pendingProcessor = null
-            return null
-        }
         val tracker = ComposeNavigationTracker(
             screenChangeDetector = detector,
             processor = pendingProcessor
@@ -84,15 +75,6 @@ class Navigation internal constructor() {
         pendingProcessor = null
         Logger.d(TAG, "ComposeNavigationTracker initialized")
         return tracker
-    }
-
-    private val isRouteApiAvailable: Boolean by lazy {
-        try {
-            Class.forName("androidx.navigation.NavDestination").getMethod("getRoute")
-            true
-        } catch (_: Exception) {
-            false
-        }
     }
 
     /**

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
@@ -71,8 +71,7 @@ class Navigation internal constructor() {
             processor = pendingProcessor
         )
         composeTracker = tracker
-        pendingDetector = null
-        pendingProcessor = null
+        clearTrackerConfig()
         Logger.d(TAG, "ComposeNavigationTracker initialized")
         return tracker
     }

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/Navigation.kt
@@ -66,6 +66,12 @@ class Navigation internal constructor() {
 
     private fun createTrackerIfConfigured(): ComposeNavigationTracker? {
         val detector = pendingDetector ?: return null
+        if (!isRouteApiAvailable) {
+            Logger.d(TAG, "NavDestination.getRoute() not available (requires navigation 2.4.0+), Compose tracking disabled")
+            pendingDetector = null
+            pendingProcessor = null
+            return null
+        }
         val tracker = ComposeNavigationTracker(
             screenChangeDetector = detector,
             processor = pendingProcessor
@@ -75,6 +81,15 @@ class Navigation internal constructor() {
         pendingProcessor = null
         Logger.d(TAG, "ComposeNavigationTracker initialized")
         return tracker
+    }
+
+    private val isRouteApiAvailable: Boolean by lazy {
+        try {
+            Class.forName("androidx.navigation.NavDestination").getMethod("getRoute")
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     /**

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -25,7 +25,6 @@ import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.common.utils.adapters.ActivityLifecycleCallbacksAdapter
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import com.splunk.rum.integration.navigation.automatic.ComposeNavigationTracker
 import com.splunk.rum.integration.navigation.automatic.NavigationEventEmitter
 import com.splunk.rum.integration.navigation.automatic.ScreenChangeDetector
 import com.splunk.rum.integration.navigation.automatic.callback.NavigationActivityCallback
@@ -74,6 +73,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         if (!moduleConfiguration.isEnabled) {
             Navigation.instance.listener = null
             Navigation.instance.composeTracker = null
+            Navigation.instance.clearTrackerConfig()
             emitter.clearCache()
             (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
             currentActivityReference = null
@@ -106,18 +106,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             }
         }
 
-        if (isNavigationAvailable()) {
-            Navigation.instance.composeTracker = ComposeNavigationTracker(
-                screenChangeDetector = detector,
-                processor = moduleConfiguration.navigationEventProcessor
-            )
-            Logger.d(TAG, "ComposeNavigationTracker initialized")
-        } else {
-            Logger.d(
-                TAG,
-                "androidx.navigation.NavDestination.getRoute not found on classpath, Compose navigation tracking disabled: requires androidx.navigation 2.4.0+"
-            )
-        }
+        Navigation.instance.setTrackerConfig(detector, moduleConfiguration.navigationEventProcessor)
 
         (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
         currentActivityReference = null
@@ -155,14 +144,6 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
         }
 
         application.registerActivityLifecycleCallbacks(fragmentActivityCallback)
-    }
-
-    private fun isNavigationAvailable(): Boolean = try {
-        Class.forName("androidx.navigation.NavDestination")
-            .getMethod("getRoute")
-        true
-    } catch (_: Exception) {
-        false
     }
 
     private val navigationListener = object : Navigation.Listener {

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -44,6 +44,7 @@ internal class ComposeNavigationTracker(
     private var activeListener: NavController.OnDestinationChangedListener? = null
 
     fun register(navController: NavController) {
+        if (!routeApiAvailable) return
         if (registeredController?.get() === navController) return
 
         clearRegistration()

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -72,14 +72,27 @@ internal class ComposeNavigationTracker(
         screenChangeDetector.clearComposeRoute()
     }
 
+    private var routeApiAvailable = true
+
     private fun handleDestinationChanged(destination: NavDestination, arguments: Bundle?) {
+        if (!routeApiAvailable) return
         if (destination is NavGraph) return
         if (destination.navigatorName == NAVIGATOR_NAME_DIALOG) return
 
-        val screenName = destination.route ?: return
+        val screenName = try {
+            destination.route
+        } catch (e: LinkageError) {
+            routeApiAvailable = false
+            Logger.w(TAG, "NavDestination.route not available, disabling Compose tracking: ${e.message}")
+            return
+        } ?: return
 
         val attrMap = extractArguments(arguments)
-        destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+        try {
+            destination.parent?.route?.let { attrMap[ATTR_NAV_GRAPH] = it }
+        } catch (_: LinkageError) {
+            // guarded by the flag above on next call
+        }
 
         if (processor != null) {
             val event = NavigationEvent(

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -55,6 +55,12 @@ internal class ComposeNavigationTracker(
         registeredController = WeakReference(navController)
         activeListener = listener
         navController.addOnDestinationChangedListener(listener)
+        if (!routeApiAvailable) {
+            navController.removeOnDestinationChangedListener(listener)
+            registeredController = null
+            activeListener = null
+            return
+        }
         Logger.d(TAG, "Registered NavController for Compose navigation tracking")
     }
 

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTracker.kt
@@ -17,6 +17,7 @@
 package com.splunk.rum.integration.navigation.automatic
 
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph
@@ -50,9 +51,9 @@ internal class ComposeNavigationTracker(
         val listener = NavController.OnDestinationChangedListener { _, destination, arguments ->
             handleDestinationChanged(destination, arguments)
         }
-        navController.addOnDestinationChangedListener(listener)
         registeredController = WeakReference(navController)
         activeListener = listener
+        navController.addOnDestinationChangedListener(listener)
         Logger.d(TAG, "Registered NavController for Compose navigation tracking")
     }
 
@@ -72,9 +73,12 @@ internal class ComposeNavigationTracker(
         screenChangeDetector.clearComposeRoute()
     }
 
-    private var routeApiAvailable = true
+    @VisibleForTesting
+    internal var routeApiAvailable = true
+        private set
 
-    private fun handleDestinationChanged(destination: NavDestination, arguments: Bundle?) {
+    @VisibleForTesting
+    internal fun handleDestinationChanged(destination: NavDestination, arguments: Bundle?) {
         if (!routeApiAvailable) return
         if (destination is NavGraph) return
         if (destination.navigatorName == NAVIGATOR_NAME_DIALOG) return
@@ -83,6 +87,7 @@ internal class ComposeNavigationTracker(
             destination.route
         } catch (e: LinkageError) {
             routeApiAvailable = false
+            clearRegistration()
             Logger.w(TAG, "NavDestination.route not available, disabling Compose tracking: ${e.message}")
             return
         } ?: return

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/NavigationTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/NavigationTest.kt
@@ -43,7 +43,7 @@ class NavigationTest {
     }
 
     @Test
-    fun `registerNavController without config does not crash and tracker remains null`() {
+    fun `registerNavController without install is a no-op`() {
         navigation.registerNavController(navController)
 
         assertNull(navigation.composeTracker)
@@ -79,20 +79,5 @@ class NavigationTest {
         navigation.registerNavController(navController)
 
         assertNull(navigation.composeTracker)
-    }
-
-    @Test
-    fun `pending config is cleared after tracker creation`() {
-        navigation.setTrackerConfig(detector, null)
-        navigation.registerNavController(navController)
-
-        val secondNavigation = Navigation()
-        secondNavigation.composeTracker = null
-
-        navigation.clearTrackerConfig()
-        val anotherController = mock(NavController::class.java)
-        navigation.registerNavController(anotherController)
-
-        assertNotNull(navigation.composeTracker)
     }
 }

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/NavigationTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/NavigationTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.navigation
+
+import androidx.navigation.NavController
+import com.splunk.rum.integration.navigation.automatic.NavigationEventEmitter
+import com.splunk.rum.integration.navigation.automatic.ScreenChangeDetector
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NavigationTest {
+
+    private lateinit var navigation: Navigation
+    private lateinit var detector: ScreenChangeDetector
+    private lateinit var navController: NavController
+
+    @Before
+    fun setUp() {
+        navigation = Navigation()
+        detector = ScreenChangeDetector(NavigationEventEmitter())
+        navController = mock(NavController::class.java)
+    }
+
+    @Test
+    fun `registerNavController without config does not crash and tracker remains null`() {
+        navigation.registerNavController(navController)
+
+        assertNull(navigation.composeTracker)
+    }
+
+    @Test
+    fun `registerNavController creates tracker when config is pending`() {
+        navigation.setTrackerConfig(detector, null)
+
+        navigation.registerNavController(navController)
+
+        assertNotNull(navigation.composeTracker)
+    }
+
+    @Test
+    fun `registerNavController reuses tracker on second call`() {
+        navigation.setTrackerConfig(detector, null)
+
+        navigation.registerNavController(navController)
+        val firstTracker = navigation.composeTracker
+
+        val secondController = mock(NavController::class.java)
+        navigation.registerNavController(secondController)
+
+        assertSame(firstTracker, navigation.composeTracker)
+    }
+
+    @Test
+    fun `clearTrackerConfig prevents tracker creation`() {
+        navigation.setTrackerConfig(detector, null)
+        navigation.clearTrackerConfig()
+
+        navigation.registerNavController(navController)
+
+        assertNull(navigation.composeTracker)
+    }
+
+    @Test
+    fun `pending config is cleared after tracker creation`() {
+        navigation.setTrackerConfig(detector, null)
+        navigation.registerNavController(navController)
+
+        val secondNavigation = Navigation()
+        secondNavigation.composeTracker = null
+
+        navigation.clearTrackerConfig()
+        val anotherController = mock(NavController::class.java)
+        navigation.registerNavController(anotherController)
+
+        assertNotNull(navigation.composeTracker)
+    }
+}

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
@@ -17,7 +17,6 @@
 package com.splunk.rum.integration.navigation.automatic
 
 import android.os.Looper
-import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.splunk.rum.agent.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
@@ -30,6 +29,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -82,58 +82,58 @@ class ComposeNavigationTrackerTest {
 
     @Test
     fun `destination change with route emits navigation event`() {
-        val navController = mock(NavController::class.java)
-        tracker.register(navController)
+        val destination = createDestination(route = "home")
 
-        val destination = createDestination(route = "home!")
-        simulateDestinationChanged(navController, destination)
+        tracker.handleDestinationChanged(destination, null)
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertEquals(1, exportedLogs.size)
-        assertEquals("home!", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+        assertEquals("home", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
     }
 
+    /**
+     * Verifies the LinkageError catch guard works. We can't run against a real pre-2.4.0
+     * navigation library in unit tests, so Mockito simulates the NoSuchMethodError that the
+     * JVM would throw at the destination.route call site for that version mismatch.
+     */
     @Test
     fun `LinkageError on route access disables tracking without crash`() {
-        val navController = mock(NavController::class.java)
-        tracker.register(navController)
-
         val destination = mock(NavDestination::class.java)
         `when`(destination.navigatorName).thenReturn("composable")
         `when`(destination.route).thenThrow(NoSuchMethodError("getRoute"))
 
-        simulateDestinationChanged(navController, destination)
+        tracker.handleDestinationChanged(destination, null)
+        shadowOf(Looper.getMainLooper()).idle()
 
-        assertTrue("Should not crash, events should be empty", exportedLogs.isEmpty())
+        assertTrue("Events should be empty", exportedLogs.isEmpty())
+        assertFalse("routeApiAvailable should be false", tracker.routeApiAvailable)
     }
 
     @Test
     fun `subsequent destinations are skipped after LinkageError`() {
-        val navController = mock(NavController::class.java)
-        tracker.register(navController)
-
         val badDestination = mock(NavDestination::class.java)
         `when`(badDestination.navigatorName).thenReturn("composable")
         `when`(badDestination.route).thenThrow(NoSuchMethodError("getRoute"))
-        simulateDestinationChanged(navController, badDestination)
+        tracker.handleDestinationChanged(badDestination, null)
 
         val goodDestination = createDestination(route = "settings")
-        simulateDestinationChanged(navController, goodDestination)
+        tracker.handleDestinationChanged(goodDestination, null)
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertTrue("No events should emit after LinkageError disabled tracking", exportedLogs.isEmpty())
     }
 
     @Test
     fun `IncompatibleClassChangeError is also caught`() {
-        val navController = mock(NavController::class.java)
-        tracker.register(navController)
-
         val destination = mock(NavDestination::class.java)
         `when`(destination.navigatorName).thenReturn("composable")
         `when`(destination.route).thenThrow(IncompatibleClassChangeError("test"))
 
-        simulateDestinationChanged(navController, destination)
+        tracker.handleDestinationChanged(destination, null)
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertTrue("Should not crash", exportedLogs.isEmpty())
+        assertFalse("routeApiAvailable should be false", tracker.routeApiAvailable)
     }
 
     private fun createDestination(route: String): NavDestination {
@@ -142,13 +142,5 @@ class ComposeNavigationTrackerTest {
         `when`(destination.route).thenReturn(route)
         `when`(destination.parent).thenReturn(null)
         return destination
-    }
-
-    private fun simulateDestinationChanged(navController: NavController, destination: NavDestination) {
-        val listenerField = tracker.javaClass.getDeclaredField("activeListener")
-        listenerField.isAccessible = true
-        val listener = listenerField.get(tracker) as? NavController.OnDestinationChangedListener
-        listener?.onDestinationChanged(navController, destination, null)
-        shadowOf(Looper.getMainLooper()).idle()
     }
 }

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
@@ -17,6 +17,7 @@
 package com.splunk.rum.integration.navigation.automatic
 
 import android.os.Looper
+import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import com.splunk.rum.agent.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
@@ -35,6 +36,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -134,6 +136,19 @@ class ComposeNavigationTrackerTest {
 
         assertTrue("Should not crash", exportedLogs.isEmpty())
         assertFalse("routeApiAvailable should be false", tracker.routeApiAvailable)
+    }
+
+    @Test
+    fun `register is rejected after LinkageError disables tracking`() {
+        val badDestination = mock(NavDestination::class.java)
+        `when`(badDestination.navigatorName).thenReturn("composable")
+        `when`(badDestination.route).thenThrow(NoSuchMethodError("getRoute"))
+        tracker.handleDestinationChanged(badDestination, null)
+
+        val navController = mock(NavController::class.java)
+        tracker.register(navController)
+
+        verifyNoInteractions(navController)
     }
 
     private fun createDestination(route: String): NavDestination {

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.navigation.automatic
+
+import android.os.Looper
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import com.splunk.rum.agent.common.otel.SplunkOpenTelemetrySdk
+import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
+import com.splunk.rum.integration.agent.internal.attributes.ScreenNameTracker
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.logs.SdkLoggerProvider
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class ComposeNavigationTrackerTest {
+
+    private val exportedLogs = mutableListOf<LogRecordData>()
+    private lateinit var emitter: NavigationEventEmitter
+    private lateinit var detector: ScreenChangeDetector
+    private lateinit var tracker: ComposeNavigationTracker
+
+    private val collectingExporter = object : LogRecordExporter {
+        override fun export(logs: MutableCollection<LogRecordData>): CompletableResultCode {
+            exportedLogs.addAll(logs)
+            return CompletableResultCode.ofSuccess()
+        }
+
+        override fun flush() = CompletableResultCode.ofSuccess()
+        override fun shutdown() = CompletableResultCode.ofSuccess()
+    }
+
+    @Before
+    fun setUp() {
+        exportedLogs.clear()
+        ScreenNameTracker.screenName = GlobalRumConstants.DEFAULT_SCREEN_NAME
+
+        val loggerProvider = SdkLoggerProvider.builder()
+            .addLogRecordProcessor(SimpleLogRecordProcessor.create(collectingExporter))
+            .build()
+        SplunkOpenTelemetrySdk.instance = OpenTelemetrySdk.builder()
+            .setLoggerProvider(loggerProvider)
+            .build()
+
+        emitter = NavigationEventEmitter()
+        emitter.processCachedEvents()
+        detector = ScreenChangeDetector(emitter)
+        tracker = ComposeNavigationTracker(screenChangeDetector = detector, processor = null)
+    }
+
+    @After
+    fun tearDown() {
+        SplunkOpenTelemetrySdk.instance = null
+    }
+
+    @Test
+    fun `destination change with route emits navigation event`() {
+        val navController = mock(NavController::class.java)
+        tracker.register(navController)
+
+        val destination = createDestination(route = "home")
+        simulateDestinationChanged(navController, destination)
+
+        assertEquals(1, exportedLogs.size)
+        assertEquals("home", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+    }
+
+    @Test
+    fun `LinkageError on route access disables tracking without crash`() {
+        val navController = mock(NavController::class.java)
+        tracker.register(navController)
+
+        val destination = mock(NavDestination::class.java)
+        `when`(destination.navigatorName).thenReturn("composable")
+        `when`(destination.route).thenThrow(NoSuchMethodError("getRoute"))
+
+        simulateDestinationChanged(navController, destination)
+
+        assertTrue("Should not crash, events should be empty", exportedLogs.isEmpty())
+    }
+
+    @Test
+    fun `subsequent destinations are skipped after LinkageError`() {
+        val navController = mock(NavController::class.java)
+        tracker.register(navController)
+
+        val badDestination = mock(NavDestination::class.java)
+        `when`(badDestination.navigatorName).thenReturn("composable")
+        `when`(badDestination.route).thenThrow(NoSuchMethodError("getRoute"))
+        simulateDestinationChanged(navController, badDestination)
+
+        val goodDestination = createDestination(route = "settings")
+        simulateDestinationChanged(navController, goodDestination)
+
+        assertTrue("No events should emit after LinkageError disabled tracking", exportedLogs.isEmpty())
+    }
+
+    @Test
+    fun `IncompatibleClassChangeError is also caught`() {
+        val navController = mock(NavController::class.java)
+        tracker.register(navController)
+
+        val destination = mock(NavDestination::class.java)
+        `when`(destination.navigatorName).thenReturn("composable")
+        `when`(destination.route).thenThrow(IncompatibleClassChangeError("test"))
+
+        simulateDestinationChanged(navController, destination)
+
+        assertTrue("Should not crash", exportedLogs.isEmpty())
+    }
+
+    private fun createDestination(route: String): NavDestination {
+        val destination = mock(NavDestination::class.java)
+        `when`(destination.navigatorName).thenReturn("composable")
+        `when`(destination.route).thenReturn(route)
+        `when`(destination.parent).thenReturn(null)
+        return destination
+    }
+
+    private fun simulateDestinationChanged(navController: NavController, destination: NavDestination) {
+        val listenerField = tracker.javaClass.getDeclaredField("activeListener")
+        listenerField.isAccessible = true
+        val listener = listenerField.get(tracker) as? NavController.OnDestinationChangedListener
+        listener?.onDestinationChanged(navController, destination, null)
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+}

--- a/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
+++ b/integration/navigation/src/test/kotlin/com/splunk/rum/integration/navigation/automatic/ComposeNavigationTrackerTest.kt
@@ -85,11 +85,11 @@ class ComposeNavigationTrackerTest {
         val navController = mock(NavController::class.java)
         tracker.register(navController)
 
-        val destination = createDestination(route = "home")
+        val destination = createDestination(route = "home!")
         simulateDestinationChanged(navController, destination)
 
         assertEquals(1, exportedLogs.size)
-        assertEquals("home", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
+        assertEquals("home!", exportedLogs[0].attributes.get(GlobalRumConstants.SCREEN_NAME_KEY))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Removes all reflection from the navigation module's install path to reduce main thread activity upon install

### Context

The original `isNavigationAvailable()` ran `Class.forName().getMethod()` synchronously on the main thread during `SplunkRum.install()`. On pressured devices this can trigger a dex I/O, `NavDestination.<clinit>`, and a reflective method hierarchy walk, contributing to main thread activity and potential ANRs for heavily loaded, non performant apps

### Details

- **`NavigationModuleIntegration.onInstall()`**: Removed the `isNavigationAvailable()` check entirely (`Class.forName("NavDestination").getMethod("getRoute")`) and the eager `ComposeNavigationTracker` creation. Instead, stores the tracker's dependencies (`ScreenChangeDetector`, `NavigationEventProcessor`) via `Navigation.setTrackerConfig()` for deferred use.

- **`Navigation.registerNavController()`**: Creates the `ComposeNavigationTracker` lazily on the customer's first call. Since this happens in UI code (e.g. `setContent`) after `SplunkRum.install()` completes, the work is no longer competing for the ANR budget during startup. No reflection is performed here as the tracker is just an object allocation

- **`ComposeNavigationTracker.handleDestinationChanged()`**: Added a `LinkageError` catch around `destination.route` access. If the app is on `androidx.navigation` < 2.4.0 (where `getRoute()` doesn't exist), the tracker disables itself on first destination change and logs a warning instead of crashing. This replaces the removed `getMethod("getRoute")` reflection guard with zero upfront cost. `LinkageError` covers `NoSuchMethodError`, `NoClassDefFoundError`, `IncompatibleClassChangeError`, etc.

- Fragment/Activity automatic tracking is unchanged
- `isAutomatedTrackingEnabled` behavior is unchanged (Compose tracking is independent of it, same as before)
- `registerNavController()` called multiple times with the same instance is still a no-op
- Apps that don't use Compose Navigation pay zero cost (tracker is never created)
- Module disabled (`isEnabled = false`) still fully cleans up and logs a warning on `registerNavController()`

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Ensure navigation module and automated tracking including jetpack compose still work