### PR TITLE
DEMRUM-5902: Improve AgentStorage and Preferences Initialization

### DIFF
--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/OpenTelemetryInitializer.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/OpenTelemetryInitializer.kt
@@ -20,7 +20,7 @@ import android.app.Application
 import com.splunk.rum.agent.common.otel.logRecord.AndroidLogRecordExporter
 import com.splunk.rum.agent.common.otel.span.AndroidSpanExporter
 import com.splunk.rum.agent.common.otel.span.SpanInterceptorExporter
-import com.splunk.rum.agent.common.storage.AgentStorage
+import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.common.job.JobIdStorage
 import com.splunk.rum.common.job.JobManager
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
@@ -39,6 +39,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 
 class OpenTelemetryInitializer(
     application: Application,
+    agentStorage: IAgentStorage,
     deferredUntilForeground: Boolean,
     spanInterceptor: ((SpanData) -> SpanData?)? = null
 ) {
@@ -48,7 +49,6 @@ class OpenTelemetryInitializer(
     private val logRecordProcessors: MutableList<LogRecordProcessor> = mutableListOf()
 
     init {
-        val agentStorage = AgentStorage.attach(application)
         val jobManager = JobManager.attach(application)
         val jobIdStorage = JobIdStorage.init(application, isEncrypted = false)
 

--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/internal/OfflineOtelDataProcessor.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/internal/OfflineOtelDataProcessor.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import com.splunk.rum.agent.common.otel.logRecord.UploadOtelLogRecordData
 import com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayData
 import com.splunk.rum.agent.common.otel.span.UploadOtelSpanData
-import com.splunk.rum.agent.common.storage.AgentStorage
 import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.common.job.IJobManager
 import com.splunk.rum.common.job.JobIdStorage
@@ -90,9 +89,8 @@ class OfflineOtelDataProcessor internal constructor(
 
         private var instance: OfflineOtelDataProcessor? = null
 
-        fun attach(context: Context): OfflineOtelDataProcessor = synchronized(lock) {
+        fun attach(context: Context, agentStorage: IAgentStorage): OfflineOtelDataProcessor = synchronized(lock) {
             instance ?: run {
-                val agentStorage = AgentStorage.attach(context)
                 val jobManager = JobManager.attach(context)
                 val jobIdStorage = JobIdStorage.init(context, isEncrypted = false)
 

--- a/common/storage/src/main/AndroidManifest.xml
+++ b/common/storage/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
             android:name=".StorageInstaller"
             android:authorities="${applicationId}.StorageInstaller"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:initOrder="1" />
     </application>
 </manifest>

--- a/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/AgentPreferencesStore.kt
+++ b/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/AgentPreferencesStore.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.agent.common.storage
+
+import android.content.Context
+import com.splunk.rum.common.storage.cache.FileSimplePermanentCache
+import com.splunk.rum.common.storage.extensions.noBackupFilesDirCompat
+import com.splunk.rum.common.storage.filemanager.FileManagerFactory
+import com.splunk.rum.common.storage.preferences.Preferences
+import java.io.File
+
+/** Owns the single Preferences loader used by production AgentStorage attachment in this process. */
+internal object AgentPreferencesStore {
+    @Volatile
+    private var instance: Preferences? = null
+
+    private val lock = Any()
+
+    fun preload(context: Context) {
+        obtain(context)
+    }
+
+    fun obtain(context: Context): Preferences {
+        instance?.let { return it }
+
+        return synchronized(lock) {
+            instance ?: createPreferences(context.applicationContext ?: context).also {
+                instance = it
+            }
+        }
+    }
+
+    internal fun resetForTest() {
+        synchronized(lock) {
+            instance?.close()
+            instance = null
+        }
+    }
+
+    private fun createPreferences(context: Context): Preferences {
+        return Preferences.create {
+            FileSimplePermanentCache(
+                AgentStorageFiles.preferencesFile(context),
+                FileManagerFactory.createPlainFileManager()
+            )
+        }
+    }
+}
+
+internal object AgentStorageFiles {
+    private const val VERSION = 1
+
+    fun rootDir(context: Context): File = File(context.noBackupFilesDirCompat, "agent")
+
+    fun versionDir(rootDir: File): File = File(rootDir, "$VERSION")
+
+    fun preferencesFile(context: Context): File {
+        return File(versionDir(rootDir(context)), "preferences/preferences.dat")
+    }
+}

--- a/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/AgentStorage.kt
+++ b/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/AgentStorage.kt
@@ -17,7 +17,9 @@
 package com.splunk.rum.agent.common.storage
 
 import android.content.Context
+import android.os.Looper
 import android.os.StatFs
+import android.util.Log
 import com.splunk.rum.agent.common.storage.extensions.MB
 import com.splunk.rum.agent.common.storage.extensions.availableBlocksCompat
 import com.splunk.rum.agent.common.storage.extensions.blockSizeCompat
@@ -25,14 +27,12 @@ import com.splunk.rum.agent.common.storage.policy.StoragePolicy
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.common.storage.Storage
 import com.splunk.rum.common.storage.cache.FilePermanentCache
-import com.splunk.rum.common.storage.cache.FileSimplePermanentCache
-import com.splunk.rum.common.storage.extensions.noBackupFilesDirCompat
-import com.splunk.rum.common.storage.filemanager.EncryptedFileManager
 import com.splunk.rum.common.storage.filemanager.FileManagerFactory
 import com.splunk.rum.common.storage.preferences.Preferences
 import com.splunk.rum.common.utils.extensions.toJSONArray
 import com.splunk.rum.common.utils.runOnBackgroundThread
 import java.io.File
+import java.util.concurrent.atomic.AtomicReference
 import org.json.JSONArray
 import org.json.JSONException
 
@@ -49,25 +49,21 @@ import org.json.JSONException
  *           ├─spans/
  *           └─session_replay/
  */
-class AgentStorage(context: Context) : IAgentStorage {
-
-    private val preferencesFileManager = FileManagerFactory.createPlainFileManager()
+class AgentStorage private constructor(
+    context: Context,
     private val preferences: Preferences
+) : IAgentStorage {
 
     private val internalStorage =
         Storage(FilePermanentCache(FileManagerFactory.createPlainFileManager()))
 
-    private val rootDir = File(context.noBackupFilesDirCompat, "agent")
-    private val agentVersionDir =
-        File(rootDir, "$VERSION${if (preferencesFileManager is EncryptedFileManager) "e" else ""}")
-    private val preferencesFile = File(agentVersionDir, "preferences/preferences.dat")
+    private val rootDir = AgentStorageFiles.rootDir(context)
+    private val agentVersionDir = AgentStorageFiles.versionDir(rootDir)
     private val logDir = File(agentVersionDir, "logs")
     private val spanDir = File(agentVersionDir, "spans")
     private val sessionReplayDir = File(agentVersionDir, "session_replay")
 
     init {
-        preferences = Preferences(FileSimplePermanentCache(preferencesFile, preferencesFileManager))
-
         agentVersionDir.mkdirs()
         logDir.mkdirs()
         spanDir.mkdirs()
@@ -431,22 +427,35 @@ class AgentStorage(context: Context) : IAgentStorage {
         private const val SESSION_REPLAY_IDS_KEY = "BUFFERED_SESSION_REPLAY_IDS"
 
         private const val TAG = "AgentStorage"
-        private val lock = Any()
         private val migrationLock = Any()
 
-        /**
-         * If storage model changes this version needs to be changed. This will ensure data consistency.
-         * The storage will wipe all the legacy data (older version than this one).
-         */
-        private const val VERSION = 1
+        private val instance = AtomicReference<IAgentStorage?>()
 
-        private var instance: IAgentStorage? = null
+        fun attach(context: Context): IAgentStorage {
+            instance.get()?.let { return it }
 
-        fun attach(context: Context): IAgentStorage = synchronized(lock) {
-            instance ?: AgentStorage(context).also {
-                instance = it
-                Logger.v(TAG, "attach(): AgentStorage attached.")
+            // Callers never wait for storage initialization. A rare race may build two candidates;
+            // only the first published instance is retained. Candidates share the process Preferences owner,
+            // so discarding a candidate does not create or cancel another preference load.
+            val applicationContext = context.applicationContext ?: context
+            val candidate = AgentStorage(applicationContext, AgentPreferencesStore.obtain(applicationContext))
+            val initializationThread = Thread.currentThread()
+            val threadType = if (initializationThread === Looper.getMainLooper().thread) "main" else "background"
+            if (instance.compareAndSet(null, candidate)) {
+                Log.d(TAG, "attach(): AgentStorage initialized on $threadType thread '${initializationThread.name}'.")
+                return candidate
             }
+
+            Log.d(
+                TAG,
+                "attach(): AgentStorage candidate initialized on $threadType thread '${initializationThread.name}' " +
+                    "and discarded because another thread published the singleton."
+            )
+            return instance.get() ?: candidate
+        }
+
+        internal fun resetForTest() {
+            instance.set(null)
         }
     }
 }

--- a/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/StorageInstaller.kt
+++ b/common/storage/src/main/kotlin/com/splunk/rum/agent/common/storage/StorageInstaller.kt
@@ -27,7 +27,12 @@ internal class StorageInstaller : ContentProvider() {
 
     override fun onCreate(): Boolean {
         val application = context?.applicationContext as Application
-        runOnBackgroundThread {
+
+        // Only the lightweight owner is published here. The cache path, cache object, file read, and
+        // deserialization are performed by the Preferences worker.
+        AgentPreferencesStore.preload(application)
+
+        runOnBackgroundThread(name = "SplunkStorageBackgroundInit") {
             AgentStorage.attach(application)
         }
         return true

--- a/common/storage/src/test/kotlin/com/splunk/rum/agent/common/storage/AgentStorageTest.kt
+++ b/common/storage/src/test/kotlin/com/splunk/rum/agent/common/storage/AgentStorageTest.kt
@@ -21,10 +21,15 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.splunk.rum.common.storage.extensions.noBackupFilesDirCompat
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,14 +44,82 @@ class AgentStorageTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        storage = AgentStorage(context)
         testStorageDir = File(context.noBackupFilesDirCompat, "agent")
+        resetProcessStorage()
+        storage = AgentStorage.attach(context) as AgentStorage
     }
 
     @After
     fun tearDown() {
+        resetProcessStorage()
         if (testStorageDir.exists()) {
             testStorageDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `attach returns the same published instance to concurrent callers`() {
+        resetProcessStorage()
+        val callerCount = 8
+        val executor = Executors.newFixedThreadPool(callerCount)
+        val ready = CountDownLatch(callerCount)
+        val start = CountDownLatch(1)
+
+        try {
+            val results = (1..callerCount).map {
+                executor.submit<IAgentStorage> {
+                    ready.countDown()
+                    start.await()
+                    AgentStorage.attach(context)
+                }
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS))
+            start.countDown()
+            val instances = results.map { it.get(5, TimeUnit.SECONDS) }
+
+            instances.forEach { assertSame(instances.first(), it) }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `attach candidates use the process preferences owner`() {
+        resetProcessStorage()
+        AgentPreferencesStore.preload(context)
+
+        val attachedStorage = AgentStorage.attach(context)
+        val preferencesField = AgentStorage::class.java.getDeclaredField("preferences")
+        preferencesField.isAccessible = true
+
+        assertSame(AgentPreferencesStore.obtain(context), preferencesField.get(attachedStorage))
+    }
+
+    @Test
+    fun `preference store returns one owner to concurrent callers`() {
+        resetProcessStorage()
+        val callerCount = 8
+        val executor = Executors.newFixedThreadPool(callerCount)
+        val ready = CountDownLatch(callerCount)
+        val start = CountDownLatch(1)
+
+        try {
+            val results = (1..callerCount).map {
+                executor.submit {
+                    ready.countDown()
+                    start.await()
+                    AgentPreferencesStore.obtain(context)
+                }
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS))
+            start.countDown()
+            val preferences = results.map { it.get(5, TimeUnit.SECONDS) }
+
+            preferences.forEach { assertSame(preferences.first(), it) }
+        } finally {
+            executor.shutdownNow()
         }
     }
 
@@ -85,7 +158,8 @@ class AgentStorageTest {
         storage.writeAppInstallationId(testId)
         storage.commit()
 
-        val newStorage = AgentStorage(context)
+        resetProcessStorage()
+        val newStorage = AgentStorage.attach(context)
         val result = newStorage.readAppInstallationId()
 
         assertEquals(testId, result)
@@ -141,7 +215,8 @@ class AgentStorageTest {
         storage.writeEndpointConfig(config)
         storage.commit()
 
-        val newStorage = AgentStorage(context)
+        resetProcessStorage()
+        val newStorage = AgentStorage.attach(context)
         assertEquals(config, newStorage.readEndpointConfig())
     }
 
@@ -193,5 +268,10 @@ class AgentStorageTest {
         storage.writeEndpointConfig(config)
 
         assertEquals(config, storage.readEndpointConfig())
+    }
+
+    private fun resetProcessStorage() {
+        AgentStorage.resetForTest()
+        AgentPreferencesStore.resetForTest()
     }
 }

--- a/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/SplunkRum.kt
+++ b/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/SplunkRum.kt
@@ -333,8 +333,9 @@ class SplunkRum private constructor(
                 storage
             )
 
-            val sessionManager = AgentIntegration.obtainInstance(application).sessionManager
-            val offlineOtelDataProcessor = OfflineOtelDataProcessor.attach(application)
+            val agentIntegration = AgentIntegration.obtainInstance(application)
+            val sessionManager = agentIntegration.createSessionManager(storage)
+            val offlineOtelDataProcessor = OfflineOtelDataProcessor.attach(application, storage)
 
             // The shared MutableAttributes instance used by both
             // GlobalAttributeSpanProcessor and the public SplunkRum.globalAttributes API
@@ -345,6 +346,7 @@ class SplunkRum private constructor(
                 agentConfiguration,
                 userManager,
                 sessionManager,
+                storage,
                 moduleConfigurations.toList(),
                 globalAttributes,
                 offlineOtelDataProcessor

--- a/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
+++ b/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
@@ -19,7 +19,7 @@ package com.splunk.rum.integration.agent.api.internal
 import android.app.Application
 import com.splunk.rum.agent.common.otel.OpenTelemetryInitializer
 import com.splunk.rum.agent.common.otel.internal.OfflineOtelDataProcessor
-import com.splunk.rum.agent.common.storage.AgentStorage
+import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.common.utils.extensions.forEachFast
 import com.splunk.rum.integration.agent.api.AgentConfiguration
@@ -60,6 +60,7 @@ internal object SplunkRumAgentCore {
         agentConfiguration: AgentConfiguration,
         userManager: IUserManager,
         sessionManager: ISplunkSessionManager,
+        storage: IAgentStorage,
         moduleConfigurations: List<ModuleConfiguration>,
         globalAttributes: MutableAttributes,
         offlineOtelDataProcessor: OfflineOtelDataProcessor
@@ -81,8 +82,6 @@ internal object SplunkRumAgentCore {
 
         sessionManager.reset()
 
-        val storage = AgentStorage.attach(application)
-
         val appInstallationID = storage.readAppInstallationId() ?: UUID.randomUUID().toString().replace("-", "").also {
             storage.writeAppInstallationId(it)
         }
@@ -94,6 +93,7 @@ internal object SplunkRumAgentCore {
 
         val initializer = OpenTelemetryInitializer(
             application,
+            storage,
             agentConfiguration.deferredUntilForeground,
             agentConfiguration.spanInterceptor
         )
@@ -105,12 +105,12 @@ internal object SplunkRumAgentCore {
             .joinResources(AgentResource.allResource(application, appInstallationID, finalConfiguration))
             .addSpanProcessor(UserIdSpanProcessor(userManager))
             .addSpanProcessor(ErrorIdentifierAttributesSpanProcessor(application))
-            .addSpanProcessor(SessionIdSpanProcessor(agentIntegration.sessionManager))
+            .addSpanProcessor(SessionIdSpanProcessor(sessionManager))
             .addSpanProcessor(SplunkInternalGlobalAttributeSpanProcessor())
             .addLogRecordProcessor(ScreenNameLogRecordProcessor(ScreenNameTracker))
             .addLogRecordProcessor(SessionActivityLogProcessor(sessionManager))
             // Session Replay module is special case of Log Records that are NOT converted to Spans.
-            .addLogRecordProcessor(SessionReplaySessionIdLogProcessor(agentIntegration.sessionManager))
+            .addLogRecordProcessor(SessionReplaySessionIdLogProcessor(sessionManager))
 
         if (agentConfiguration.enableDebugLogging) {
             initializer.addSpanProcessor(SimpleSpanProcessor.builder(LoggerSpanExporter()).build())
@@ -132,7 +132,7 @@ internal object SplunkRumAgentCore {
             }
         }
 
-        agentIntegration.install(application, openTelemetry, moduleConfigurations, globalAttributes)
+        agentIntegration.install(application, openTelemetry, sessionManager, moduleConfigurations, globalAttributes)
 
         installTimestamp = System.currentTimeMillis()
         if (agentConfiguration.endpoint != null) {

--- a/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCoreTest.kt
+++ b/integration/agent/api/src/test/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCoreTest.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.splunk.rum.agent.common.otel.internal.OfflineOtelDataProcessor
 import com.splunk.rum.agent.common.storage.AgentStorage
+import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.common.storage.extensions.noBackupFilesDirCompat
 import com.splunk.rum.integration.agent.api.AgentConfiguration
 import com.splunk.rum.integration.agent.api.EndpointConfiguration
@@ -29,6 +30,7 @@ import com.splunk.rum.integration.agent.internal.AgentIntegration
 import com.splunk.rum.integration.agent.internal.session.ISplunkSessionManager
 import com.splunk.rum.integration.agent.internal.user.IUserManager
 import java.io.File
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -39,6 +41,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
 @RunWith(AndroidJUnit4::class)
@@ -154,6 +158,17 @@ class SplunkRumAgentCoreTest {
     }
 
     @Test
+    fun `install uses the supplied storage instance`() {
+        val suppliedStorage = mock(IAgentStorage::class.java)
+        `when`(suppliedStorage.readAppInstallationId()).thenReturn("existing-installation-id")
+
+        installSplunkRumAgent(suppliedStorage)
+
+        verify(suppliedStorage).readAppInstallationId()
+        verify(suppliedStorage, never()).writeAppInstallationId(org.mockito.ArgumentMatchers.anyString())
+    }
+
+    @Test
     fun `install does not configure context storage provider when sampled out`() {
         `when`(mockAgentConfig.session.samplingRate).thenReturn(0.0)
         assertNull(System.getProperty(contextStorageProviderProperty))
@@ -189,12 +204,13 @@ class SplunkRumAgentCoreTest {
         assertEquals(custom, System.getProperty(contextStorageProviderProperty))
     }
 
-    private fun installSplunkRumAgent() {
+    private fun installSplunkRumAgent(agentStorage: IAgentStorage = storage) {
         SplunkRumAgentCore.install(
             application,
             mockAgentConfig,
             mockUserManager,
             mockSessionManager,
+            agentStorage,
             emptyList(),
             MutableAttributes(),
             mockOfflineOtelDataProcessor
@@ -202,20 +218,27 @@ class SplunkRumAgentCoreTest {
     }
 
     private fun cleanupStorage() {
+        resetAgentStorageSingleton()
+
         if (testStorageDir.exists()) {
             testStorageDir.deleteRecursively()
         }
-
-        resetAgentStorageSingleton()
     }
 
     private fun resetAgentStorageSingleton() {
-        try {
-            val field = AgentStorage::class.java.getDeclaredField("instance")
-            field.isAccessible = true
-            field.set(null, null)
-        } catch (e: Exception) {
-            // Ignore reflection errors in tests
-        }
+        val storageField = AgentStorage::class.java.getDeclaredField("instance")
+        storageField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val storageInstance = storageField.get(null) as AtomicReference<Any?>
+        storageInstance.set(null)
+
+        val preferencesStoreClass = Class.forName(
+            "com.splunk.rum.agent.common.storage.AgentPreferencesStore"
+        )
+        val preferencesStore = preferencesStoreClass.getField("INSTANCE").get(null)
+        val preferencesField = preferencesStoreClass.getDeclaredField("instance")
+        preferencesField.isAccessible = true
+        (preferencesField.get(preferencesStore) as? AutoCloseable)?.close()
+        preferencesField.set(preferencesStore, null)
     }
 }

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
@@ -23,7 +23,7 @@ import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants.PREVIOUS_SESSION_ID_KEY
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants.RUM_TRACER_NAME
 import com.splunk.rum.agent.common.otel.internal.GlobalRumConstants.SESSION_ID_KEY
-import com.splunk.rum.agent.common.storage.AgentStorage
+import com.splunk.rum.agent.common.storage.IAgentStorage
 import com.splunk.rum.common.logger.Logger
 import com.splunk.rum.common.utils.extensions.forEachFast
 import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
@@ -35,20 +35,15 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import java.util.concurrent.TimeUnit
 
-class AgentIntegration private constructor(context: Context) {
-    val sessionManager: ISplunkSessionManager
+class AgentIntegration private constructor(@Suppress("UNUSED_PARAMETER") context: Context) {
     internal val listeners: MutableSet<Listener> = HashSet()
     var globalAttributes: Attributes = Attributes.empty()
         private set
 
-    init {
-        val storage = AgentStorage.attach(context)
-        sessionManager = SplunkSessionManager(storage)
-    }
-
     fun install(
         application: Application,
         openTelemetry: OpenTelemetrySdk,
+        sessionManager: ISplunkSessionManager,
         moduleConfigurations: List<ModuleConfiguration>,
         globalAttributes: Attributes
     ) {
@@ -56,6 +51,7 @@ class AgentIntegration private constructor(context: Context) {
 
         registerModuleInitializationStart(MODULE_NAME)
 
+        listeners.forEachFast { it.onSessionManagerReady(sessionManager) }
         sessionManager.sessionListeners += object : SplunkSessionManager.SessionListener {
             override fun onSessionChanged(sessionId: String, timestamp: Long) {
                 openTelemetry.sdkLoggerProvider.get(RUM_TRACER_NAME)
@@ -86,7 +82,11 @@ class AgentIntegration private constructor(context: Context) {
         listeners.forEachFast { it.onPostInstall() }
     }
 
+    fun createSessionManager(agentStorage: IAgentStorage): ISplunkSessionManager = SplunkSessionManager(agentStorage)
+
     internal interface Listener {
+        fun onSessionManagerReady(sessionManager: ISplunkSessionManager)
+
         fun onInstall(
             application: Application,
             openTelemetry: OpenTelemetry,

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
@@ -36,11 +36,11 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
     protected lateinit var sessionManager: ISplunkSessionManager
         private set
 
+    protected open val observesSessionChanges: Boolean = false
+
     fun attach(context: Context) {
         val agentIntegration = AgentIntegration.obtainInstance(context)
         agentIntegration.listeners += installationListener
-        sessionManager = agentIntegration.sessionManager
-        agentIntegration.sessionManager.sessionListeners += sessionChangeListener
 
         onAttach(context)
     }
@@ -60,6 +60,13 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
     }
 
     private val installationListener = object : AgentIntegration.Listener {
+        override fun onSessionManagerReady(sessionManager: ISplunkSessionManager) {
+            this@ModuleIntegration.sessionManager = sessionManager
+            if (observesSessionChanges) {
+                sessionManager.sessionListeners += sessionChangeListener
+            }
+        }
+
         override fun onInstall(
             application: Application,
             openTelemetry: OpenTelemetry,

--- a/integration/agent/internal/src/test/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegrationTest.kt
+++ b/integration/agent/internal/src/test/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegrationTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.agent.internal.module
+
+import android.app.Application
+import com.splunk.rum.integration.agent.common.module.ModuleConfiguration
+import com.splunk.rum.integration.agent.internal.AgentIntegration
+import com.splunk.rum.integration.agent.internal.session.ISplunkSessionManager
+import com.splunk.rum.integration.agent.internal.session.SplunkSessionManager
+import io.opentelemetry.api.OpenTelemetry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ModuleIntegrationTest {
+
+    @Before
+    fun setUp() {
+        val instanceField = AgentIntegration::class.java.getDeclaredField("instanceInternal")
+        instanceField.isAccessible = true
+        instanceField.set(null, null)
+        AgentIntegration.modules.clear()
+    }
+
+    @Test
+    fun `attach defers session manager and listener wiring until manager is ready`() {
+        val application = RuntimeEnvironment.getApplication() as Application
+        val module = TestModuleIntegration()
+
+        module.attach(application)
+
+        val sessionListeners = mutableSetOf<SplunkSessionManager.SessionListener>()
+        val sessionManager = mock(ISplunkSessionManager::class.java)
+        `when`(sessionManager.sessionListeners).thenReturn(sessionListeners)
+
+        val agentIntegration = AgentIntegration.obtainInstance(application)
+        agentIntegration.listeners.single().onSessionManagerReady(sessionManager)
+        sessionListeners.single().onSessionChanged("session-id", 1L)
+
+        assertSame(sessionManager, module.attachedSessionManager())
+        assertEquals("session-id", module.lastSessionId)
+    }
+
+    @Test
+    fun `module does not register a session listener by default`() {
+        val application = RuntimeEnvironment.getApplication() as Application
+        val module = DefaultModuleIntegration()
+        module.attach(application)
+
+        val sessionListeners = mutableSetOf<SplunkSessionManager.SessionListener>()
+        val sessionManager = mock(ISplunkSessionManager::class.java)
+        `when`(sessionManager.sessionListeners).thenReturn(sessionListeners)
+
+        AgentIntegration.obtainInstance(application).listeners.single().onSessionManagerReady(sessionManager)
+
+        assertSame(sessionManager, module.attachedSessionManager())
+        assertEquals(0, sessionListeners.size)
+    }
+
+    private class TestModuleIntegration : ModuleIntegration<TestModuleConfiguration>(TestModuleConfiguration) {
+        var lastSessionId: String? = null
+
+        override val observesSessionChanges: Boolean = true
+
+        fun attachedSessionManager(): ISplunkSessionManager = sessionManager
+
+        override fun onInstall(
+            application: Application,
+            openTelemetry: OpenTelemetry,
+            moduleConfigurations: List<ModuleConfiguration>
+        ) = Unit
+
+        override fun onSessionChange(sessionId: String) {
+            lastSessionId = sessionId
+        }
+    }
+
+    private class DefaultModuleIntegration : ModuleIntegration<TestModuleConfiguration>(TestModuleConfiguration) {
+        fun attachedSessionManager(): ISplunkSessionManager = sessionManager
+
+        override fun onInstall(
+            application: Application,
+            openTelemetry: OpenTelemetry,
+            moduleConfigurations: List<ModuleConfiguration>
+        ) = Unit
+    }
+
+    private object TestModuleConfiguration : ModuleConfiguration {
+        override val name: String = "test"
+        override val attributes: List<Pair<String, String>> = emptyList()
+    }
+}

--- a/integration/sessionreplay/src/main/kotlin/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
+++ b/integration/sessionreplay/src/main/kotlin/com/splunk/rum/integration/sessionreplay/SessionReplayModuleIntegration.kt
@@ -55,6 +55,8 @@ internal object SessionReplayModuleIntegration : ModuleIntegration<SessionReplay
     private var isInstalled = false
     private val runtimeState = RuntimeState()
 
+    override val observesSessionChanges: Boolean = true
+
     override fun onAttach(context: Context) {
         Logger.d(TAG, "onAttach()")
 


### PR DESCRIPTION

### Description

Starts Agent preference loading and storage initialization early from `StorageInstaller`, removes hidden storage attachment from module and OpenTelemetry initialization, and prevents callers from waiting for an in-flight `AgentStorage` constructor.

### Changes

- Set `StorageInstaller` to `initOrder=1` so it runs before Splunk providers using the default order.
- Start the shared Preferences preload from `StorageInstaller`.
- Run Agent storage construction on the named `SplunkStorageBackgroundInit` worker.
- Introduce one process-wide `AgentPreferencesStore`.
- Replace synchronized singleton construction with atomic candidate publication.
- Log whether the winning or discarded storage candidate initialized on main or background.
- Obtain storage once during `SplunkRum.install()` and pass it to:
  - `SplunkRumAgentCore`;
  - `OpenTelemetryInitializer`; and
  - `OfflineOtelDataProcessor`.
- Remove storage construction from `AgentIntegration`.
- Create `SplunkSessionManager` during explicit Agent installation. Notify modules through `onSessionManagerReady`.
- Register module session listeners only when `observesSessionChanges` is enabled. Opt Session Replay into session-change observation.
- Retain lazy `AgentStorage.attach()` fallbacks in upload jobs for process recreation.
- Remove the impossible encrypted-file-manager directory suffix check.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes
 - All new and old tests pass. 
 - Builds and runs correctly.
 - All functionality behaves as expected. 
