### PR TITLE
NO-TICKET: Release fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        google()
-    }
-
-    dependencies {
-        classpath(Dependencies.gradle)
-        classpath(Dependencies.kotlin)
-        classpath(Dependencies.jacoco)
-    }
-}
-
 plugins {
     id(Dependencies.nexusPublishPluginId) version Dependencies.nexusPublishPluginVersion
 }
@@ -26,12 +13,6 @@ allprojects {
             force("androidx.core:core:1.13.1")
             force("androidx.core:core-ktx:1.13.1")
         }
-    }
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-        google()
     }
 
     afterEvaluate {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    gradlePluginPortal()
-    google()
-    mavenCentral()
-}
-
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
     implementation("com.android.tools.build:gradle:8.6.0")

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,14 @@
+pluginManagement {
+    apply from: '../gradle/repositories.gradle'
+
+    repositories commonRepositories
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    apply from: '../gradle/repositories.gradle'
+
+    repositories commonRepositories
+}

--- a/buildSrc/src/main/kotlin/plugins/ConfigAndroidLibrary.kt
+++ b/buildSrc/src/main/kotlin/plugins/ConfigAndroidLibrary.kt
@@ -3,11 +3,20 @@ package plugins
 import Configurations
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.withType
 
 class ConfigAndroidLibrary : Plugin<Project> by local plugin {
     apply<ConfigLint>()
     apply<ConfigJacoco>()
+
+    tasks.withType<Test> {
+        systemProperty(
+            "robolectric.dependency.repo.url",
+            "https://maven-central.storage-download.googleapis.com/maven2"
+        )
+    }
 
     android {
         buildFeatures {

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -1,0 +1,8 @@
+ext.commonRepositories = {
+    maven {
+        name = 'mavenCentralMirror'
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
+    google()
+    mavenCentral()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,22 @@
 // Plugin management configuration
 pluginManagement {
+    apply from: 'gradle/repositories.gradle'
+
+    repositories commonRepositories
     repositories {
         gradlePluginPortal()
         //uncomment to look for plugins in local maven (.m2) folder
         mavenLocal()
-        google() // needed for Android Gradle Plugin
     }
+}
+
+dependencyResolutionManagement {
+    apply from: 'gradle/repositories.gradle'
+
+    repositories {
+        mavenLocal()
+    }
+    repositories commonRepositories
 }
 
 // Common modules


### PR DESCRIPTION
## Title: Release fix

- Resolve Maven Central through a mirror to unblock releases failing on HTTP 429. The mirror is Google's official read-only mirror of Maven Central. Artifacts are identical, and `mavenCentral()` is kept as a fallback, so this changes where artifacts are fetched from, not which artifacts are used.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI