### PR TITLE
DEMRUM-5638: Remove all opentelemetry-android dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Unreleased
 
+##### Enhancements:
+* Removed the OpenTelemetry Android runtime dependency
+
 ### Version 2.3.2 - 2026-07-10
 
 ##### New features:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add the Splunk RUM agent library to your app module's `build.gradle` file depend
 implementation("com.splunk:splunk-otel-android:2.3.2")
 ```
 
-**Important:** Remove the following line from your dependencies if present, as the upstream OpenTelemetry Android repo is already linked in our SDK:
+The Splunk RUM SDK does not require the OpenTelemetry Android instrumentation artifact. Remove the following dependency if you previously added it only for this SDK:
 ```
 implementation("io.opentelemetry.android:instrumentation:2.0.0")
 ```

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -89,9 +89,7 @@ object Dependencies {
 
     object Otel {
         private const val oTelInstrumentationBomAlpha = "2.15.0-alpha"
-        const val otelAndroidBomVersion = "0.11.0-alpha"
         const val instrumentationBomAlpha = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$oTelInstrumentationBomAlpha"
-        const val androidBom = "io.opentelemetry.android:opentelemetry-android-bom:$otelAndroidBomVersion"
 
         const val api = "io.opentelemetry:opentelemetry-api"
         const val sdk = "io.opentelemetry:opentelemetry-sdk"
@@ -103,10 +101,5 @@ object Dependencies {
         const val instrumentationApi = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api"
         const val instrumentationApiIncubator =
             "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator"
-
-        const val androidSession = "io.opentelemetry.android:session"
-        const val androidServices = "io.opentelemetry.android:services"
-        const val androidCommon = "io.opentelemetry.android:common"
-        const val androidInstrumentation = "io.opentelemetry.android.instrumentation:android-instrumentation"
     }
 }

--- a/common/otel/src/main/AndroidManifest.xml
+++ b/common/otel/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application>
         <service
             android:name="com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob"

--- a/instrumentation/runtime/anr/build.gradle.kts
+++ b/instrumentation/runtime/anr/build.gradle.kts
@@ -23,7 +23,6 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":common:otel"))
@@ -35,7 +34,6 @@ dependencies {
     implementation(Dependencies.Common.logger)
     implementation(Dependencies.Common.utils)
 
-    testImplementation(platform(Dependencies.Otel.androidBom))
     testImplementation(Dependencies.Otel.sdk)
     testImplementation(Dependencies.Test.junit)
     testImplementation(Dependencies.Test.robolectric)

--- a/instrumentation/runtime/anr/src/main/kotlin/com/splunk/rum/instrumentation/anr/internal/AnrReporterInstrumentation.kt
+++ b/instrumentation/runtime/anr/src/main/kotlin/com/splunk/rum/instrumentation/anr/internal/AnrReporterInstrumentation.kt
@@ -18,7 +18,6 @@
 package com.splunk.rum.instrumentation.anr.internal
 
 import android.app.Application
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.splunk.rum.agent.common.utils.extensions.isStartedInForeground
@@ -49,8 +48,7 @@ class AnrReporterInstrumentation {
     }
 
     /** Installs the ANR watchdog and starts foreground-only detection. */
-    fun install(context: Context, openTelemetry: OpenTelemetry) {
-        val application = context.applicationContext as Application
+    fun install(application: Application, openTelemetry: OpenTelemetry) {
         val reporter = AnrReporter(openTelemetry, additionalExtractors.toList())
 
         val mainLooper = Looper.getMainLooper()

--- a/instrumentation/runtime/anr/src/main/kotlin/com/splunk/rum/instrumentation/anr/internal/extractor/RumAnrAttributesExtractor.kt
+++ b/instrumentation/runtime/anr/src/main/kotlin/com/splunk/rum/instrumentation/anr/internal/extractor/RumAnrAttributesExtractor.kt
@@ -17,7 +17,6 @@
 package com.splunk.rum.instrumentation.anr.internal.extractor
 
 import android.app.Application
-import android.content.Context
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
 import com.splunk.rum.common.utils.AppStateObserver
 import io.opentelemetry.api.common.AttributesBuilder
@@ -28,13 +27,13 @@ import io.opentelemetry.api.common.AttributesBuilder
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-class RumAnrAttributesExtractor(context: Context) : AnrAttributesExtractor {
+class RumAnrAttributesExtractor(application: Application) : AnrAttributesExtractor {
 
     private var appState: String? = null
 
     init {
         AppStateObserver.listeners += AppStateObserverListener()
-        AppStateObserver.attach(context.applicationContext as Application)
+        AppStateObserver.attach(application)
     }
 
     override fun extract(attributes: AttributesBuilder, stackTrace: Array<StackTraceElement>) {

--- a/instrumentation/runtime/anr/src/test/kotlin/com/splunk/rum/instrumentation/anr/internal/extractor/RumAnrAttributesExtractorTest.kt
+++ b/instrumentation/runtime/anr/src/test/kotlin/com/splunk/rum/instrumentation/anr/internal/extractor/RumAnrAttributesExtractorTest.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.instrumentation.anr.internal.extractor
 
-import android.content.Context
+import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
 import io.opentelemetry.api.common.Attributes
@@ -33,8 +33,8 @@ class RumAnrAttributesExtractorTest {
 
     @Before
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        extractor = RumAnrAttributesExtractor(context)
+        val application: Application = ApplicationProvider.getApplicationContext()
+        extractor = RumAnrAttributesExtractor(application)
     }
 
     @Test

--- a/instrumentation/runtime/crash/build.gradle.kts
+++ b/instrumentation/runtime/crash/build.gradle.kts
@@ -23,7 +23,6 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":common:otel"))

--- a/instrumentation/runtime/crash/src/main/kotlin/com/splunk/rum/instrumentation/crash/internal/CrashReporterInstrumentation.kt
+++ b/instrumentation/runtime/crash/src/main/kotlin/com/splunk/rum/instrumentation/crash/internal/CrashReporterInstrumentation.kt
@@ -17,7 +17,7 @@
 
 package com.splunk.rum.instrumentation.crash.internal
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.instrumentation.crash.internal.extractor.CrashAttributesExtractor
 import com.splunk.rum.instrumentation.crash.internal.extractor.RuntimeDetailsExtractor
 import io.opentelemetry.api.OpenTelemetry
@@ -43,11 +43,11 @@ class CrashReporterInstrumentation {
     }
 
     /** Installs the crash reporting uncaught exception handler. No-ops if already installed. */
-    fun install(context: Context, openTelemetry: OpenTelemetry) {
+    fun install(application: Application, openTelemetry: OpenTelemetry) {
         if (!installed.compareAndSet(false, true)) {
             return
         }
-        val extractors = additionalExtractors + RuntimeDetailsExtractor.create(context.applicationContext)
+        val extractors = additionalExtractors + RuntimeDetailsExtractor.create(application)
         CrashReporter(openTelemetry, extractors).install()
     }
 }

--- a/instrumentation/runtime/crash/src/main/kotlin/com/splunk/rum/instrumentation/crash/internal/extractor/RumCrashAttributesExtractor.kt
+++ b/instrumentation/runtime/crash/src/main/kotlin/com/splunk/rum/instrumentation/crash/internal/extractor/RumCrashAttributesExtractor.kt
@@ -17,7 +17,6 @@
 package com.splunk.rum.instrumentation.crash.internal.extractor
 
 import android.app.Application
-import android.content.Context
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
 import com.splunk.rum.common.utils.AppStateObserver
 import io.opentelemetry.api.common.AttributesBuilder
@@ -29,14 +28,14 @@ import java.util.concurrent.atomic.AtomicBoolean
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-class RumCrashAttributesExtractor(context: Context) : CrashAttributesExtractor {
+class RumCrashAttributesExtractor(application: Application) : CrashAttributesExtractor {
 
     private val crashHappened = AtomicBoolean(false)
     private var appState: String? = null
 
     init {
         AppStateObserver.listeners += AppStateObserverListener()
-        AppStateObserver.attach(context.applicationContext as Application)
+        AppStateObserver.attach(application)
     }
 
     override fun extract(attributes: AttributesBuilder, crashDetails: CrashDetails) {

--- a/instrumentation/runtime/crash/src/test/kotlin/com/splunk/rum/instrumentation/crash/internal/CrashReporterInstrumentationTest.kt
+++ b/instrumentation/runtime/crash/src/test/kotlin/com/splunk/rum/instrumentation/crash/internal/CrashReporterInstrumentationTest.kt
@@ -17,7 +17,7 @@
 
 package com.splunk.rum.instrumentation.crash.internal
 
-import android.content.Context
+import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.opentelemetry.api.OpenTelemetry
 import org.junit.After
@@ -31,7 +31,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CrashReporterInstrumentationTest {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val application: Application = ApplicationProvider.getApplicationContext()
     private var originalHandler: Thread.UncaughtExceptionHandler? = null
 
     @Before
@@ -48,10 +48,10 @@ class CrashReporterInstrumentationTest {
     fun `install is idempotent and does not re-wrap the default handler`() {
         val instrumentation = CrashReporterInstrumentation()
 
-        instrumentation.install(context, OpenTelemetry.noop())
+        instrumentation.install(application, OpenTelemetry.noop())
         val afterFirst = Thread.getDefaultUncaughtExceptionHandler()
 
-        instrumentation.install(context, OpenTelemetry.noop())
+        instrumentation.install(application, OpenTelemetry.noop())
         val afterSecond = Thread.getDefaultUncaughtExceptionHandler()
 
         assertTrue(afterFirst is CrashReportingExceptionHandler)

--- a/instrumentation/runtime/crash/src/test/kotlin/com/splunk/rum/instrumentation/crash/internal/extractor/RumCrashAttributesExtractorTest.kt
+++ b/instrumentation/runtime/crash/src/test/kotlin/com/splunk/rum/instrumentation/crash/internal/extractor/RumCrashAttributesExtractorTest.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.instrumentation.crash.internal.extractor
 
-import android.content.Context
+import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
 import io.opentelemetry.api.common.Attributes
@@ -33,8 +33,8 @@ class RumCrashAttributesExtractorTest {
 
     @Before
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        extractor = RumCrashAttributesExtractor(context)
+        val application: Application = ApplicationProvider.getApplicationContext()
+        extractor = RumCrashAttributesExtractor(application)
     }
 
     @Test

--- a/instrumentation/runtime/slowrendering/build.gradle.kts
+++ b/instrumentation/runtime/slowrendering/build.gradle.kts
@@ -23,14 +23,12 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(Dependencies.Otel.api)
 
     implementation(Dependencies.Common.logger)
 
-    testImplementation(platform(Dependencies.Otel.androidBom))
     testImplementation(Dependencies.Otel.sdk)
     testImplementation(Dependencies.Test.junit)
     testImplementation(Dependencies.Test.robolectric)

--- a/instrumentation/runtime/slowrendering/src/main/kotlin/com/splunk/rum/instrumentation/slowrendering/internal/SlowRenderingInstrumentation.kt
+++ b/instrumentation/runtime/slowrendering/src/main/kotlin/com/splunk/rum/instrumentation/slowrendering/internal/SlowRenderingInstrumentation.kt
@@ -18,7 +18,6 @@
 package com.splunk.rum.instrumentation.slowrendering.internal
 
 import android.app.Application
-import android.content.Context
 import android.os.Build
 import com.splunk.rum.common.logger.Logger
 import io.opentelemetry.api.OpenTelemetry
@@ -47,7 +46,7 @@ class SlowRenderingInstrumentation {
     }
 
     /** Registers the frame-metrics listeners and starts polling. No-op below API 24. */
-    fun install(context: Context, openTelemetry: OpenTelemetry) {
+    fun install(application: Application, openTelemetry: OpenTelemetry) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Logger.w(
                 TAG,
@@ -56,7 +55,6 @@ class SlowRenderingInstrumentation {
             return
         }
 
-        val application = context.applicationContext as Application
         val detector = SlowRenderListener(
             openTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME),
             slowRenderingDetectionPollInterval

--- a/integration/agent/api/build.gradle.kts
+++ b/integration/agent/api/build.gradle.kts
@@ -24,7 +24,6 @@ android {
 
 dependencies {
     api(platform(Dependencies.Otel.instrumentationBomAlpha))
-    api(platform(Dependencies.Otel.androidBom))
 
     api(project(":common:otel"))
     api(project(":integration:agent:common"))

--- a/integration/agent/internal/build.gradle.kts
+++ b/integration/agent/internal/build.gradle.kts
@@ -23,15 +23,10 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     api(project(":integration:agent:common"))
     implementation(project(":common:otel"))
     implementation(project(":common:storage"))
     implementation(project(":common:utils"))
-
-    implementation(Dependencies.Otel.androidSession)
-    implementation(Dependencies.Otel.androidInstrumentation)
 
     implementation(Dependencies.Common.logger)
     implementation(Dependencies.Common.http)

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
@@ -30,28 +30,16 @@ import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.model.Module
 import com.splunk.rum.integration.agent.internal.session.ISplunkSessionManager
 import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
-import io.opentelemetry.android.instrumentation.InstallationContext
-import io.opentelemetry.android.session.SessionManager
-import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import java.util.concurrent.TimeUnit
 
 class AgentIntegration private constructor(context: Context) {
     val sessionManager: ISplunkSessionManager
-    val listeners: MutableSet<Listener> = HashSet()
+    internal val listeners: MutableSet<Listener> = HashSet()
     var globalAttributes: Attributes = Attributes.empty()
         private set
-
-    // The opentelemetry-android InstallationContext API needs an argument of type
-    // io.opentelemetry.android.session.SessionManager. val oTelSessionManager is a no-op definition of same.
-    val oTelSessionManager = object : SessionManager {
-        override fun getSessionId(): String = "dummy-session-id"
-
-        override fun addObserver(observer: SessionObserver) {
-            // no-op
-        }
-    }
 
     init {
         val storage = AgentStorage.attach(context)
@@ -59,7 +47,7 @@ class AgentIntegration private constructor(context: Context) {
     }
 
     fun install(
-        context: Context,
+        application: Application,
         openTelemetry: OpenTelemetrySdk,
         moduleConfigurations: List<ModuleConfiguration>,
         globalAttributes: Attributes
@@ -79,7 +67,7 @@ class AgentIntegration private constructor(context: Context) {
                     .emit()
             }
         }
-        sessionManager.install(context)
+        sessionManager.install(application)
 
         val seenConfigurationNames = mutableSetOf<String>()
 
@@ -91,19 +79,17 @@ class AgentIntegration private constructor(context: Context) {
             val module = modules[config.name] ?: Module(config.name)
             modules[config.name] = module.copy(configuration = config)
         }
-        val oTelInstallationContext =
-            InstallationContext(context.applicationContext as Application, openTelemetry, oTelSessionManager)
-        listeners.forEachFast { it.onInstall(context, oTelInstallationContext, moduleConfigurations) }
+        listeners.forEachFast { it.onInstall(application, openTelemetry, moduleConfigurations) }
 
         registerModuleInitializationEnd(MODULE_NAME)
 
         listeners.forEachFast { it.onPostInstall() }
     }
 
-    interface Listener {
+    internal interface Listener {
         fun onInstall(
-            context: Context,
-            oTelInstallationContext: InstallationContext,
+            application: Application,
+            openTelemetry: OpenTelemetry,
             moduleConfigurations: List<ModuleConfiguration>
         )
 

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
@@ -16,12 +16,13 @@
 
 package com.splunk.rum.integration.agent.internal.module
 
+import android.app.Application
 import android.content.Context
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.session.ISplunkSessionManager
 import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 
 abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultModuleConfiguration: T) {
@@ -47,8 +48,8 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
     protected open fun onAttach(context: Context) {}
 
     protected abstract fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     )
 
@@ -60,16 +61,16 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
 
     private val installationListener = object : AgentIntegration.Listener {
         override fun onInstall(
-            context: Context,
-            oTelInstallationContext: InstallationContext,
+            application: Application,
+            openTelemetry: OpenTelemetry,
             moduleConfigurations: List<ModuleConfiguration>
         ) {
             val clazz = defaultModuleConfiguration::class
 
             moduleConfiguration = moduleConfigurations.find { it::class == clazz } as? T ?: defaultModuleConfiguration
-            this@ModuleIntegration.globalAttributes = AgentIntegration.obtainInstance(context).globalAttributes
+            this@ModuleIntegration.globalAttributes = AgentIntegration.obtainInstance(application).globalAttributes
             AgentIntegration.registerModuleInitializationStart(defaultModuleConfiguration.name)
-            this@ModuleIntegration.onInstall(context, oTelInstallationContext, moduleConfigurations)
+            this@ModuleIntegration.onInstall(application, openTelemetry, moduleConfigurations)
             AgentIntegration.registerModuleInitializationEnd(defaultModuleConfiguration.name)
         }
 

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/session/SplunkSessionManager.kt
@@ -17,7 +17,6 @@
 package com.splunk.rum.integration.agent.internal.session
 
 import android.app.Application
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.agent.common.storage.SessionId as SessionIdStorageData
@@ -37,7 +36,7 @@ interface ISplunkSessionManager {
     val previousSessionId: String?
     val sessionListeners: MutableSet<SessionListener>
 
-    fun install(context: Context)
+    fun install(application: Application)
     fun trackSessionActivity()
     fun reset()
     fun sessionId(timestamp: Long): String
@@ -50,7 +49,7 @@ object NoOpSplunkSessionManager : ISplunkSessionManager {
     override val sessionStart: Long = 0L
     override val sessionLastActivity: Long = 0L
     override val sessionListeners: MutableSet<SessionListener> = mutableSetOf()
-    override fun install(context: Context) = Unit
+    override fun install(application: Application) = Unit
     override fun trackSessionActivity() = Unit
     override fun reset() = Unit
 
@@ -103,11 +102,11 @@ class SplunkSessionManager internal constructor(private val agentStorage: IAgent
 
     private var maxSessionLength: Long = DEFAULT_SESSION_LENGTH
 
-    override fun install(context: Context) {
+    override fun install(application: Application) {
         createNewSessionIfNeeded()
 
         appStateObserver.listeners.add(AppStateObserverListener())
-        appStateObserver.attach(context.applicationContext as Application)
+        appStateObserver.attach(application)
     }
 
     override fun reset() {

--- a/integration/anr/build.gradle.kts
+++ b/integration/anr/build.gradle.kts
@@ -23,14 +23,12 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
     implementation(project(":instrumentation:runtime:anr"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Otel.api)
 
     implementation(Dependencies.Common.logger)
@@ -40,4 +38,3 @@ dependencies {
     testImplementation(Dependencies.Test.robolectric)
     testImplementation(Dependencies.Test.androidXTestCore)
 }
-

--- a/integration/anr/src/main/kotlin/com/splunk/rum/integration/anr/AnrModuleIntegration.kt
+++ b/integration/anr/src/main/kotlin/com/splunk/rum/integration/anr/AnrModuleIntegration.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.integration.anr
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.anr.internal.AnrReporterInstrumentation
 import com.splunk.rum.instrumentation.anr.internal.extractor.RumAnrAttributesExtractor
@@ -24,7 +24,7 @@ import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.common.module.find
 import com.splunk.rum.integration.agent.internal.legacy.LegacyAnrModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object AnrModuleIntegration : ModuleIntegration<AnrModuleConfiguration>(
     defaultModuleConfiguration = AnrModuleConfiguration()
@@ -33,8 +33,8 @@ internal object AnrModuleIntegration : ModuleIntegration<AnrModuleConfiguration>
     private const val TAG = "AnrIntegration"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -45,8 +45,8 @@ internal object AnrModuleIntegration : ModuleIntegration<AnrModuleConfiguration>
         if (isEnabled) {
             Logger.d(TAG, "Installing ANR reporter")
             val anrReporterInstrumentation = AnrReporterInstrumentation()
-            anrReporterInstrumentation.addAttributesExtractor(RumAnrAttributesExtractor(context))
-            anrReporterInstrumentation.install(context, oTelInstallationContext.openTelemetry)
+            anrReporterInstrumentation.addAttributesExtractor(RumAnrAttributesExtractor(application))
+            anrReporterInstrumentation.install(application, openTelemetry)
         } else {
             Logger.d(TAG, "ANR reporting is disabled")
         }

--- a/integration/applicationlifecycle/build.gradle.kts
+++ b/integration/applicationlifecycle/build.gradle.kts
@@ -23,12 +23,9 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Common.utils)
     implementation(Dependencies.Common.logger)
 }

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -27,7 +27,7 @@ import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
 import com.splunk.rum.integration.applicationlifecycle.model.AppState
 import com.splunk.rum.integration.applicationlifecycle.model.ApplicationLifecycleData
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import java.util.concurrent.TimeUnit
 
 internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<ApplicationLifecycleModuleConfiguration>(
@@ -46,8 +46,8 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
     }
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")

--- a/integration/crash/build.gradle.kts
+++ b/integration/crash/build.gradle.kts
@@ -23,14 +23,12 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
-    
+
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
     implementation(project(":instrumentation:runtime:crash"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Otel.api)
 
     implementation(Dependencies.Common.logger)

--- a/integration/crash/src/main/kotlin/com/splunk/rum/integration/crash/CrashModuleIntegration.kt
+++ b/integration/crash/src/main/kotlin/com/splunk/rum/integration/crash/CrashModuleIntegration.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.integration.crash
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.crash.internal.CrashReporterInstrumentation
 import com.splunk.rum.instrumentation.crash.internal.extractor.RumCrashAttributesExtractor
@@ -24,7 +24,7 @@ import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.common.module.find
 import com.splunk.rum.integration.agent.internal.legacy.LegacyCrashModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object CrashModuleIntegration : ModuleIntegration<CrashModuleConfiguration>(
     defaultModuleConfiguration = CrashModuleConfiguration()
@@ -33,8 +33,8 @@ internal object CrashModuleIntegration : ModuleIntegration<CrashModuleConfigurat
     private const val TAG = "CrashIntegration"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -45,8 +45,8 @@ internal object CrashModuleIntegration : ModuleIntegration<CrashModuleConfigurat
         if (isEnabled) {
             Logger.d(TAG, "Installing crash reporter")
             val crashReporterInstrumentation = CrashReporterInstrumentation()
-            crashReporterInstrumentation.addAttributesExtractor(RumCrashAttributesExtractor(context))
-            crashReporterInstrumentation.install(context, oTelInstallationContext.openTelemetry)
+            crashReporterInstrumentation.addAttributesExtractor(RumCrashAttributesExtractor(application))
+            crashReporterInstrumentation.install(application, openTelemetry)
         } else {
             Logger.d(TAG, "Crash reporting is disabled")
         }

--- a/integration/httpurlconnection-auto/build.gradle.kts
+++ b/integration/httpurlconnection-auto/build.gradle.kts
@@ -23,7 +23,6 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":integration:agent:internal"))
@@ -31,7 +30,6 @@ dependencies {
     implementation(project(":common:otel"))
     implementation(project(":common:utils"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Otel.instrumentationApi)
 
     implementation(Dependencies.Common.logger)

--- a/integration/httpurlconnection-auto/src/main/kotlin/com/splunk/rum/integration/httpurlconnection/auto/HttpURLModuleIntegration.kt
+++ b/integration/httpurlconnection-auto/src/main/kotlin/com/splunk/rum/integration/httpurlconnection/auto/HttpURLModuleIntegration.kt
@@ -16,12 +16,12 @@
 
 package com.splunk.rum.integration.httpurlconnection.auto
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.httpurlconnection.auto.HttpUrlInstrumentation
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object HttpURLModuleIntegration : ModuleIntegration<HttpURLModuleConfiguration>(
     defaultModuleConfiguration = HttpURLModuleConfiguration()
@@ -30,8 +30,8 @@ internal object HttpURLModuleIntegration : ModuleIntegration<HttpURLModuleConfig
     private const val TAG = "HttpURLIntegration"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -49,7 +49,7 @@ internal object HttpURLModuleIntegration : ModuleIntegration<HttpURLModuleConfig
                     .takeIf { it.isNotEmpty() }
                     ?.let { capturedResponseHeaders = it }
 
-                install(oTelInstallationContext.openTelemetry)
+                install(openTelemetry)
             }
         }
     }

--- a/integration/interactions/build.gradle.kts
+++ b/integration/interactions/build.gradle.kts
@@ -35,8 +35,5 @@ dependencies {
 
     compileOnly(Dependencies.Android.Compose.ui)
 
-    implementation(platform(Dependencies.Otel.androidBom))
-    implementation(Dependencies.Otel.androidInstrumentation)
-
     testImplementation(Dependencies.Test.junit)
 }

--- a/integration/interactions/src/main/kotlin/com/splunk/rum/integration/interactions/InteractionsModuleIntegration.kt
+++ b/integration/interactions/src/main/kotlin/com/splunk/rum/integration/interactions/InteractionsModuleIntegration.kt
@@ -36,7 +36,7 @@ import com.splunk.rum.integration.agent.internal.identification.ComposeElementId
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
 import com.splunk.rum.integration.agent.internal.utils.runIfComposeUiExists
 import com.splunk.rum.integration.interactions.api.InteractionCapture
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import java.util.concurrent.TimeUnit
 
 internal object InteractionsModuleIntegration : ModuleIntegration<InteractionsModuleConfiguration>(
@@ -64,8 +64,8 @@ internal object InteractionsModuleIntegration : ModuleIntegration<InteractionsMo
     }
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         // No-op, as Interactions does not require any specific installation steps.

--- a/integration/lifecycle/build.gradle.kts
+++ b/integration/lifecycle/build.gradle.kts
@@ -23,15 +23,11 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Common.utils)
     implementation(Dependencies.Common.logger)
-    
+
     implementation(Dependencies.Android.fragmentKtx)
 }
-

--- a/integration/lifecycle/src/main/kotlin/com/splunk/rum/integration/lifecycle/LifecycleModuleIntegration.kt
+++ b/integration/lifecycle/src/main/kotlin/com/splunk/rum/integration/lifecycle/LifecycleModuleIntegration.kt
@@ -17,7 +17,6 @@
 package com.splunk.rum.integration.lifecycle
 
 import android.app.Application
-import android.content.Context
 import android.os.Build
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
@@ -26,7 +25,7 @@ import com.splunk.rum.integration.lifecycle.callback.ActivityLifecycleCallback
 import com.splunk.rum.integration.lifecycle.callback.FragmentActivityCallback21
 import com.splunk.rum.integration.lifecycle.callback.FragmentActivityCallback29
 import com.splunk.rum.integration.lifecycle.callback.FragmentLifecycleCallback
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 /**
  * Module integration for capturing UI lifecycle events (Activity and Fragment lifecycle transitions).
@@ -42,8 +41,8 @@ internal object LifecycleModuleIntegration : ModuleIntegration<LifecycleModuleCo
     private var emitter: LifecycleEventEmitter? = null
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall() called")
@@ -55,7 +54,6 @@ internal object LifecycleModuleIntegration : ModuleIntegration<LifecycleModuleCo
 
         Logger.d(TAG, "Lifecycle module is enabled. Registering lifecycle callbacks.")
 
-        val application = context.applicationContext as Application
         val lifecycleEmitter = LifecycleEventEmitter(moduleConfiguration.allowedEvents)
         emitter = lifecycleEmitter
 

--- a/integration/navigation/build.gradle.kts
+++ b/integration/navigation/build.gradle.kts
@@ -27,14 +27,10 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:internal"))
     implementation(project(":integration:agent:api"))
     implementation(project(":common:utils"))
     implementation(project(":common:otel"))
-
-    implementation(Dependencies.Otel.androidInstrumentation)
 
     implementation(Dependencies.Android.fragmentKtx)
 

--- a/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
+++ b/integration/navigation/src/main/kotlin/com/splunk/rum/integration/navigation/NavigationModuleIntegration.kt
@@ -31,7 +31,7 @@ import com.splunk.rum.integration.navigation.automatic.callback.NavigationActivi
 import com.splunk.rum.integration.navigation.automatic.callback.NavigationFragmentActivityCallback21
 import com.splunk.rum.integration.navigation.automatic.callback.NavigationFragmentActivityCallback29
 import com.splunk.rum.integration.navigation.automatic.callback.NavigationFragmentCallback
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import java.lang.ref.WeakReference
 
@@ -65,8 +65,8 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
     }
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall")
@@ -75,7 +75,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
             Navigation.instance.composeTracker = null
             Navigation.instance.clearTrackerConfig()
             emitter.clearCache()
-            (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
+            application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
             currentActivityReference = null
             return
         }
@@ -85,8 +85,6 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
 
         if (moduleConfiguration.isAutomatedTrackingEnabled) {
             Logger.d(TAG, "Navigation module automated tracking enabled. Registering navigation callbacks.")
-
-            val application = context.applicationContext as Application
 
             registerActivityLifecycle(application, detector)
             registerFragmentLifecycle(application, detector)
@@ -108,7 +106,7 @@ internal object NavigationModuleIntegration : ModuleIntegration<NavigationModule
 
         Navigation.instance.setTrackerConfig(detector, moduleConfiguration.navigationEventProcessor)
 
-        (context as Application).unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
+        application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacksAdapter)
         currentActivityReference = null
     }
 

--- a/integration/networkmonitor/build.gradle.kts
+++ b/integration/networkmonitor/build.gradle.kts
@@ -23,14 +23,12 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":integration:agent:internal"))
     implementation(project(":instrumentation:runtime:networkmonitor"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
-
+    implementation(Dependencies.Otel.api)
     implementation(Dependencies.Otel.semConvIncubating)
 
     implementation(Dependencies.Common.logger)

--- a/integration/networkmonitor/src/main/kotlin/com/splunk/rum/integration/networkmonitor/NetworkMonitorModuleIntegration.kt
+++ b/integration/networkmonitor/src/main/kotlin/com/splunk/rum/integration/networkmonitor/NetworkMonitorModuleIntegration.kt
@@ -16,7 +16,7 @@
 
 package com.splunk.rum.integration.networkmonitor
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.networkmonitor.internal.NetworkMonitorInstrumentation
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
@@ -24,7 +24,7 @@ import com.splunk.rum.integration.agent.common.module.find
 import com.splunk.rum.integration.agent.internal.legacy.LegacyNetworkMonitorModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
 import com.splunk.rum.integration.agent.internal.processor.SplunkInternalGlobalAttributeSpanProcessor
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE
 import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NetworkConnectionTypeIncubatingValues.UNKNOWN
@@ -36,8 +36,8 @@ internal object NetworkMonitorModuleIntegration : ModuleIntegration<NetworkMonit
     private const val TAG = "NetworkMonitorIntegration"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -59,7 +59,7 @@ internal object NetworkMonitorModuleIntegration : ModuleIntegration<NetworkMonit
                         attributes
                     )
                 }
-                install(oTelInstallationContext.application, oTelInstallationContext.openTelemetry)
+                install(application, openTelemetry)
             }
         }
     }

--- a/integration/okhttp3-auto/build.gradle.kts
+++ b/integration/okhttp3-auto/build.gradle.kts
@@ -23,12 +23,9 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:internal"))
     implementation(project(":instrumentation:runtime:okhttp3-auto"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
-
+    implementation(Dependencies.Otel.api)
     implementation(Dependencies.Common.logger)
 }

--- a/integration/okhttp3-auto/src/main/kotlin/com/splunk/rum/integration/okhttp3/auto/OkHttp3AutoModuleIntegration.kt
+++ b/integration/okhttp3-auto/src/main/kotlin/com/splunk/rum/integration/okhttp3/auto/OkHttp3AutoModuleIntegration.kt
@@ -16,12 +16,12 @@
 
 package com.splunk.rum.integration.okhttp3.auto
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.okhttp3.auto.OkHttpInstrumentation
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object OkHttp3AutoModuleIntegration : ModuleIntegration<OkHttp3AutoModuleConfiguration>(
     defaultModuleConfiguration = OkHttp3AutoModuleConfiguration()
@@ -30,8 +30,8 @@ internal object OkHttp3AutoModuleIntegration : ModuleIntegration<OkHttp3AutoModu
     private const val TAG = "OkHttp3Integration"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -47,7 +47,7 @@ internal object OkHttp3AutoModuleIntegration : ModuleIntegration<OkHttp3AutoModu
                     .takeIf { it.isNotEmpty() }
                     ?.let { capturedResponseHeaders = it }
 
-                install(oTelInstallationContext.openTelemetry)
+                install(openTelemetry)
             }
         }
     }

--- a/integration/okhttp3-manual/build.gradle.kts
+++ b/integration/okhttp3-manual/build.gradle.kts
@@ -23,13 +23,9 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:api"))
     implementation(project(":integration:agent:internal"))
     implementation(project(":instrumentation:runtime:okhttp3-manual"))
-
-    implementation(Dependencies.Otel.androidInstrumentation)
 
     /**
      * Okio must be explicitly included since a newer version is being enforced than what is transitively used by OkHttp.

--- a/integration/okhttp3-manual/src/main/kotlin/com/splunk/rum/integration/okhttp3/manual/OkHttp3ManualModuleIntegration.kt
+++ b/integration/okhttp3-manual/src/main/kotlin/com/splunk/rum/integration/okhttp3/manual/OkHttp3ManualModuleIntegration.kt
@@ -16,12 +16,12 @@
 
 package com.splunk.rum.integration.okhttp3.manual
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.okhttp3.OkHttpTelemetry
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object OkHttp3ManualModuleIntegration : ModuleIntegration<OkHttp3ManualModuleConfiguration>(
     defaultModuleConfiguration = OkHttp3ManualModuleConfiguration()
@@ -32,14 +32,14 @@ internal object OkHttp3ManualModuleIntegration : ModuleIntegration<OkHttp3Manual
         private set
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
 
         // Setup OkHttp3 manual instrumentation
-        okHttpTelemetry = OkHttpTelemetry.builder(oTelInstallationContext.openTelemetry)
+        okHttpTelemetry = OkHttpTelemetry.builder(openTelemetry)
             .apply {
                 moduleConfiguration.capturedRequestHeaders.takeIf { it.isNotEmpty() }
                     ?.let { setCapturedRequestHeaders(it) }

--- a/integration/sessionreplay/build.gradle.kts
+++ b/integration/sessionreplay/build.gradle.kts
@@ -23,13 +23,9 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:api"))
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
-
-    implementation(Dependencies.Otel.androidInstrumentation)
 
     implementation(Dependencies.SessionReplay.instrumentationSessionRecordingCore)
     implementation(Dependencies.SessionReplay.instrumentationSessionRecordingInteractions)

--- a/integration/sessionreplay/src/main/kotlin/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
+++ b/integration/sessionreplay/src/main/kotlin/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.sessionreplay
 
+import android.app.Application
 import android.content.Context
 import android.webkit.WebView
 import com.splunk.android.instrumentation.recording.core.api.DataListener
@@ -35,7 +36,7 @@ import com.splunk.rum.integration.agent.internal.utils.runIfComposeUiExists
 import com.splunk.rum.integration.sessionreplay.api.SessionReplay as SplunkSessionReplay
 import com.splunk.rum.integration.sessionreplay.api.Status
 import com.splunk.rum.integration.sessionreplay.index.TimeIndex
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.Value
 import java.util.concurrent.TimeUnit
@@ -61,8 +62,8 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
     }
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")

--- a/integration/slowrendering/build.gradle.kts
+++ b/integration/slowrendering/build.gradle.kts
@@ -23,14 +23,12 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
     implementation(platform(Dependencies.Otel.instrumentationBomAlpha))
 
     implementation(project(":integration:agent:internal"))
     implementation(project(":common:otel"))
     implementation(project(":instrumentation:runtime:slowrendering"))
 
-    implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Otel.api)
 
     implementation(Dependencies.Common.logger)

--- a/integration/slowrendering/src/main/kotlin/com/splunk/rum/integration/slowrendering/SlowRenderingModuleIntegration.kt
+++ b/integration/slowrendering/src/main/kotlin/com/splunk/rum/integration/slowrendering/SlowRenderingModuleIntegration.kt
@@ -16,14 +16,14 @@
 
 package com.splunk.rum.integration.slowrendering
 
-import android.content.Context
+import android.app.Application
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.instrumentation.slowrendering.internal.SlowRenderingInstrumentation
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
 import com.splunk.rum.integration.agent.common.module.find
 import com.splunk.rum.integration.agent.internal.legacy.LegacySlowRenderingModuleConfiguration
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 
 internal object SlowRenderingModuleIntegration : ModuleIntegration<SlowRenderingModuleConfiguration>(
     defaultModuleConfiguration = SlowRenderingModuleConfiguration()
@@ -32,8 +32,8 @@ internal object SlowRenderingModuleIntegration : ModuleIntegration<SlowRendering
     private const val TAG = "SlowRendering"
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")
@@ -49,7 +49,7 @@ internal object SlowRenderingModuleIntegration : ModuleIntegration<SlowRendering
             Logger.d(TAG, "Installing Slow Rendering Detector")
             val slowRenderingInstrumentation = SlowRenderingInstrumentation()
             slowRenderingInstrumentation.setSlowRenderingDetectionPollInterval(interval)
-            slowRenderingInstrumentation.install(context, oTelInstallationContext.openTelemetry)
+            slowRenderingInstrumentation.install(application, openTelemetry)
         } else {
             Logger.d(TAG, "Slow Rendering detection is disabled")
         }

--- a/integration/startup/build.gradle.kts
+++ b/integration/startup/build.gradle.kts
@@ -27,13 +27,9 @@ android {
 }
 
 dependencies {
-    implementation(platform(Dependencies.Otel.androidBom))
-
     implementation(project(":integration:agent:internal"))
     implementation(project(":instrumentation:runtime:startup"))
     implementation(project(":common:otel"))
-
-    implementation(Dependencies.Otel.androidInstrumentation)
 
     implementation(Dependencies.Common.logger)
     implementation(Dependencies.Common.utils)

--- a/integration/startup/src/main/kotlin/com/splunk/rum/integration/startup/StartupModuleIntegration.kt
+++ b/integration/startup/src/main/kotlin/com/splunk/rum/integration/startup/StartupModuleIntegration.kt
@@ -16,6 +16,7 @@
 
 package com.splunk.rum.integration.startup
 
+import android.app.Application
 import android.content.Context
 import com.splunk.rum.agent.common.otel.SplunkOpenTelemetrySdk
 import com.splunk.rum.agent.common.otel.extensions.toInstant
@@ -28,7 +29,7 @@ import com.splunk.rum.integration.agent.internal.AgentIntegration.Companion.modu
 import com.splunk.rum.integration.agent.internal.module.ModuleIntegration
 import com.splunk.rum.integration.startup.model.StartupData
 import com.splunk.rum.startup.ApplicationStartupTimekeeper
-import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import java.util.concurrent.TimeUnit
@@ -55,8 +56,8 @@ internal object StartupModuleIntegration : ModuleIntegration<StartupModuleConfig
     }
 
     override fun onInstall(
-        context: Context,
-        oTelInstallationContext: InstallationContext,
+        application: Application,
+        openTelemetry: OpenTelemetry,
         moduleConfigurations: List<ModuleConfiguration>
     ) {
         Logger.d(TAG, "onInstall()")


### PR DESCRIPTION
## Description
Removes the SDK’s remaining dependency on OpenTelemetry Android while retaining the standard OpenTelemetry API/SDK used for telemetry generation and export.

## Changes

- Removed all opentelemetry-android BOM and artifact declarations.
- Removed InstallationContext from agent and module installation.
- Removed the dummy OpenTelemetry Android SessionManager.
- Replaced InstallationContext with explicit Application and OpenTelemetry parameters.
- Updated all module integrations to use the application and OpenTelemetry instance created by SplunkRumAgentCore.
- Updated application-specific receiver contracts for session management, ANR, crash reporting, network monitoring, and slow-rendering instrumentation.
- Added direct OpenTelemetry API dependencies where modules now consume OpenTelemetry explicitly.
- Explicitly declared android.permission.INTERNET (needed for telemetry upload), which was previously contributed transitively.
- Stopped inheriting OpenTelemetry Android’s READ_PHONE_STATE manifest permission as that's a dangerous permission and should be added by host app at their discretion. 

## Permission impact
- Network monitoring continues to report:
  - Connection type
  - Network availability
  - Carrier information when available through permission-free APIs. 
- Without phone-state permission, cellular connection subtype—such as LTE, NR, EDGE, or HSPA—may be unavailable. The SDK continues to handle this gracefully.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Changes build and run as expected. 
- All instrumentations initializations work as expected. 
- SessionManagement install getting `Application` instead of `Context` work as expected.  
- Upload to backend (requiring the INTERNET permission) works as expected. 
- Attribute extractors getting `Application` instead of `Context` work as expected.  
- All instrumentations behave as expected. 
