### PR TITLE
NO-TICKET: Preserve pre-2.3.3 JobScheduler service entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ##### Enhancements:
 * Removed the OpenTelemetry Android runtime dependency
 
+##### Fixes:
+* Preserved pre-2.3.3 JobScheduler service entry points so scheduled uploads survive SDK package renames
+
 ### Version 2.3.3 - 2026-08-12
 
 ##### Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Removed the OpenTelemetry Android runtime dependency
 
 ##### Fixes:
-* Preserved pre-2.3.3 JobScheduler service entry points so scheduled uploads survive SDK package renames
+* Preserved old JobScheduler service entry points so in-flight upload jobs remain runnable when component names change during an SDK upgrade
 
 ### Version 2.3.3 - 2026-08-12
 

--- a/common/otel/proguard-rules.pro
+++ b/common/otel/proguard-rules.pro
@@ -1,1 +1,0 @@
--repackageclasses 'com.splunk.rum.agent.common.otel'

--- a/common/otel/src/main/AndroidManifest.xml
+++ b/common/otel/src/main/AndroidManifest.xml
@@ -4,6 +4,19 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
+        <!--
+            Keep the pre-2.3.3 service names for jobs persisted across an app update.
+            JobScheduler can attempt to instantiate these components.
+        -->
+        <service
+            android:name="com.splunk.rum.common.otel.span.UploadOtelSpanDataJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+        <service
+            android:name="com.splunk.rum.common.otel.logRecord.UploadOtelLogRecordDataJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+        <service
+            android:name="com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
             android:name="com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
@@ -11,7 +24,7 @@
             android:name="com.splunk.rum.agent.common.otel.logRecord.UploadOtelLogRecordDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
-            android:name=".logRecord.UploadSessionReplayDataJob"
+            android:name="com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
     </application>
 

--- a/common/otel/src/main/AndroidManifest.xml
+++ b/common/otel/src/main/AndroidManifest.xml
@@ -5,8 +5,9 @@
 
     <application>
         <!--
-            Keep the pre-2.3.3 service names for jobs persisted across an app update.
-            JobScheduler can attempt to instantiate these components.
+            Keep the old service names for jobs persisted or already being dispatched across an
+            app update. Offline job migration can cancel and reschedule a job, but cancellation is
+            not atomic with JobScheduler service startup.
         -->
         <service
             android:name="com.splunk.rum.common.otel.span.UploadOtelSpanDataJob"
@@ -16,6 +17,9 @@
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
             android:name="com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+        <service
+            android:name="com.splunk.rum.common.otel.span.UploadSessionReplayDataJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
             android:name="com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob"

