### PR TITLE
DEMRUM-6216: Move the first network detection to background

### DIFF
--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/NetworkMonitorInstrumentation.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/NetworkMonitorInstrumentation.kt
@@ -73,14 +73,21 @@ class NetworkMonitorInstrumentation {
         )
         currentNetworkProvider.addNetworkChangeListener { currentNetwork ->
             val attributes = CurrentNetworkAttributes.extract(currentNetwork)
-            attributeListeners.forEach { listener ->
-                try {
-                    listener(attributes)
-                } catch (exception: RuntimeException) {
-                    Log.w(TAG, "Network change listener failed.", exception)
-                }
-            }
             eventEmitter.emit(attributes)
+            notifyAttributeListeners(attributes)
+        }
+        currentNetworkProvider.start { currentNetwork ->
+            notifyAttributeListeners(CurrentNetworkAttributes.extract(currentNetwork))
+        }
+    }
+
+    private fun notifyAttributeListeners(attributes: Attributes) {
+        attributeListeners.forEach { listener ->
+            try {
+                listener(attributes)
+            } catch (exception: RuntimeException) {
+                Log.w(TAG, "Network change listener failed.", exception)
+            }
         }
     }
 

--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CarrierFinder.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CarrierFinder.kt
@@ -70,7 +70,6 @@ internal class CarrierFinder(private val context: Context, private val telephony
         val carrierName = manager.simCarrierIdName?.takeIf { it.isNotEmpty() }?.toString()
         val (mcc, mnc, iso) = getMccMncIso(manager)
         return Carrier(
-            id = manager.simCarrierId,
             name = carrierName,
             mobileCountryCode = mcc,
             mobileNetworkCode = mnc,

--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProvider.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProvider.kt
@@ -26,6 +26,8 @@ import java.io.Closeable
 internal interface CurrentNetworkProvider : Closeable {
     val currentNetwork: CurrentNetwork
 
+    fun start(initialNetworkListener: NetworkChangeListener)
+
     fun refreshNetworkStatus(): CurrentNetwork
 
     fun addNetworkChangeListener(listener: NetworkChangeListener)

--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImpl.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImpl.kt
@@ -24,24 +24,37 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.util.Log
+import com.splunk.rum.common.utils.thread.NamedThreadFactory
 import com.splunk.rum.instrumentation.networkmonitor.internal.model.CurrentNetwork
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 internal class CurrentNetworkProviderImpl(
     private val networkDetector: NetworkDetector,
     private val connectivityManager: ConnectivityManager,
-    createNetworkMonitoringRequest: () -> NetworkRequest = ::createNetworkMonitoringRequest
+    private val initialDetectionExecutor: ExecutorService = createInitialDetectionExecutor(),
+    private val createNetworkMonitoringRequest: () -> NetworkRequest = ::createNetworkMonitoringRequest
 ) : CurrentNetworkProvider {
-    @Volatile
-    override var currentNetwork: CurrentNetwork = CurrentNetworkProvider.UNKNOWN_NETWORK
-        private set
+    override val currentNetwork: CurrentNetwork
+        get() = networkSnapshot.get().network
 
     private val callbackRef = AtomicReference<NetworkCallback>()
     private val listeners = CopyOnWriteArrayList<NetworkChangeListener>()
+    private val started = AtomicBoolean()
+    private val closed = AtomicBoolean()
+    private val networkSnapshot = AtomicReference(
+        NetworkSnapshot(callbackObserved = false, network = CurrentNetworkProvider.UNKNOWN_NETWORK)
+    )
 
-    init {
-        refreshNetworkStatus()
+    override fun start(initialNetworkListener: NetworkChangeListener) {
+        if (!started.compareAndSet(false, true) || closed.get()) {
+            return
+        }
+
+        val initialSnapshot = networkSnapshot.get()
         try {
             registerNetworkCallbacks(createNetworkMonitoringRequest)
         } catch (exception: Exception) {
@@ -51,16 +64,21 @@ internal class CurrentNetworkProviderImpl(
                 exception
             )
         }
+        detectInitialNetwork(initialSnapshot, initialNetworkListener)
     }
 
     override fun refreshNetworkStatus(): CurrentNetwork {
-        currentNetwork = try {
-            networkDetector.detectCurrentNetwork()
-        } catch (exception: Exception) {
-            Log.w(TAG, "Failed to detect the current network.", exception)
-            CurrentNetworkProvider.UNKNOWN_NETWORK
-        }
-        return currentNetwork
+        val detectedNetwork = detectCurrentNetwork()
+        val currentSnapshot = networkSnapshot.get()
+        networkSnapshot.set(currentSnapshot.copy(network = detectedNetwork))
+        return detectedNetwork
+    }
+
+    private fun detectCurrentNetwork(): CurrentNetwork = try {
+        networkDetector.detectCurrentNetwork()
+    } catch (exception: Exception) {
+        Log.w(TAG, "Failed to detect the current network.", exception)
+        CurrentNetworkProvider.UNKNOWN_NETWORK
     }
 
     override fun addNetworkChangeListener(listener: NetworkChangeListener) {
@@ -72,6 +90,7 @@ internal class CurrentNetworkProviderImpl(
     }
 
     override fun close() {
+        closed.set(true)
         callbackRef.getAndSet(null)?.let { callback ->
             try {
                 connectivityManager.unregisterNetworkCallback(callback)
@@ -79,7 +98,43 @@ internal class CurrentNetworkProviderImpl(
                 Log.w(TAG, "Failed to unregister network callbacks.", exception)
             }
         }
+        initialDetectionExecutor.shutdownNow()
         listeners.clear()
+    }
+
+    private fun detectInitialNetwork(initialSnapshot: NetworkSnapshot, initialNetworkListener: NetworkChangeListener) {
+        initialDetectionExecutor.execute {
+            try {
+                if (closed.get() || networkSnapshot.get() !== initialSnapshot) {
+                    return@execute
+                }
+
+                val detectedNetwork = detectCurrentNetwork()
+                if (!closed.get()) {
+                    val initialStatePublished = networkSnapshot.compareAndSet(
+                        initialSnapshot,
+                        initialSnapshot.copy(network = detectedNetwork)
+                    )
+                    if (initialStatePublished) {
+                        initialNetworkListener.onNetworkChange(detectedNetwork)
+
+                        // A callback based network detection can happen immediately. Reapply its latest
+                        // state to attributes without emitting another network change event.
+                        val latestSnapshot = networkSnapshot.get()
+                        if (latestSnapshot.callbackObserved) {
+                            initialNetworkListener.onNetworkChange(latestSnapshot.network)
+                        }
+                    }
+                }
+            } finally {
+                initialDetectionExecutor.shutdown()
+            }
+        }
+    }
+
+    private fun invalidateInitialDetection() {
+        val currentSnapshot = networkSnapshot.get()
+        networkSnapshot.set(currentSnapshot.copy(callbackObserved = true))
     }
 
     private fun registerNetworkCallbacks(createNetworkMonitoringRequest: () -> NetworkRequest) {
@@ -98,14 +153,17 @@ internal class CurrentNetworkProviderImpl(
 
     private inner class ConnectionMonitor : NetworkCallback() {
         override fun onAvailable(network: Network) {
+            invalidateInitialDetection()
             val activeNetwork = refreshNetworkStatus()
             Log.d(TAG, "onAvailable: currentNetwork=$activeNetwork")
             notifyListeners(activeNetwork)
         }
 
         override fun onLost(network: Network) {
+            invalidateInitialDetection()
             val noNetwork = CurrentNetworkProvider.NO_NETWORK
-            currentNetwork = noNetwork
+            val currentSnapshot = networkSnapshot.get()
+            networkSnapshot.set(currentSnapshot.copy(network = noNetwork))
             Log.d(TAG, "onLost: currentNetwork=$noNetwork")
             notifyListeners(noNetwork)
         }
@@ -113,6 +171,9 @@ internal class CurrentNetworkProviderImpl(
 
     private companion object {
         private const val TAG = "CurrentNetworkProvider"
+
+        fun createInitialDetectionExecutor(): ExecutorService =
+            Executors.newSingleThreadExecutor(NamedThreadFactory("SplunkNetworkMonitor"))
 
         fun createNetworkMonitoringRequest(): NetworkRequest = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -122,4 +183,6 @@ internal class CurrentNetworkProviderImpl(
             .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
             .build()
     }
+
+    private data class NetworkSnapshot(val callbackObserved: Boolean, val network: CurrentNetwork)
 }

--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImpl.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImpl.kt
@@ -29,6 +29,7 @@ import com.splunk.rum.instrumentation.networkmonitor.internal.model.CurrentNetwo
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -91,43 +92,43 @@ internal class CurrentNetworkProviderImpl(
 
     override fun close() {
         closed.set(true)
-        callbackRef.getAndSet(null)?.let { callback ->
-            try {
-                connectivityManager.unregisterNetworkCallback(callback)
-            } catch (exception: RuntimeException) {
-                Log.w(TAG, "Failed to unregister network callbacks.", exception)
-            }
-        }
+        callbackRef.getAndSet(null)?.let(::unregisterNetworkCallback)
         initialDetectionExecutor.shutdownNow()
         listeners.clear()
     }
 
     private fun detectInitialNetwork(initialSnapshot: NetworkSnapshot, initialNetworkListener: NetworkChangeListener) {
-        initialDetectionExecutor.execute {
-            try {
-                if (closed.get() || networkSnapshot.get() !== initialSnapshot) {
-                    return@execute
-                }
+        try {
+            initialDetectionExecutor.execute {
+                try {
+                    if (closed.get() || networkSnapshot.get() !== initialSnapshot) {
+                        return@execute
+                    }
 
-                val detectedNetwork = detectCurrentNetwork()
-                if (!closed.get()) {
-                    val initialStatePublished = networkSnapshot.compareAndSet(
-                        initialSnapshot,
-                        initialSnapshot.copy(network = detectedNetwork)
-                    )
-                    if (initialStatePublished) {
-                        initialNetworkListener.onNetworkChange(detectedNetwork)
+                    val detectedNetwork = detectCurrentNetwork()
+                    if (!closed.get()) {
+                        val initialStatePublished = networkSnapshot.compareAndSet(
+                            initialSnapshot,
+                            initialSnapshot.copy(network = detectedNetwork)
+                        )
+                        if (initialStatePublished) {
+                            initialNetworkListener.onNetworkChange(detectedNetwork)
 
-                        // A callback based network detection can happen immediately. Reapply its latest
-                        // state to attributes without emitting another network change event.
-                        val latestSnapshot = networkSnapshot.get()
-                        if (latestSnapshot.callbackObserved) {
-                            initialNetworkListener.onNetworkChange(latestSnapshot.network)
+                            // A callback based network detection can happen immediately. Reapply its latest
+                            // state to attributes without emitting another network change event.
+                            val latestSnapshot = networkSnapshot.get()
+                            if (latestSnapshot.callbackObserved) {
+                                initialNetworkListener.onNetworkChange(latestSnapshot.network)
+                            }
                         }
                     }
+                } finally {
+                    initialDetectionExecutor.shutdown()
                 }
-            } finally {
-                initialDetectionExecutor.shutdown()
+            }
+        } catch (exception: RejectedExecutionException) {
+            if (!closed.get()) {
+                Log.w(TAG, "Failed to schedule initial network detection.", exception)
             }
         }
     }
@@ -145,6 +146,17 @@ internal class CurrentNetworkProviderImpl(
             connectivityManager.registerNetworkCallback(createNetworkMonitoringRequest(), callback)
         }
         callbackRef.set(callback)
+        if (closed.get() && callbackRef.compareAndSet(callback, null)) {
+            unregisterNetworkCallback(callback)
+        }
+    }
+
+    private fun unregisterNetworkCallback(callback: NetworkCallback) {
+        try {
+            connectivityManager.unregisterNetworkCallback(callback)
+        } catch (exception: RuntimeException) {
+            Log.w(TAG, "Failed to unregister network callbacks.", exception)
+        }
     }
 
     private fun notifyListeners(activeNetwork: CurrentNetwork) {

--- a/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/NetworkDetectorImpl.kt
+++ b/instrumentation/runtime/networkmonitor/src/main/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/NetworkDetectorImpl.kt
@@ -69,13 +69,17 @@ internal class NetworkDetectorImpl(private val context: Context, private val con
             ConnectivityManager.TYPE_ETHERNET -> NetworkState.TRANSPORT_WIRED
             else -> return CurrentNetworkProvider.UNKNOWN_NETWORK
         }
-        return buildCurrentNetwork(state, carrierFinder.get(), activeNetwork.subtypeName)
+        return buildCurrentNetwork(
+            state,
+            if (state == NetworkState.TRANSPORT_CELLULAR) carrierFinder.get() else null,
+            activeNetwork.subtypeName
+        )
     }
 
     private fun buildNetwork(state: NetworkState, includeSubtype: Boolean = false): CurrentNetwork =
         buildCurrentNetwork(
             state,
-            carrierFinder.get(),
+            if (state == NetworkState.TRANSPORT_CELLULAR) carrierFinder.get() else null,
             if (includeSubtype) findSubtype() else null
         )
 

--- a/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/NetworkMonitorInstrumentationTest.kt
+++ b/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/NetworkMonitorInstrumentationTest.kt
@@ -77,6 +77,20 @@ class NetworkMonitorInstrumentationTest {
     }
 
     @Test
+    fun initialNetworkNotifiesAttributeListenerWithoutEmittingNetworkChange() {
+        val provider = FakeCurrentNetworkProvider()
+        val observedTypes = mutableListOf<String?>()
+        val instrumentation = instrumentationWith(provider)
+            .addNetworkChangeListener { observedTypes += it[NETWORK_CONNECTION_TYPE] }
+
+        instrumentation.install(application, openTelemetry)
+        provider.publishInitial(CurrentNetworkProvider.NO_NETWORK)
+
+        assertEquals(listOf("unavailable"), observedTypes)
+        verify(logRecordBuilder, never()).emit()
+    }
+
+    @Test
     fun backgroundSuppressesEventButNotAttributeListener() {
         val provider = FakeCurrentNetworkProvider()
         val observedTypes = mutableListOf<String?>()
@@ -158,7 +172,12 @@ class NetworkMonitorInstrumentationTest {
 
     private class FakeCurrentNetworkProvider : CurrentNetworkProvider {
         private val listeners = mutableListOf<NetworkChangeListener>()
+        private var initialNetworkListener = NetworkChangeListener {}
         override var currentNetwork = CurrentNetworkProvider.UNKNOWN_NETWORK
+
+        override fun start(initialNetworkListener: NetworkChangeListener) {
+            this.initialNetworkListener = initialNetworkListener
+        }
 
         override fun refreshNetworkStatus(): CurrentNetwork = currentNetwork
 
@@ -177,6 +196,11 @@ class NetworkMonitorInstrumentationTest {
         fun publish(network: CurrentNetwork) {
             currentNetwork = network
             listeners.forEach { it.onNetworkChange(network) }
+        }
+
+        fun publishInitial(network: CurrentNetwork) {
+            currentNetwork = network
+            initialNetworkListener.onNetworkChange(network)
         }
     }
 }

--- a/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CarrierFinderTest.kt
+++ b/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CarrierFinderTest.kt
@@ -49,18 +49,17 @@ class CarrierFinderTest {
 
     @Test
     fun extractsModernCarrierFields() {
-        `when`(telephonyManager.simCarrierId).thenReturn(123)
         `when`(telephonyManager.simCarrierIdName).thenReturn("Example")
         `when`(telephonyManager.simOperator).thenReturn("310260")
         `when`(telephonyManager.simCountryIso).thenReturn("us")
 
         val carrier = CarrierFinder(context, telephonyManager).get()
 
-        assertEquals(123, carrier?.id)
         assertEquals("Example", carrier?.name)
         assertEquals("310", carrier?.mobileCountryCode)
         assertEquals("260", carrier?.mobileNetworkCode)
         assertEquals("us", carrier?.isoCountryCode)
+        verify(telephonyManager, never()).simCarrierId
     }
 
     @Test

--- a/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImplTest.kt
+++ b/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImplTest.kt
@@ -22,6 +22,8 @@ import android.net.Network
 import android.net.NetworkRequest
 import com.splunk.rum.instrumentation.networkmonitor.internal.model.CurrentNetwork
 import com.splunk.rum.instrumentation.networkmonitor.internal.model.NetworkState
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -44,19 +46,28 @@ class CurrentNetworkProviderImplTest {
     private val detector = mock(NetworkDetector::class.java)
     private val connectivityManager = mock(ConnectivityManager::class.java)
     private val request = mock(NetworkRequest::class.java)
+    private val initialDetectionExecutor = QueuingExecutorService()
 
     @Test
-    fun detectsInitialNetworkAndRegistersCallback() {
+    fun detectsInitialNetworkOffTheCallingThreadAndRegistersCallback() {
         val wifi = CurrentNetwork(NetworkState.TRANSPORT_WIFI)
+        val observedInitialNetworks = mutableListOf<CurrentNetwork>()
         `when`(detector.detectCurrentNetwork()).thenReturn(wifi)
 
-        val provider = createProvider()
+        val provider = createProvider { observedInitialNetworks += it }
 
-        assertEquals(wifi, provider.currentNetwork)
+        assertEquals(CurrentNetworkProvider.UNKNOWN_NETWORK, provider.currentNetwork)
+        verify(detector, never()).detectCurrentNetwork()
         verify(connectivityManager).registerNetworkCallback(
             any(NetworkRequest::class.java),
             any(ConnectivityManager.NetworkCallback::class.java)
         )
+
+        initialDetectionExecutor.runAll()
+
+        assertEquals(wifi, provider.currentNetwork)
+        assertEquals(listOf(wifi), observedInitialNetworks)
+        verify(detector).detectCurrentNetwork()
     }
 
     @Test
@@ -65,10 +76,15 @@ class CurrentNetworkProviderImplTest {
         `when`(detector.detectCurrentNetwork()).thenReturn(CurrentNetworkProvider.UNKNOWN_NETWORK)
         var requestCreations = 0
 
-        CurrentNetworkProviderImpl(detector, connectivityManager) {
+        val provider = CurrentNetworkProviderImpl(
+            detector,
+            connectivityManager,
+            initialDetectionExecutor
+        ) {
             requestCreations++
             request
         }
+        provider.start {}
 
         verify(connectivityManager).registerDefaultNetworkCallback(
             any(ConnectivityManager.NetworkCallback::class.java)
@@ -86,6 +102,7 @@ class CurrentNetworkProviderImplTest {
         val cellular = CurrentNetwork(NetworkState.TRANSPORT_CELLULAR, subType = "LTE")
         `when`(detector.detectCurrentNetwork()).thenReturn(unknown, cellular)
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
         val observed = mutableListOf<CurrentNetwork>()
         provider.addNetworkChangeListener { observed += it }
 
@@ -100,6 +117,7 @@ class CurrentNetworkProviderImplTest {
         `when`(detector.detectCurrentNetwork())
             .thenReturn(CurrentNetwork(NetworkState.TRANSPORT_WIFI))
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
         val observed = mutableListOf<CurrentNetwork>()
         provider.addNetworkChangeListener { observed += it }
 
@@ -114,6 +132,7 @@ class CurrentNetworkProviderImplTest {
         `when`(detector.detectCurrentNetwork()).thenThrow(IllegalStateException("unavailable"))
 
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
 
         assertEquals(CurrentNetworkProvider.UNKNOWN_NETWORK, provider.currentNetwork)
     }
@@ -123,6 +142,7 @@ class CurrentNetworkProviderImplTest {
         `when`(detector.detectCurrentNetwork())
             .thenReturn(CurrentNetwork(NetworkState.TRANSPORT_WIFI))
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
         val observed = mutableListOf<CurrentNetwork>()
         val listener = NetworkChangeListener { observed += it }
         provider.addNetworkChangeListener(listener)
@@ -138,6 +158,7 @@ class CurrentNetworkProviderImplTest {
         `when`(detector.detectCurrentNetwork())
             .thenReturn(CurrentNetwork(NetworkState.TRANSPORT_WIFI))
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
         val observed = mutableListOf<CurrentNetwork>()
         provider.addNetworkChangeListener { observed += it }
         val callback = registeredCallback()
@@ -165,6 +186,7 @@ class CurrentNetworkProviderImplTest {
     fun unregisterFailureIsLoggedAndDoesNotEscapeClose() {
         `when`(detector.detectCurrentNetwork()).thenReturn(CurrentNetworkProvider.UNKNOWN_NETWORK)
         val provider = createProvider()
+        initialDetectionExecutor.runAll()
         val callback = registeredCallback()
         doThrow(IllegalArgumentException("not registered"))
             .`when`(connectivityManager)
@@ -192,6 +214,8 @@ class CurrentNetworkProviderImplTest {
 
         val provider = createProvider()
 
+        initialDetectionExecutor.runAll()
+
         assertEquals(wifi, provider.currentNetwork)
         verify(
             connectivityManager,
@@ -199,12 +223,108 @@ class CurrentNetworkProviderImplTest {
         ).unregisterNetworkCallback(any(ConnectivityManager.NetworkCallback::class.java))
     }
 
-    private fun createProvider(): CurrentNetworkProviderImpl =
-        CurrentNetworkProviderImpl(detector, connectivityManager) { request }
+    @Test
+    fun callbackBeforeInitialDetectionPreventsTheInitialNetworkTrip() {
+        val cellular = CurrentNetwork(NetworkState.TRANSPORT_CELLULAR, subType = "LTE")
+        `when`(detector.detectCurrentNetwork()).thenReturn(cellular)
+        val provider = createProvider()
+
+        registeredCallback().onAvailable(mock(Network::class.java))
+        initialDetectionExecutor.runAll()
+
+        assertEquals(cellular, provider.currentNetwork)
+        verify(detector, times(1)).detectCurrentNetwork()
+    }
+
+    @Test
+    fun callbackDuringInitialDetectionPreventsItsResultFromReplacingCallbackState() {
+        val wifi = CurrentNetwork(NetworkState.TRANSPORT_WIFI)
+        val provider = createProvider()
+        val callback = registeredCallback()
+        `when`(detector.detectCurrentNetwork()).thenAnswer {
+            callback.onLost(mock(Network::class.java))
+            wifi
+        }
+
+        initialDetectionExecutor.runAll()
+
+        assertEquals(CurrentNetworkProvider.NO_NETWORK, provider.currentNetwork)
+    }
+
+    @Test
+    fun callbackAfterInitialCommitReconcilesInitialAttributesToTheLatestState() {
+        val wifi = CurrentNetwork(NetworkState.TRANSPORT_WIFI)
+        `when`(detector.detectCurrentNetwork()).thenReturn(wifi)
+        val provider = CurrentNetworkProviderImpl(
+            detector,
+            connectivityManager,
+            initialDetectionExecutor
+        ) { request }
+        val observedInitialNetworks = mutableListOf<CurrentNetwork>()
+        lateinit var callback: ConnectivityManager.NetworkCallback
+        provider.start { network ->
+            observedInitialNetworks += network
+            if (observedInitialNetworks.size == 1) {
+                callback.onLost(mock(Network::class.java))
+            }
+        }
+        callback = registeredCallback()
+
+        initialDetectionExecutor.runAll()
+
+        assertEquals(
+            listOf(wifi, CurrentNetworkProvider.NO_NETWORK),
+            observedInitialNetworks
+        )
+        assertEquals(CurrentNetworkProvider.NO_NETWORK, provider.currentNetwork)
+    }
+
+    private fun createProvider(
+        initialNetworkListener: NetworkChangeListener = NetworkChangeListener {}
+    ): CurrentNetworkProviderImpl = CurrentNetworkProviderImpl(
+        detector,
+        connectivityManager,
+        initialDetectionExecutor
+    ) { request }.also { provider -> provider.start(initialNetworkListener) }
 
     private fun registeredCallback(): ConnectivityManager.NetworkCallback {
         val captor = ArgumentCaptor.forClass(ConnectivityManager.NetworkCallback::class.java)
         verify(connectivityManager).registerNetworkCallback(any(NetworkRequest::class.java), captor.capture())
         return captor.value
+    }
+
+    private class QueuingExecutorService : AbstractExecutorService() {
+        private val tasks = ArrayDeque<Runnable>()
+        private var shutdown = false
+
+        override fun execute(command: Runnable) {
+            check(!shutdown)
+            tasks.addLast(command)
+        }
+
+        override fun shutdown() {
+            shutdown = true
+        }
+
+        override fun shutdownNow(): List<Runnable> {
+            shutdown = true
+            return buildList {
+                while (tasks.isNotEmpty()) {
+                    add(tasks.removeFirst())
+                }
+            }
+        }
+
+        override fun isShutdown(): Boolean = shutdown
+
+        override fun isTerminated(): Boolean = shutdown && tasks.isEmpty()
+
+        override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean = isTerminated
+
+        fun runAll() {
+            while (tasks.isNotEmpty()) {
+                tasks.removeFirst().run()
+            }
+        }
     }
 }

--- a/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImplTest.kt
+++ b/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/CurrentNetworkProviderImplTest.kt
@@ -23,6 +23,7 @@ import android.net.NetworkRequest
 import com.splunk.rum.instrumentation.networkmonitor.internal.model.CurrentNetwork
 import com.splunk.rum.instrumentation.networkmonitor.internal.model.NetworkState
 import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -30,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -183,6 +185,29 @@ class CurrentNetworkProviderImplTest {
     }
 
     @Test
+    fun closeDuringRegistrationUnregistersCallbackAndDoesNotScheduleInitialDetection() {
+        val provider = CurrentNetworkProviderImpl(
+            detector,
+            connectivityManager,
+            initialDetectionExecutor
+        ) { request }
+        doAnswer {
+            provider.close()
+            null
+        }.`when`(connectivityManager).registerNetworkCallback(
+            any(NetworkRequest::class.java),
+            any(ConnectivityManager.NetworkCallback::class.java)
+        )
+
+        provider.start {}
+
+        verify(connectivityManager).unregisterNetworkCallback(
+            any(ConnectivityManager.NetworkCallback::class.java)
+        )
+        verify(detector, never()).detectCurrentNetwork()
+    }
+
+    @Test
     fun unregisterFailureIsLoggedAndDoesNotEscapeClose() {
         `when`(detector.detectCurrentNetwork()).thenReturn(CurrentNetworkProvider.UNKNOWN_NETWORK)
         val provider = createProvider()
@@ -298,7 +323,9 @@ class CurrentNetworkProviderImplTest {
         private var shutdown = false
 
         override fun execute(command: Runnable) {
-            check(!shutdown)
+            if (shutdown) {
+                throw RejectedExecutionException()
+            }
             tasks.addLast(command)
         }
 

--- a/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/NetworkDetectorTest.kt
+++ b/instrumentation/runtime/networkmonitor/src/test/kotlin/com/splunk/rum/instrumentation/networkmonitor/internal/network/NetworkDetectorTest.kt
@@ -72,6 +72,25 @@ class NetworkDetectorTest {
     }
 
     @Test
+    fun wifiDoesNotReadOrIncludeCellularCarrier() {
+        val (telephonyContext, telephonyManager) = contextWithTelephonyAccess()
+        `when`(telephonyManager.simCarrierIdName).thenReturn("Example")
+        val network = mock(Network::class.java)
+        val capabilities = mock(NetworkCapabilities::class.java)
+        `when`(connectivityManager.activeNetwork).thenReturn(network)
+        `when`(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
+        `when`(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true)
+
+        val currentNetwork = NetworkDetector.create(telephonyContext, connectivityManager).detectCurrentNetwork()
+
+        assertEquals(NetworkState.TRANSPORT_WIFI, currentNetwork.state)
+        assertNull(currentNetwork.carrierName)
+        verify(telephonyManager, never()).simCarrierIdName
+        verify(telephonyManager, never()).simOperator
+        verify(telephonyManager, never()).simCountryIso
+    }
+
+    @Test
     fun unsupportedCapabilityTransportIsUnknown() {
         assertTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH, NetworkState.TRANSPORT_UNKNOWN)
     }

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessor.kt
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor
 class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+        val isNetworkEvent = span.name == NETWORK_CHANGE_EVENT_NAME
         attributes.forEach { key, value ->
             // screen.name is added onto every log record at emit time by
             // ScreenNameLogRecordProcessor. When those log records are later converted to
@@ -36,6 +37,12 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
             if (key == GlobalRumConstants.SCREEN_NAME_KEY &&
                 span.getAttribute(GlobalRumConstants.SCREEN_NAME_KEY) != null
             ) {
+                return@forEach
+            }
+            // Network change logs capture the complete network state when they are emitted.
+            // They can be converted to spans after the global network state has changed, so
+            // do not mix that later state into the event-time snapshot.
+            if (isNetworkEvent && key in NETWORK_ATTRIBUTE_KEYS) {
                 return@forEach
             }
             @Suppress("UNCHECKED_CAST")
@@ -51,6 +58,16 @@ class SplunkInternalGlobalAttributeSpanProcessor : SpanProcessor {
     override fun isEndRequired(): Boolean = true
 
     companion object {
+        private const val NETWORK_CHANGE_EVENT_NAME = "network.change"
+        private val NETWORK_ATTRIBUTE_KEYS = setOf(
+            AttributeKey.stringKey("network.connection.type"),
+            AttributeKey.stringKey("network.connection.subtype"),
+            AttributeKey.stringKey("network.carrier.name"),
+            AttributeKey.stringKey("network.carrier.mcc"),
+            AttributeKey.stringKey("network.carrier.mnc"),
+            AttributeKey.stringKey("network.carrier.icc")
+        )
+
         val attributes = MutableAttributes().apply {
             this[GlobalRumConstants.SCREEN_NAME_KEY] = GlobalRumConstants.DEFAULT_SCREEN_NAME
         }

--- a/integration/agent/internal/src/test/kotlin/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessorTest.kt
+++ b/integration/agent/internal/src/test/kotlin/com/splunk/rum/integration/agent/internal/processor/SplunkInternalGlobalAttributeSpanProcessorTest.kt
@@ -31,6 +31,8 @@ import org.mockito.Mockito.`when`
 class SplunkInternalGlobalAttributeSpanProcessorTest {
 
     private val processor = SplunkInternalGlobalAttributeSpanProcessor()
+    private val connectionType = AttributeKey.stringKey("network.connection.type")
+    private val carrierName = AttributeKey.stringKey("network.carrier.name")
 
     @Before
     fun setup() {
@@ -41,6 +43,8 @@ class SplunkInternalGlobalAttributeSpanProcessorTest {
     fun teardown() {
         SplunkInternalGlobalAttributeSpanProcessor.attributes[GlobalRumConstants.SCREEN_NAME_KEY] =
             GlobalRumConstants.DEFAULT_SCREEN_NAME
+        SplunkInternalGlobalAttributeSpanProcessor.attributes.remove(connectionType)
+        SplunkInternalGlobalAttributeSpanProcessor.attributes.remove(carrierName)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -93,6 +97,30 @@ class SplunkInternalGlobalAttributeSpanProcessorTest {
             GlobalRumConstants.SCREEN_NAME_KEY as AttributeKey<Any>,
             "CurrentScreen" as Any
         )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `does not mix current network globals into network event snapshot`() {
+        SplunkInternalGlobalAttributeSpanProcessor.attributes[connectionType] = "wifi"
+        SplunkInternalGlobalAttributeSpanProcessor.attributes[carrierName] = "Example"
+        val span = mockSpan(name = "network.change", existingScreenName = null)
+
+        processor.onStart(Context.root(), span)
+
+        verify(span, never()).setAttribute(connectionType as AttributeKey<Any>, "wifi" as Any)
+        verify(span, never()).setAttribute(carrierName as AttributeKey<Any>, "Example" as Any)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `applies current network globals to ordinary spans`() {
+        SplunkInternalGlobalAttributeSpanProcessor.attributes[connectionType] = "wifi"
+        val span = mockSpan(name = "HTTP GET", existingScreenName = null)
+
+        processor.onStart(Context.root(), span)
+
+        verify(span).setAttribute(connectionType as AttributeKey<Any>, "wifi" as Any)
     }
 
     @Test


### PR DESCRIPTION

### Description

Moves the very first network detection off the main thread. This first detection is used to capture offline case when app starts when device is offline. Global network span attributes are updated from this first detection without emitting a `network.change` event. 

`ConnectivityManager` callbacks (`onAvailable()`, `onLost()`) driven global network attribute updates and  `network.change` event emission stays the same. It happens outside the main thread. 

Also removes the `simCarrierId` probe.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Perform these steps on one new and one old API levels (I used API 33 and API 23) 
-- Build and run the sample app
-- Validate offline scenario doesn't emit a `network.change` event but updates global attributes to capture `network.connection.type` = unavailable. 
-- Validate general scenarios - network transitions are captured as expected via `network.change ` events and global attributes. 

