### PR TITLE
DEMRUM-5905:  call OpenTelemetry Resource.getDefault only once during install

### DIFF
--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/OpenTelemetryInitializer.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/OpenTelemetryInitializer.kt
@@ -52,7 +52,7 @@ class OpenTelemetryInitializer(
         val jobManager = JobManager.attach(application)
         val jobIdStorage = JobIdStorage.init(application, isEncrypted = false)
 
-        resource = Resource.getDefault()
+        resource = Resource.empty()
 
         val spanExporter = SpanInterceptorExporter(
             AndroidSpanExporter(

--- a/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/resource/AgentResourceTest.kt
+++ b/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/resource/AgentResourceTest.kt
@@ -21,7 +21,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.splunk.rum.integration.agent.api.AgentConfiguration
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.resources.Resource
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -64,5 +66,30 @@ class AgentResourceTest {
             resource.getAttribute(AttributeKey.stringKey("deployment.environment.name"))
         )
         assertNull(resource.getAttribute(AttributeKey.stringKey("deployment.environment")))
+    }
+
+    @Test
+    fun `allResource includes default OTel SDK resource attributes`() {
+        val mockAgentConfig = mock(AgentConfiguration::class.java)
+
+        val resource = AgentResource.allResource(context, "test-id", mockAgentConfig)
+
+        assertNotNull(resource.getAttribute(AttributeKey.stringKey("telemetry.sdk.name")))
+        assertNotNull(resource.getAttribute(AttributeKey.stringKey("telemetry.sdk.language")))
+        assertNotNull(resource.getAttribute(AttributeKey.stringKey("telemetry.sdk.version")))
+    }
+
+    @Test
+    fun `allResource merged with empty produces same result as merged with getDefault`() {
+        val mockAgentConfig = mock(AgentConfiguration::class.java)
+        `when`(mockAgentConfig.appName).thenReturn("test-app")
+        `when`(mockAgentConfig.deploymentEnvironment).thenReturn("test")
+
+        val allResource = AgentResource.allResource(context, "test-id", mockAgentConfig)
+
+        val fromEmpty = Resource.empty().merge(allResource)
+        val fromDefault = Resource.getDefault().merge(allResource)
+
+        assertEquals(fromDefault.attributes, fromEmpty.attributes)
     }
 }


### PR DESCRIPTION
### Description

- Remove redundant `Resource.getDefault()` call in `OpenTelemetryInitializer`, it now starts from `Resource.empty()` since `AgentResource.allResource()` already calls `Resource.getDefault()` and merges all RUM attributes on top.
- Eliminates a duplicate ServiceLoader classpath scan on the main thread during SDK initialization

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- New unit test verifies `allResource()` still includes default OTel SDK attributes (`telemetry.sdk.name`, etc.)
- New unit test proves `Resource.empty().merge(allResource)` equals `Resource.getDefault().merge(allResource)`, confirming no attribute regression