### PR TITLE
DEMRUM-6288: Stop disabled modules from retaining AppState listeners 

### DIFF
--- a/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/SplunkRum.kt
+++ b/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/SplunkRum.kt
@@ -292,6 +292,7 @@ class SplunkRum private constructor(
 
             if (Build.VERSION.SDK_INT < lowestApiLevel) {
                 Logger.w(TAG, "install() - Unsupported Android version")
+                AgentIntegration.notifyInstallSkipped()
 
                 return SplunkRum(
                     agentStorage = null,
@@ -312,6 +313,7 @@ class SplunkRum private constructor(
 
             if (isSubprocess && agentConfiguration.instrumentedProcessName != null) {
                 Logger.d(TAG, "install() - Subprocess detected exiting")
+                AgentIntegration.notifyInstallSkipped()
 
                 return SplunkRum(
                     agentStorage = null,

--- a/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
+++ b/integration/agent/api/src/main/kotlin/com/splunk/rum/integration/agent/api/internal/SplunkRumAgentCore.kt
@@ -71,7 +71,10 @@ internal object SplunkRumAgentCore {
             else -> Math.random() < samplingRate
         }
 
-        if (!shouldBeRunning) return OpenTelemetry.noop()
+        if (!shouldBeRunning) {
+            AgentIntegration.notifyInstallSkipped()
+            return OpenTelemetry.noop()
+        }
 
         // Configure the OTel Context API only once we are committed to running RUM, so no-op
         // install paths do not mutate this process-wide JVM property for unrelated host-app code.

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/AgentIntegration.kt
@@ -94,6 +94,8 @@ class AgentIntegration private constructor(context: Context) {
         )
 
         fun onPostInstall()
+
+        fun onInstallSkipped() {}
     }
 
     companion object {
@@ -118,6 +120,14 @@ class AgentIntegration private constructor(context: Context) {
             }
 
             return instanceInternal!!
+        }
+
+        /** No-ops when no module has attached, so the instance is not created on a no-op install path. */
+        fun notifyInstallSkipped() {
+            val instance = instanceInternal ?: return
+
+            Logger.d(TAG, "notifyInstallSkipped()")
+            instance.listeners.forEachFast { it.onInstallSkipped() }
         }
 
         fun registerModuleInitializationStart(name: String) {

--- a/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
+++ b/integration/agent/internal/src/main/kotlin/com/splunk/rum/integration/agent/internal/module/ModuleIntegration.kt
@@ -56,6 +56,10 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
     protected open fun onPostInstall() {
     }
 
+    /** Called instead of [onInstall] when the agent does not install, such as a sampled out session. */
+    protected open fun onInstallSkipped() {
+    }
+
     protected open fun onSessionChange(sessionId: String) {
     }
 
@@ -76,6 +80,10 @@ abstract class ModuleIntegration<T : ModuleConfiguration>(protected val defaultM
 
         override fun onPostInstall() {
             this@ModuleIntegration.onPostInstall()
+        }
+
+        override fun onInstallSkipped() {
+            this@ModuleIntegration.onInstallSkipped()
         }
     }
 

--- a/integration/applicationlifecycle/build.gradle.kts
+++ b/integration/applicationlifecycle/build.gradle.kts
@@ -31,4 +31,7 @@ dependencies {
     implementation(Dependencies.Otel.androidInstrumentation)
     implementation(Dependencies.Common.utils)
     implementation(Dependencies.Common.logger)
+
+    testImplementation(Dependencies.Test.junit)
+    testImplementation(Dependencies.Test.robolectric)
 }

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -57,12 +57,19 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
             canReport = true
             cache.forEachFast { reportEvent(it) }
         } else {
-            Logger.w(TAG, "Module is disabled.")
-            canReport = false
+            disableAndRemoveListener()
         }
 
         cache.clear()
     }
+
+    internal fun disableAndRemoveListener() {
+        Logger.w(TAG, "Module is disabled. Removing AppState listener.")
+        canReport = false
+        AppStateObserver.listeners -= appStateListener
+    }
+
+    internal val appStateListenerReference: AppStateObserver.Listener get() = appStateListener
 
     private val appStateListener = object : AppStateObserver.Listener {
 

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -41,7 +41,9 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
 
     override fun onAttach(context: Context) {
         Logger.d(TAG, "onAttach() called")
-        AppStateObserver.listeners += appStateListener
+        if (appStateListener !in AppStateObserver.listeners) {
+            AppStateObserver.listeners += appStateListener
+        }
         AppStateObserver.attach(context as Application)
     }
 
@@ -66,7 +68,8 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
     internal fun disableAndRemoveListener() {
         Logger.w(TAG, "Module is disabled. Removing AppState listener.")
         canReport = false
-        AppStateObserver.listeners -= appStateListener
+        AppStateObserver.listeners.removeAll { it === appStateListener }
+        cache.clear()
     }
 
     internal val appStateListenerReference: AppStateObserver.Listener get() = appStateListener

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -87,14 +87,9 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
     }
 
     private fun reportEvent(applicationLifecycleData: ApplicationLifecycleData) {
-        if (canReport == false) {
-            Logger.i(TAG, "Cannot report event, module disabled.")
-            return
-        }
-
         val logger = SplunkOpenTelemetrySdk.instance?.sdkLoggerProvider
 
-        if (logger == null || canReport == null) {
+        if (logger == null || canReport != true) {
             Logger.i(TAG, "Tracer provider not ready or reporting status unknown. Caching event")
             cache += applicationLifecycleData
             return

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -35,6 +35,7 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
 ) {
 
     private const val TAG = "ApplicationLifecycleModuleIntegration"
+    private const val MAX_CACHE_SIZE = 10
 
     private var canReport: Boolean? = null
     private val cache: MutableList<ApplicationLifecycleData> = mutableListOf()
@@ -90,11 +91,14 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
     }
 
     private fun reportEvent(applicationLifecycleData: ApplicationLifecycleData) {
+        if (canReport == false) return
+
         val logger = SplunkOpenTelemetrySdk.instance?.sdkLoggerProvider
 
-        if (logger == null || canReport != true) {
-            Logger.i(TAG, "Tracer provider not ready or reporting status unknown. Caching event")
-            cache += applicationLifecycleData
+        if (logger == null || canReport == null) {
+            if (cache.size < MAX_CACHE_SIZE) {
+                cache += applicationLifecycleData
+            }
             return
         }
 

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -42,9 +42,7 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
 
     override fun onAttach(context: Context) {
         Logger.d(TAG, "onAttach() called")
-        if (appStateListener !in AppStateObserver.listeners) {
-            AppStateObserver.listeners += appStateListener
-        }
+        registerAppStateListener()
         AppStateObserver.attach(context as Application)
     }
 
@@ -58,12 +56,20 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
         if (moduleConfiguration.isEnabled) {
             Logger.d(TAG, "Module is enabled. Reporting events.")
             canReport = true
+            // A previous skipped install may have removed the listener.
+            registerAppStateListener()
             cache.forEachFast { reportEvent(it) }
         } else {
             disableAndRemoveListener()
         }
 
         cache.clear()
+    }
+
+    private fun registerAppStateListener() {
+        if (appStateListener !in AppStateObserver.listeners) {
+            AppStateObserver.listeners += appStateListener
+        }
     }
 
     public override fun onInstallSkipped() {

--- a/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
+++ b/integration/applicationlifecycle/src/main/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegration.kt
@@ -66,8 +66,17 @@ internal object ApplicationLifecycleModuleIntegration : ModuleIntegration<Applic
         cache.clear()
     }
 
+    public override fun onInstallSkipped() {
+        Logger.d(TAG, "Install skipped. Removing AppState listener.")
+        removeListenerAndClearCache()
+    }
+
     internal fun disableAndRemoveListener() {
         Logger.w(TAG, "Module is disabled. Removing AppState listener.")
+        removeListenerAndClearCache()
+    }
+
+    private fun removeListenerAndClearCache() {
         canReport = false
         AppStateObserver.listeners.removeAll { it === appStateListener }
         cache.clear()

--- a/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
+++ b/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.rum.integration.applicationlifecycle
+
+import com.splunk.rum.common.utils.AppStateObserver
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ApplicationLifecycleModuleIntegrationTest {
+
+    private val moduleListener: AppStateObserver.Listener
+        get() = ApplicationLifecycleModuleIntegration.appStateListenerReference
+
+    @Before
+    fun setUp() {
+        AppStateObserver.listeners.clear()
+    }
+
+    @After
+    fun tearDown() {
+        AppStateObserver.listeners.clear()
+    }
+
+    @Test
+    fun disableRemovesModuleListenerFromAppStateObserver() {
+        AppStateObserver.listeners += moduleListener
+        assertTrue(AppStateObserver.listeners.contains(moduleListener))
+
+        ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
+
+        assertFalse(
+            "Module listener should be removed when module is disabled",
+            AppStateObserver.listeners.contains(moduleListener)
+        )
+    }
+
+    @Test
+    fun disableIsIdempotent() {
+        AppStateObserver.listeners += moduleListener
+
+        ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
+        ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
+
+        assertFalse(
+            "Repeated disable should not throw or re-add the listener",
+            AppStateObserver.listeners.contains(moduleListener)
+        )
+    }
+
+    @Test
+    fun disableDoesNotAffectOtherModuleListeners() {
+        val sessionManagerListener = object : AppStateObserver.Listener {}
+        val crashListener = object : AppStateObserver.Listener {}
+
+        AppStateObserver.listeners += sessionManagerListener
+        AppStateObserver.listeners += moduleListener
+        AppStateObserver.listeners += crashListener
+
+        ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
+
+        assertFalse(AppStateObserver.listeners.contains(moduleListener))
+        assertTrue(
+            "Session manager listener should remain",
+            AppStateObserver.listeners.contains(sessionManagerListener)
+        )
+        assertTrue(
+            "Crash listener should remain",
+            AppStateObserver.listeners.contains(crashListener)
+        )
+        assertEquals(2, AppStateObserver.listeners.size)
+    }
+
+    @Test
+    fun disableRemovesOnlyOneInstanceEvenIfDuplicatelyRegistered() {
+        AppStateObserver.listeners += moduleListener
+        AppStateObserver.listeners += moduleListener
+
+        ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
+
+        assertEquals(
+            "Only one instance should be removed per disable call (MutableList -= semantics)",
+            1,
+            AppStateObserver.listeners.count { it === moduleListener }
+        )
+    }
+}

--- a/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
+++ b/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
@@ -92,15 +92,16 @@ class ApplicationLifecycleModuleIntegrationTest {
     }
 
     @Test
-    fun disableRemovesOnlyOneInstanceEvenIfDuplicatelyRegistered() {
+    fun disableRemovesAllInstancesIfDuplicatelyRegistered() {
         AppStateObserver.listeners += moduleListener
         AppStateObserver.listeners += moduleListener
+        assertEquals(2, AppStateObserver.listeners.count { it === moduleListener })
 
         ApplicationLifecycleModuleIntegration.disableAndRemoveListener()
 
         assertEquals(
-            "Only one instance should be removed per disable call (MutableList -= semantics)",
-            1,
+            "All instances of the module listener should be removed",
+            0,
             AppStateObserver.listeners.count { it === moduleListener }
         )
     }

--- a/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
+++ b/integration/applicationlifecycle/src/test/kotlin/com/splunk/rum/integration/applicationlifecycle/ApplicationLifecycleModuleIntegrationTest.kt
@@ -69,6 +69,35 @@ class ApplicationLifecycleModuleIntegrationTest {
     }
 
     @Test
+    fun skippedInstallRemovesModuleListenerFromAppStateObserver() {
+        AppStateObserver.listeners += moduleListener
+
+        ApplicationLifecycleModuleIntegration.onInstallSkipped()
+
+        assertFalse(
+            "Module listener should be removed when installation is skipped",
+            AppStateObserver.listeners.contains(moduleListener)
+        )
+    }
+
+    @Test
+    fun skippedInstallDoesNotAffectOtherModuleListeners() {
+        val sessionManagerListener = object : AppStateObserver.Listener {}
+
+        AppStateObserver.listeners += sessionManagerListener
+        AppStateObserver.listeners += moduleListener
+
+        ApplicationLifecycleModuleIntegration.onInstallSkipped()
+
+        assertFalse(AppStateObserver.listeners.contains(moduleListener))
+        assertTrue(
+            "Other module listeners should remain when installation is skipped",
+            AppStateObserver.listeners.contains(sessionManagerListener)
+        )
+        assertEquals(1, AppStateObserver.listeners.size)
+    }
+
+    @Test
     fun disableDoesNotAffectOtherModuleListeners() {
         val sessionManagerListener = object : AppStateObserver.Listener {}
         val crashListener = object : AppStateObserver.Listener {}


### PR DESCRIPTION
### Description

- When` ApplicationLifecycleModuleConfiguration.isEnabled` = false, the module's `onInstall()` now removes its `AppStateObserver.Listener` and stops caching events. Previously, `onInstall()` set `canReport` = false but left the listener registered, so it kept firing on every app state transition only to discard the event immediately. A disabled module should not retain callbacks.

- Only this module's listener is removed; other consumers of the shared `AppStateObserver` singleton (session manager, crash, ANR, network monitor, span exporter) are unaffected.

- Listener registration in `onAttach() `is now idempotent to prevent duplicate registrations.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes
- run unit tests
- run sample app with `ApplicationLifecycleModuleConfiguration`(isEnabled = false) flag
- See "Module is disabled. Removing AppState listener." in logcat upon install 
- See no app state events, and no "Cannot report event, module disabled" messages in the log
- verify it still works normally when enabled