--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/internal/OfflineOtelDataProcessor.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/internal/OfflineOtelDataProcessor.kt
@@ -58,6 +58,9 @@ class OfflineOtelDataProcessor internal constructor(
     }
 
     private fun startProcessingLocalData(olderThan: Long) {
+        // Cancellation is not atomic with JobScheduler dispatch. Legacy service entry points must
+        // remain available in case Android has already started an old component while migration
+        // is canceling and rescheduling the job.
         agentStorage.getLogs(olderThan).forEachFast {
             val id = it.nameWithoutExtension
             cancelJob(id)

--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
@@ -35,7 +35,7 @@ import java.net.UnknownHostException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-internal class UploadOtelLogRecordDataJob : JobService() {
+internal open class UploadOtelLogRecordDataJob : JobService() {
 
     private val storage by lazy { AgentStorage.attach(application) }
     private val jobIdStorage by lazy { JobIdStorage.init(application, isEncrypted = false) }

--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/logRecord/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/logRecord/UploadSessionReplayDataJob.kt
@@ -35,7 +35,7 @@ import java.net.UnknownHostException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-internal class UploadSessionReplayDataJob : JobService() {
+internal open class UploadSessionReplayDataJob : JobService() {
 
     private val storage by lazy { AgentStorage.attach(application) }
     private val jobIdStorage by lazy { JobIdStorage.init(application, isEncrypted = false) }

--- a/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/agent/common/otel/span/UploadOtelSpanDataJob.kt
@@ -35,7 +35,7 @@ import java.net.UnknownHostException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-internal class UploadOtelSpanDataJob : JobService() {
+internal open class UploadOtelSpanDataJob : JobService() {
 
     private val storage by lazy { AgentStorage.attach(application) }
     private val jobIdStorage by lazy { JobIdStorage.init(application, isEncrypted = false) }

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
@@ -17,7 +17,10 @@
 package com.splunk.rum.common.otel.logRecord
 
 /**
- * Compatibility entry point for log-record upload jobs scheduled by SDK versions before 2.3.3.
+ * Compatibility entry point for old log-record upload jobs.
+ *
+ * The old component name remains available because JobScheduler may already be dispatching a
+ * persisted job while offline data migration is canceling and rescheduling it.
  *
  * The implementation is inherited so persisted jobs can complete without creating a second
  * upload job or changing their JobScheduler ID.

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.common.otel.logRecord
+
+/**
+ * Compatibility entry point for log-record upload jobs scheduled by SDK versions before 2.3.3.
+ *
+ * The implementation is inherited so persisted jobs can complete without creating a second
+ * upload job or changing their JobScheduler ID.
+ */
+internal class UploadOtelLogRecordDataJob : com.splunk.rum.agent.common.otel.logRecord.UploadOtelLogRecordDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadOtelLogRecordDataJob.kt
@@ -21,8 +21,5 @@ package com.splunk.rum.common.otel.logRecord
  *
  * The old component name remains available because JobScheduler may already be dispatching a
  * persisted job while offline data migration is canceling and rescheduling it.
- *
- * The implementation is inherited so persisted jobs can complete without creating a second
- * upload job or changing their JobScheduler ID.
  */
 internal class UploadOtelLogRecordDataJob : com.splunk.rum.agent.common.otel.logRecord.UploadOtelLogRecordDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
@@ -17,8 +17,10 @@
 package com.splunk.rum.common.otel.logRecord
 
 /**
- * Compatibility entry point for session-replay upload jobs scheduled by SDK versions before
- * 2.3.3.
+ * Compatibility entry point for old Session Replay upload jobs.
+ *
+ * The old component name remains available because JobScheduler may already be dispatching a
+ * persisted job while offline data migration is canceling and rescheduling it.
  *
  * The implementation is inherited so persisted jobs can complete without creating a second
  * upload job or changing their JobScheduler ID.

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
@@ -21,8 +21,5 @@ package com.splunk.rum.common.otel.logRecord
  *
  * The old component name remains available because JobScheduler may already be dispatching a
  * persisted job while offline data migration is canceling and rescheduling it.
- *
- * The implementation is inherited so persisted jobs can complete without creating a second
- * upload job or changing their JobScheduler ID.
  */
 internal class UploadSessionReplayDataJob : com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/logRecord/UploadSessionReplayDataJob.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.common.otel.logRecord
+
+/**
+ * Compatibility entry point for session-replay upload jobs scheduled by SDK versions before
+ * 2.3.3.
+ *
+ * The implementation is inherited so persisted jobs can complete without creating a second
+ * upload job or changing their JobScheduler ID.
+ */
+internal class UploadSessionReplayDataJob : com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.common.otel.span
+
+/**
+ * Compatibility entry point for span upload jobs scheduled by SDK versions before 2.3.3.
+ *
+ * The implementation is inherited so persisted jobs can complete without creating a second
+ * upload job or changing their JobScheduler ID.
+ */
+internal class UploadOtelSpanDataJob : com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadOtelSpanDataJob.kt
@@ -21,8 +21,5 @@ package com.splunk.rum.common.otel.span
  *
  * The old component name remains available because JobScheduler may already be dispatching a
  * persisted job while offline data migration is canceling and rescheduling it.
- *
- * The implementation is inherited so persisted jobs can complete without creating a second
- * upload job or changing their JobScheduler ID.
  */
 internal class UploadOtelSpanDataJob : com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob()

--- a/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadSessionReplayDataJob.kt
+++ b/common/otel/src/main/kotlin/com/splunk/rum/common/otel/span/UploadSessionReplayDataJob.kt
@@ -17,12 +17,10 @@
 package com.splunk.rum.common.otel.span
 
 /**
- * Compatibility entry point for old span upload jobs.
+ * Compatibility entry point for Session Replay jobs scheduled before the service moved from the
+ * span package to the logRecord package.
  *
  * The old component name remains available because JobScheduler may already be dispatching a
  * persisted job while offline data migration is canceling and rescheduling it.
- *
- * The implementation is inherited so persisted jobs can complete without creating a second
- * upload job or changing their JobScheduler ID.
  */
-internal class UploadOtelSpanDataJob : com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob()
+internal class UploadSessionReplayDataJob : com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayDataJob()

--- a/common/otel/src/test/kotlin/com/splunk/rum/common/otel/JobServiceCompatibilityTest.kt
+++ b/common/otel/src/test/kotlin/com/splunk/rum/common/otel/JobServiceCompatibilityTest.kt
@@ -23,6 +23,7 @@ import com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob as CurrentUpl
 import com.splunk.rum.common.otel.logRecord.UploadOtelLogRecordDataJob
 import com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob
 import com.splunk.rum.common.otel.span.UploadOtelSpanDataJob
+import com.splunk.rum.common.otel.span.UploadSessionReplayDataJob as OldUploadSessionReplayDataJob
 import java.lang.reflect.Modifier
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -66,6 +67,11 @@ class JobServiceCompatibilityTest {
             LegacyService(
                 "com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob",
                 UploadSessionReplayDataJob::class.java,
+                CurrentUploadSessionReplayDataJob::class.java
+            ),
+            LegacyService(
+                "com.splunk.rum.common.otel.span.UploadSessionReplayDataJob",
+                OldUploadSessionReplayDataJob::class.java,
                 CurrentUploadSessionReplayDataJob::class.java
             )
         )

--- a/common/otel/src/test/kotlin/com/splunk/rum/common/otel/JobServiceCompatibilityTest.kt
+++ b/common/otel/src/test/kotlin/com/splunk/rum/common/otel/JobServiceCompatibilityTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.common.otel
+
+import android.app.job.JobService
+import com.splunk.rum.agent.common.otel.logRecord.UploadOtelLogRecordDataJob as CurrentUploadOtelLogRecordDataJob
+import com.splunk.rum.agent.common.otel.logRecord.UploadSessionReplayDataJob as CurrentUploadSessionReplayDataJob
+import com.splunk.rum.agent.common.otel.span.UploadOtelSpanDataJob as CurrentUploadOtelSpanDataJob
+import com.splunk.rum.common.otel.logRecord.UploadOtelLogRecordDataJob
+import com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob
+import com.splunk.rum.common.otel.span.UploadOtelSpanDataJob
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JobServiceCompatibilityTest {
+
+    @Test
+    fun `legacy upload services keep their old names`() {
+        legacyServices.forEach { (legacyName, legacyClass, currentClass) ->
+            assertEquals(legacyName, legacyClass.name)
+            assertEquals(currentClass, legacyClass.superclass)
+        }
+    }
+
+    @Test
+    fun `legacy upload services remain instantiable JobService entry points`() {
+        legacyServices.forEach { (_, serviceClass, _) ->
+            assertTrue(JobService::class.java.isAssignableFrom(serviceClass))
+
+            val constructor = serviceClass.getDeclaredConstructor()
+            assertNotNull(constructor)
+            assertTrue(Modifier.isPublic(constructor.modifiers))
+            assertEquals(0, constructor.parameterCount)
+        }
+    }
+
+    private companion object {
+        val legacyServices: List<LegacyService> = listOf(
+            LegacyService(
+                "com.splunk.rum.common.otel.span.UploadOtelSpanDataJob",
+                UploadOtelSpanDataJob::class.java,
+                CurrentUploadOtelSpanDataJob::class.java
+            ),
+            LegacyService(
+                "com.splunk.rum.common.otel.logRecord.UploadOtelLogRecordDataJob",
+                UploadOtelLogRecordDataJob::class.java,
+                CurrentUploadOtelLogRecordDataJob::class.java
+            ),
+            LegacyService(
+                "com.splunk.rum.common.otel.logRecord.UploadSessionReplayDataJob",
+                UploadSessionReplayDataJob::class.java,
+                CurrentUploadSessionReplayDataJob::class.java
+            )
+        )
+
+        private data class LegacyService(val legacyName: String, val legacyClass: Class<*>, val currentClass: Class<*>)
+    }
+}


### PR DESCRIPTION
### Description

Preserved pre-2.3.3 JobScheduler service entry points so scheduled uploads survive SDK package renames

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes
