### PR TITLE
DEMRUM-6380: Update server timing header regex to accept any two-digit hexadecimal flag value

### DIFF
--- a/app/src/main/kotlin/com/splunk/app/ui/httpurlconnection/HttpURLConnectionFragment.kt
+++ b/app/src/main/kotlin/com/splunk/app/ui/httpurlconnection/HttpURLConnectionFragment.kt
@@ -138,7 +138,7 @@ class HttpURLConnectionFragment : BaseFragment<FragmentHttpUrlConnectionBinding>
         executeGet(
             "https://httpbin.org/response-headers" +
                 "?Server-Timing=traceparent;desc=\"00-00000000000000000000000000000001-0000000000000001-01\"" +
-                "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-01\""
+                "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-03\""
         )
 
         showDoneToast(R.string.server_timing_header_in_response)

--- a/app/src/main/kotlin/com/splunk/app/ui/okhttp/OkHttpFragment.kt
+++ b/app/src/main/kotlin/com/splunk/app/ui/okhttp/OkHttpFragment.kt
@@ -334,7 +334,7 @@ class OkHttpFragment : BaseFragment<FragmentOkhttpBinding>() {
         executeGetRequest(
             "https://httpbin.org/response-headers" +
                 "?Server-Timing=traceparent;desc=\"00-00000000000000000000000000000001-0000000000000001-01\"" +
-                "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-01\""
+                "&Server-Timing=traceparent;desc=\"00-00000000000000000000000000000002-0000000000000002-03\""
         )
 
         showDoneToast(R.string.server_timing_header_in_response)

--- a/common/utils/src/main/kotlin/com/splunk/rum/agent/common/utils/ServerTimingHeaderParser.kt
+++ b/common/utils/src/main/kotlin/com/splunk/rum/agent/common/utils/ServerTimingHeaderParser.kt
@@ -29,14 +29,14 @@ data class ServerTraceContext(val traceId: String, val spanId: String)
 object ServerTimingHeaderParser {
 
     private val HEADER_PATTERN: Pattern = Pattern.compile(
-        """traceparent;desc=['"]00-([0-9a-f]{32})-([0-9a-f]{16})-01['"]"""
+        """traceparent;desc=['"]00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}['"]"""
     )
 
     /**
      * Parses the server-timing header to extract the trace ID and span ID.
      *
      * @param header A header string in the form:
-     *     traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-01"
+     *     traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-03"
      * @return A ServerTraceContext object containing TraceId and SpanId, or null if parsing fails.
      *      <p>This will also consider single-quotes valid for delimiting the "desc" section, even
      *      though it's not to spec.

--- a/common/utils/src/test/kotlin/com/splunk/rum/agent/common/utils/ServerTimingHeaderParserTest.kt
+++ b/common/utils/src/test/kotlin/com/splunk/rum/agent/common/utils/ServerTimingHeaderParserTest.kt
@@ -21,6 +21,17 @@ class ServerTimingHeaderParserTest {
     }
 
     @Test
+    fun `parse valid header with any two-digit hex trace flags`() {
+        val expected = ServerTraceContext("9499195c502eb217c448a68bfe0f967c", "fe16eca542cd5d86")
+
+        listOf("00", "02", "03", "ff").forEach { flags ->
+            val header =
+                """traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-$flags""""
+            assertEquals("flags: $flags", expected, ServerTimingHeaderParser.parse(header))
+        }
+    }
+
+    @Test
     fun `parse invalid header - incorrect format`() {
         val header = "invalid-header-format"
         assertNull(ServerTimingHeaderParser.parse(header))
@@ -48,6 +59,15 @@ class ServerTimingHeaderParserTest {
     fun `parse invalid header - incorrect spanId format`() {
         val header = """traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-INVALIDSPANID-01""""
         assertNull(ServerTimingHeaderParser.parse(header))
+    }
+
+    @Test
+    fun `parse invalid header - malformed trace flags`() {
+        listOf("0", "000", "0g", "GG").forEach { flags ->
+            val header =
+                """traceparent;desc="00-9499195c502eb217c448a68bfe0f967c-fe16eca542cd5d86-$flags""""
+            assertNull("flags: $flags", ServerTimingHeaderParser.parse(header))
+        }
     }
 
     @Test


### PR DESCRIPTION


### Description

The Android RUM SDK’s Server-Timing parser requires traceparent values to end in 01. Newer Java and Python agents emit valid values ending in 03, causing the header to be rejected and breaking RUM-to-backend trace correlation.
Update the parser to accept any valid two-digit hexadecimal flags value, since Android only extracts the trace and span IDs and does not interpret the flags.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- 01, 03, and other valid two-digit hex flags are accepted.
- Malformed flags remain rejected.
- Both OkHttp and HttpURLConnection are covered.
